### PR TITLE
implemet "SyslogName" configuration option

### DIFF
--- a/opendkim/opendkim-config.h
+++ b/opendkim/opendkim-config.h
@@ -223,6 +223,7 @@ struct configdef dkimf_config[] =
 	{ "SubDomains",			CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "Syslog",			CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "SyslogFacility",		CONFIG_TYPE_STRING,	FALSE },
+	{ "SyslogName",			CONFIG_TYPE_STRING,	FALSE },
 	{ "SyslogSuccess",		CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "TemporaryDirectory",		CONFIG_TYPE_STRING,	FALSE },
 	{ "TestDNSData",		CONFIG_TYPE_STRING,	FALSE },

--- a/opendkim/opendkim-genzone.8.in
+++ b/opendkim/opendkim-genzone.8.in
@@ -6,7 +6,6 @@
 .B opendkim-genzone
 [\-C address]
 [\-d domain]
-[\-s]
 [\-D]
 [\-E secs]
 [\-F]
@@ -101,10 +100,6 @@ When generating an SOA record (see
 .I \-S
 below), use
 .I secs
-as the zone retry time.  The default is 1800.
-.TP
-.I \-s
-Extends the logic of "-d" to include subdomains.
 .TP
 .I \-S
 Asks for an SOA record to be generated at the top of the output.  The

--- a/opendkim/opendkim-genzone.8.in
+++ b/opendkim/opendkim-genzone.8.in
@@ -97,6 +97,10 @@ When generating an SOA record (see
 .I \-S
 below), use
 .I secs
+as the zone retry time.  The default is 1800.
+.TP
+.I \-s
+Extends the logic of "-d" to include subdomains.
 .TP
 .I \-S
 Asks for an SOA record to be generated at the top of the output.  The

--- a/opendkim/opendkim-genzone.8.in
+++ b/opendkim/opendkim-genzone.8.in
@@ -60,9 +60,6 @@ hostname will be used; if the executing user can't be determined,
 Restricts output to those records for which the domain field is the specified
 .I domain.
 .TP
-.I \-s
-with -d, also match subdomains
-.TP
 .I \-D
 Adds a "._domainkey" suffix to selector names in the zone file.
 .TP

--- a/opendkim/opendkim-genzone.8.in
+++ b/opendkim/opendkim-genzone.8.in
@@ -6,6 +6,7 @@
 .B opendkim-genzone
 [\-C address]
 [\-d domain]
+[\-s]
 [\-D]
 [\-E secs]
 [\-F]
@@ -59,6 +60,9 @@ hostname will be used; if the executing user can't be determined,
 .I \-d domain
 Restricts output to those records for which the domain field is the specified
 .I domain.
+.TP
+.I \-s
+with -d, also match subdomains
 .TP
 .I \-D
 Adds a "._domainkey" suffix to selector names in the zone file.

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -4300,8 +4300,11 @@ dkimf_db_error(DKIMF_DB db, const char *key)
 */
 
 static void
-dkimf_init_syslog(char *facility)
+dkimf_init_syslog(char *name, char *facility)
 {
+	char *syslogident;
+	syslogident = name != NULL ? name : progname;
+
 #ifdef LOG_MAIL
 	int code;
 	struct lookup *p = NULL;
@@ -4321,11 +4324,11 @@ dkimf_init_syslog(char *facility)
 		}
 	}
 
-	openlog(progname, LOG_PID, code);
+	openlog(syslogident, LOG_PID, code);
 #else /* LOG_MAIL */
 	closelog();
 
-	openlog(progname, LOG_PID);
+	openlog(syslogident, LOG_PID);
 #endif /* LOG_MAIL */
 }
 
@@ -8392,15 +8395,18 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 	/* activate logging if requested */
 	if (conf->conf_dolog)
 	{
+		char *log_name = NULL;
 		char *log_facility = NULL;
 
 		if (data != NULL)
 		{
+			(void) config_get(data, "SyslogName", &log_name,
+			                  sizeof log_name);
 			(void) config_get(data, "SyslogFacility", &log_facility,
 			                  sizeof log_facility);
 		}
 
-		dkimf_init_syslog(log_facility);
+		dkimf_init_syslog(log_name, log_facility);
 	}
 
 	return 0;

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -4302,9 +4302,6 @@ dkimf_db_error(DKIMF_DB db, const char *key)
 static void
 dkimf_init_syslog(char *name, char *facility)
 {
-	char *syslogident;
-	syslogident = name != NULL ? name : progname;
-
 #ifdef LOG_MAIL
 	int code;
 	struct lookup *p = NULL;
@@ -4324,11 +4321,11 @@ dkimf_init_syslog(char *name, char *facility)
 		}
 	}
 
-	openlog(syslogident, LOG_PID, code);
+	openlog(name != NULL ? name : progname, LOG_PID, code);
 #else /* LOG_MAIL */
 	closelog();
 
-	openlog(syslogident, LOG_PID);
+	openlog(name != NULL ? name : progname, LOG_PID);
 #endif /* LOG_MAIL */
 }
 

--- a/opendkim/opendkim.conf.5.in
+++ b/opendkim/opendkim.conf.5.in
@@ -1111,6 +1111,13 @@ allowed in
 The default is "mail".
 
 .TP
+.I SyslogName (string)
+Log via calls to
+.I syslog(3)
+using that name. That way one could distinguish multiple instances.
+The default is the name of the executable, normally "opendkim".
+
+.TP
 .I SyslogSuccess (Boolean)
 Log via calls to
 .I syslog(3)

--- a/opendkim/opendkim.conf.sample
+++ b/opendkim/opendkim.conf.sample
@@ -713,11 +713,11 @@ Syslog			Yes
 # SyslogFacility	mail
 
 ##  SyslogName          ident
-##      default "opendkim"
+##      default "opendkim" (or the name of the executable)
 ##
-##  syslog ident to be used
+##  Identifier to be prepended to all generated log entries.
 
-# SyslogName		opendkim-foo
+# SyslogName		opendkim
 
 ##  SyslogSuccess { yes | no }
 ##  	default "no"

--- a/opendkim/opendkim.conf.sample
+++ b/opendkim/opendkim.conf.sample
@@ -712,6 +712,13 @@ Syslog			Yes
 
 # SyslogFacility	mail
 
+##  SyslogName          ident
+##      default "opendkim"
+##
+##  syslog ident to be used
+
+# SyslogName		opendkim-foo
+
 ##  SyslogSuccess { yes | no }
 ##  	default "no"
 ##


### PR DESCRIPTION
when running OpenDKIM inside a docker container, every syslog entry looks like
... opendkim[1] ...

One cannot distinguish logentries from different instances.
To solve the issue I implemented an new option "SyslogName" usable in opendkim.conf

An other option to get different syslog entries is to rename the executable as per default that name is used as syslog name. This patch would not be nessesary at all in that case.


NOTE:
due to my limited git skills an other change is included in this pull request, sorry!
How could I avoid that in the future?