### PR TITLE
miltertest: Fix undefined behaviour in mt.eom_check() with MT_SMTPREPLY

### DIFF
--- a/miltertest/miltertest.c
+++ b/miltertest/miltertest.c
@@ -3645,8 +3645,8 @@ mt_eom_check(lua_State *l)
 
 				snprintf(rbuf, sizeof rbuf, "%s%s%s%s%s",
 				         smtp,
-				         esc == NULL ? "" : " ", esc,
-				         text == NULL ? "" : " ", text);
+				         esc == NULL ? "" : " ", esc == NULL ? "" : esc,
+				         text == NULL ? "" : " ", text == NULL ? "" : text);
 
 				if (strcmp(rbuf, (char *) r->eom_rdata) == 0)
 				{


### PR DESCRIPTION
The MT_SMTPREPLY case in mt_eom_check prints two possibly-NULL char
pointers via format string %s. This triggers undefined behaviour. On my
machine, these pointers are printed as the string ‘(null)’. In any case
this distorts the test result.

The attached patch fixes this by making sure the two char pointers ‘esc’
and ‘text’ are only passed to snprintf when they are not NULL.