### PR TITLE
Add header.s field to A-R headers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ core
 *.core
 build-aux
 opendkim-[0-9].[0-9].[0-9]
+.vscode

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -10623,6 +10623,7 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, DKIM *dkim,
 		char *result;
 		char *dnssec;
 		char *domain;
+		char *sel;
 		char ss[BUFRSZ + 1];
 		char tmp[BUFRSZ + 1];
 		char val[MAXADDRESS + 1];
@@ -10746,15 +10747,16 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, DKIM *dkim,
 			                            val, sizeof val - 1);
 
 			domain = dkim_sig_getdomain(sigs[c]);
+			sel = dkim_sig_getselector(sigs[c]);
 
 			snprintf(tmp, sizeof tmp,
-			         "%s%sdkim=%s%s (%u-bit key%s%s) header.d=%s header.i=%s%s%s%s",
+			         "%s%sdkim=%s%s (%u-bit key%s%s) header.d=%s header.s=%s header.i=%s%s%s%s",
 			         c == 0 ? "" : ";",
 			         DELIMITER, result, comment,
 			         keybits,
 			         dnssec == NULL ? "" : "; ",
 			         dnssec == NULL ? "" : dnssec,
-			         domain, val,
+			         domain, sel, val,
 			         ts == DKIM_STAT_OK ? " header.b=\"" : "",
 			         ts == DKIM_STAT_OK ? ss : "",
 			         ts == DKIM_STAT_OK ? "\"" : "");

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -10623,7 +10623,7 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, DKIM *dkim,
 		char *result;
 		char *dnssec;
 		char *domain;
-		char *sel;
+		char *selector;
 		char ss[BUFRSZ + 1];
 		char tmp[BUFRSZ + 1];
 		char val[MAXADDRESS + 1];
@@ -10747,7 +10747,7 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, DKIM *dkim,
 			                            val, sizeof val - 1);
 
 			domain = dkim_sig_getdomain(sigs[c]);
-			sel = dkim_sig_getselector(sigs[c]);
+			selector = dkim_sig_getselector(sigs[c]);
 
 			snprintf(tmp, sizeof tmp,
 			         "%s%sdkim=%s%s (%u-bit key%s%s) header.d=%s header.s=%s header.i=%s%s%s%s",
@@ -10756,7 +10756,7 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, DKIM *dkim,
 			         keybits,
 			         dnssec == NULL ? "" : "; ",
 			         dnssec == NULL ? "" : dnssec,
-			         domain, sel, val,
+			         domain, selector, val,
 			         ts == DKIM_STAT_OK ? " header.b=\"" : "",
 			         ts == DKIM_STAT_OK ? ss : "",
 			         ts == DKIM_STAT_OK ? "\"" : "");

--- a/opendkim/tests/Makefile.am
+++ b/opendkim/tests/Makefile.am
@@ -3,7 +3,8 @@ check_SCRIPTS = t-sign-ss t-sign-rs t-sign-rs-tables t-sign-rs-tables-bad \
 	t-sign-rs-lua t-sign-ss-all t-sign-ss-ltag t-sign-ss-x \
 	t-verify-revoked t-verify-unspec t-verify-malformed \
 	t-verify-unsigned t-verify-unsigned-silent \
-	t-verify-syntax t-verify-ss t-verify-ss-bad t-verify-ss-ar-bad \
+	t-verify-syntax t-verify-ss t-verify-ss-header-fields t-verify-ss-bad \
+	t-verify-ss-ar-bad \
 	t-dontsign t-peer \
 	t-lua-verify-tests t-sign-ss-macro t-sign-ss-macro-value \
 	t-sign-ss-macro-value-file t-verify-report \
@@ -68,6 +69,7 @@ EXTRA_DIST = \
 		t-verify-unsigned-silent.lua \
 	t-verify-unspec t-verify-unspec.conf t-verify-unspec.lua \
 	t-verify-ss t-verify-ss.conf t-verify-ss.lua \
+	t-verify-ss-header-fields t-verify-ss-header-fields.conf t-verify-ss-header-fields.lua \
 	t-verify-ss-bad t-verify-ss-bad.conf t-verify-ss-bad.lua \
 	t-verify-ss-ar-bad t-verify-ss-ar-bad.conf t-verify-ss-ar-bad.lua \
 	t-verify-ss-rep t-verify-ss-rep.conf t-verify-ss-rep.lua \

--- a/opendkim/tests/t-verify-ss-header-fields
+++ b/opendkim/tests/t-verify-ss-header-fields
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+#
+# simple/simple test verifying header.x fields are present (should pass)
+
+if [ x"$srcdir" = x"" ]
+then
+	srcdir=`pwd`
+fi
+
+../../miltertest/miltertest $MILTERTESTFLAGS -s $srcdir/t-verify-ss-header-fields.lua

--- a/opendkim/tests/t-verify-ss-header-fields.conf
+++ b/opendkim/tests/t-verify-ss-header-fields.conf
@@ -1,0 +1,6 @@
+# simple/simple test verifying header.x fields are present (should pass)
+
+TestPublicKeys		pubkeys
+Mode			v
+On-BadSignature		reject
+Background		No

