### PR TITLE
- switches to gnutls_pubkey_verify_hash2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ ltmain.sh
 libtool
 Makefile.in
 Makefile
+*.log
+*.trs
 *.tar.gz
 *.tar.gz.md5
 *.tar.gz.sha1


### PR DESCRIPTION
My proposed fix to make libopendkim compatible with GnuTLS versions 3.4.X (and higher).

Symbol gnutls_pubkey_verify_hash was deprecated in 2013, removed in 2015.