### PR TITLE
Make the standard resolver DNSSEC aware

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -4,9 +4,9 @@ This listing shows the versions of the OpenDKIM package, the date of
 release, and a summary of the changes in that release.
 
 2.10.3		2015/05/12
-	LIBOPENDKIM: Make strict header checking non-destructive.  The last
-		change to this code resulted in failing signatures.  Reported
-		by Pedro Morales and Wez Furlong.
+	LIBOPENDKIM: Make strict header checking non-destructive.  The last change
+		to this code resulted in failing signatures.  Reported by Pedro
+		Morales and Wez Furlong.
 
 2.10.2		2015/05/10
 	Fix bug #221: Report a DKIM result of "policy" if MinimumKeyBits

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -4,9 +4,9 @@ This listing shows the versions of the OpenDKIM package, the date of
 release, and a summary of the changes in that release.
 
 2.10.3		2015/05/12
-	LIBOPENDKIM: Make strict header checking non-destructive.  The last change
-		to this code resulted in failing signatures.  Reported by Pedro
-		Morales and Wez Furlong.
+	LIBOPENDKIM: Make strict header checking non-destructive.  The last
+		change to this code resulted in failing signatures.  Reported
+		by Pedro Morales and Wez Furlong.
 
 2.10.2		2015/05/10
 	Fix bug #221: Report a DKIM result of "policy" if MinimumKeyBits

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -273,10 +273,8 @@ struct dkimf_config
 	unsigned int	conf_repcachettl;	/* reputation cache TTL */
 	unsigned int	conf_reptimeout;	/* reputation query timeout */
 #endif /* _FFR_REPUTATION */
-#ifdef USE_UNBOUND
 	unsigned int	conf_boguskey;		/* bogus key action */
 	unsigned int	conf_unprotectedkey;	/* unprotected key action */
-#endif /* USE_UNBOUND */
 #ifdef _FFR_RATE_LIMIT
 	unsigned int	conf_flowdatattl;	/* flow data TTL */
 	unsigned int	conf_flowfactor;	/* flow factor */
@@ -665,7 +663,6 @@ struct lookup log_facilities[] =
 	{ NULL,			-1 }
 };
 
-#ifdef USE_UNBOUND
 # define DKIMF_KEYACTIONS_NONE	0
 # define DKIMF_KEYACTIONS_NEUTRAL 1
 # define DKIMF_KEYACTIONS_FAIL	2
@@ -677,7 +674,6 @@ struct lookup dkimf_keyactions[] =
 	{ "fail",		DKIMF_KEYACTIONS_FAIL },
 	{ NULL,			-1 },
 };
-#endif /* USE_UNBOUND */
 
 struct lookup dkimf_statusstrings[] =
 {
@@ -6643,7 +6639,6 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 		                  &conf->conf_resolverconfig,
 		                  sizeof conf->conf_resolverconfig);
 
-#ifdef USE_UNBOUND
 		str = NULL;
 		(void) config_get(data, "BogusKey", &str, sizeof str);
 		if (str != NULL)
@@ -6685,7 +6680,6 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 		{
 			conf->conf_unprotectedkey = DKIMF_KEYACTIONS_NONE;
 		}
-#endif /* USE_UNBOUND */
 
 #ifdef USE_LUA
 		str = NULL;
@@ -10654,7 +10648,6 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, DKIM *dkim,
 
 			dnssec = NULL;
 
-#ifdef USE_UNBOUND
 			switch (dkim_sig_getdnssec(sigs[c]))
 			{
 			  case DKIM_DNSSEC_UNKNOWN:
@@ -10690,7 +10683,6 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, DKIM *dkim,
 				dnssec = "secure";
 				break;
 			}
-#endif /* USE_UNBOUND */
 
 			memset(val, '\0', sizeof val);
 

--- a/opendkim/test.c
+++ b/opendkim/test.c
@@ -709,7 +709,6 @@ dkimf_testfile(DKIM_LIB *libopendkim, struct test_context *tctx,
 
 				if (selector != NULL || domain != NULL)
 				{
-#ifdef USE_UNBOUND
 					char *dnssec;
 					int dnsseccode = DKIM_DNSSEC_UNKNOWN;
 				
@@ -739,12 +738,6 @@ dkimf_testfile(DKIM_LIB *libopendkim, struct test_context *tctx,
 					        "%s: %s: verification (s=%s d=%s, %d-bit key, %s) failed: %s\n",
 					        progname, file, selector,
 					        domain, keysize, dnssec, err);
-#else /* USE_UNBOUND */
-					fprintf(stdout,
-					        "%s: %s: verification (s=%s d=%s, %d-bit key) failed: %s\n",
-					        progname, file, selector,
-					        domain, keysize, err);
-#endif /* USE_UNBOUND */
 				}
 				else
 				{


### PR DESCRIPTION
Would you consider this patch, to make the standard resolver implementation DNSSEC aware, like the libunbound one?