--- a/opendkim/tests/t-verify-ss-header-fields.lua
+++ b/opendkim/tests/t-verify-ss-header-fields.lua
@@ -1,0 +1,140 @@
+-- Copyright (c) 2017, The Trusted Domain Project.  All rights reserved.
+
+-- simple/simple test verifying header.x fields are present (should pass)
+--
+-- Confirms that a message with a valid signature has all AR header.X fields
+
+mt.echo("*** simple/simple test verifying header.x fields are present (good)")
+
+-- setup
+if TESTSOCKET ~= nil then
+	sock = TESTSOCKET
+else
+	sock = "unix:" .. mt.getcwd() .. "/t-verify-ss-header-fields.sock"
+end
+binpath = mt.getcwd() .. "/.."
+if os.getenv("srcdir") ~= nil then
+	mt.chdir(os.getenv("srcdir"))
+end
+
+-- try to start the filter
+mt.startfilter(binpath .. "/opendkim", "-x", "t-verify-ss-header-fields.conf",
+               "-p", sock)
+
+-- try to connect to it
+conn = mt.connect(sock, 40, 0.25)
+if conn == nil then
+	error("mt.connect() failed")
+end
+
+-- send connection information
+-- mt.negotiate() is called implicitly
+if mt.conninfo(conn, "localhost", "127.0.0.1") ~= nil then
+	error("mt.conninfo() failed")
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+	error("mt.conninfo() unexpected reply")
+end
+
+-- send envelope macros and sender data
+-- mt.helo() is called implicitly
+mt.macro(conn, SMFIC_MAIL, "i", "t-verify-ss-header-fields")
+if mt.mailfrom(conn, "user@example.com") ~= nil then
+	error("mt.mailfrom() failed")
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+	error("mt.mailfrom() unexpected reply")
+end
+
+-- send headers
+-- mt.rcptto() is called implicitly
+if mt.header(conn, "DKIM-Signature", "v=1; a=rsa-sha256; c=simple/simple; d=example.com; s=test;\r\n\tt=1296710324; bh=3VWGQGY+cSNYd1MGM+X6hRXU0stl8JCaQtl4mbX/j2I=;\r\n\th=From:Date:Subject;\r\n\tb=RNAhx6cV5AeZWJDEJG1hROdvCukhJnokhI9oABHwAyUAzC6MDntoH4PrS2jS7HGw2\r\n\t D7pU4yLGrlNsGlK8JvqizYNHl+v9+B6OnWAgzkgTimWTqBCYwo8X01N6hqoXDAm8hC\r\n\t RUpmeJvC84K5/nHHLASCb4W1PC2R4VkxUoyVnlYE=") ~=nil then
+	error("mt.header(DKIM-Signature) failed")
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+	error("mt.header(DKIM-Signature) unexpected reply")
+end
+if mt.header(conn, "From", "user@example.com") ~= nil then
+	error("mt.header(From) failed")
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+	error("mt.header(From) unexpected reply")
+end
+if mt.header(conn, "Date", "Tue, 22 Dec 2009 13:04:12 -0800") ~= nil then
+	error("mt.header(Date) failed")
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+	error("mt.header(Date) unexpected reply")
+end
+if mt.header(conn, "Subject", "Signing test") ~= nil then
+	error("mt.header(Subject) failed")
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+	error("mt.header(Subject) unexpected reply")
+end
+
+-- send EOH
+if mt.eoh(conn) ~= nil then
+	error("mt.eoh() failed")
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+	error("mt.eoh() unexpected reply")
+end
+
+-- send body
+if mt.bodystring(conn, "This is a test!\r\n") ~= nil then
+	error("mt.bodystring() failed")
+end
+if mt.getreply(conn) ~= SMFIR_CONTINUE then
+	error("mt.bodystring() unexpected reply")
+end
+
+-- end of message; let the filter react
+if mt.eom(conn) ~= nil then
+	error("mt.eom() failed")
+end
+if mt.getreply(conn) ~= SMFIR_ACCEPT then
+	error("mt.eom() unexpected reply")
+end
+
+-- verify that an Authentication-Results header field got added
+if not mt.eom_check(conn, MT_HDRINSERT, "Authentication-Results") and
+   not mt.eom_check(conn, MT_HDRADD, "Authentication-Results") then
+	error("no Authentication-Results added")
+end
+
+-- verify that a DKIM pass result was added
+n = 0
+found = 0
+while true do
+	ar = mt.getheader(conn, "Authentication-Results", n)
+	if ar == nil then
+		break
+	end
+	if string.find(ar, "dkim=pass", 1, true) ~= nil then
+		found = 1
+		break
+	end
+	if string.find(ar, "header.d=example.com", 1, true) ~= nil then
+		found = 1
+		break
+	end
+	if string.find(ar, "header.s=test", 1, true) ~= nil then
+		found = 1
+		break
+	end
+	if string.find(ar, "header.i=@example.com", 1, true) ~= nil then
+		found = 1
+		break
+	end
+	if string.find(ar, "header.b=RNAhx6cV", 1, true) ~= nil then
+		found = 1
+		break
+	end
+	n = n + 1
+end
+if found == 0 then
+	error("incorrect DKIM result")
+end
+
+mt.disconnect(conn)


### PR DESCRIPTION
OpenDKIM stamps the DKIM evaluation status and header domain (`header.d`) in the Authentication-Results header for each DKIM-Signature on the message it evaluates. This PR extends the A-R header to include the selector (`header.s`) field per  IETF 7601bis (in progress).

Instead of:
```
dkim=pass header.d=valimail
```

We now have this:
```
dkim=pass header.d=valimail header.s=google2048
```
