### PR TITLE
Various minor fixes in sample opendkim.conf

### DIFF
--- a/LICENSE.Sendmail
+++ b/LICENSE.Sendmail
@@ -56,7 +56,7 @@ permitted only if each of the following conditions of 1-6 are met:
    agree that for any dispute arising out of or relating to this Software, 
    that jurisdiction and venue is proper in San Francisco or Alameda 
    counties.  These license terms and conditions reflect the complete 
-   agreement for the license of the Software (which means this supercedes 
+   agreement for the license of the Software (which means this supersedes
    prior or contemporaneous agreements or representations).  If any term
    or condition under this license is found to be invalid, the remaining
    terms and conditions still apply.

--- a/opendkim/opendkim.conf.sample
+++ b/opendkim/opendkim.conf.sample
@@ -109,7 +109,7 @@
 ##  operation.  Thus, cores will be dumped here and configuration files
 ##  are read relative to this location.
 
-# BaseDirectory		/var/run/opendkim
+# BaseDirectory		/run/opendkim
 
 ##  BodyLengthDB dataset
 ##  	default (none)
@@ -551,7 +551,7 @@ KeyFile			/var/db/dkim/example.private
 ##  ResolverConfiguration string
 ##
 ##  Passes arbitrary configuration data to the resolver.  For the stock UNIX
-##  resolver, this is ignored; for Unbound, it names a resolv.conf(5)-style
+##  resolver, this is ignored; for Unbound, it names an unbound.conf(5)-style
 ##  file that should be read for configuration information.
 
 # ResolverConfiguration	string
@@ -647,7 +647,7 @@ Selector		my-selector-name
 ##  Specifies a URI (e.g., "smtp://localhost") to which mail should be sent
 ##  via SMTP when notifications are generated.
 
-# Socket smtp://localhost
+# SMTPURI smtp://localhost
 
 ##  Socket socketspec
 ##
@@ -759,8 +759,6 @@ Syslog			Yes
 ##  See the umask(2) man page for more information.
 
 # UMask			022
-
-# UnboundConfigFile	/var/named/unbound.conf
 
 ##  Userid userid
 ##  	default (none)


### PR DESCRIPTION
This contains very minor self-explanatory fixes mostly in sample opendkim.conf files.

* Update references to /var/run → /run, as mandated by the Linux Filesystem Hierarchy Standard
* Copy-paste error `Socket` → `SMTPURI`
* Mistaken reference to resolv.conf → unbound.conf
* Delete reference to obsolete `UnboundConfigFile`
* typo in LICENSE file (flagged by Debian’s Lintian tool, sorry)

Trifles, but good to have nevertheless.