### PR TITLE
Plug memory leak in Unbound callback function

### DIFF
--- a/opendkim/opendkim-dns.c
+++ b/opendkim/opendkim-dns.c
@@ -199,6 +199,7 @@ dkimf_unbound_cb(void *mydata, int err, struct ub_result *result)
 	{
 		/* result was bogus */
 		ubdata->ubd_result = DKIM_DNSSEC_BOGUS;
+		ub_resolve_free(result);
 		return;
 	}
 	else


### PR DESCRIPTION
The proposed change adds a missing call to `ub_resolve_free(result)` in the Unbound callback function.