### PR TITLE
miltertest: Fix broken mt.data() function

### DIFF
--- a/miltertest/miltertest.c
+++ b/miltertest/miltertest.c
@@ -2566,7 +2566,7 @@ mt_data(lua_State *l)
 	ctx = (struct mt_context *) lua_touserdata(l, 1);
 	lua_pop(l, 1);
 
-	if (!mt_assert_state(ctx, STATE_DATA))
+	if (!mt_assert_state(ctx, STATE_ENVRCPT))
 		lua_error(l);
 
 	if (CHECK_MPOPTS(ctx, SMFIP_NODATA))
@@ -2663,7 +2663,7 @@ mt_header(lua_State *l)
 #endif /* SMFIP_HDR_LEADSPC */
 	memcpy(bp, value, strlen(value) + 1);
 
-	if (!mt_assert_state(ctx, STATE_ENVRCPT))
+	if (!mt_assert_state(ctx, STATE_DATA))
 		lua_error(l);
 
 	if (CHECK_MPOPTS(ctx, SMFIP_NOHDRS))


### PR DESCRIPTION
The implementation of mt.data() is broken. The state management uses the
wrong constants, thereby causing any use of mt.data() to time out:

    miltertest: select(): timeout on fd 3

The fix is straightforward. Align the mistaken use of STATE_* constants
in mt_data and mt_header with how it’s done elsewhere.