### PR TITLE
miltertest: Move man page to section 1

### DIFF
--- a/miltertest/Makefile.am
+++ b/miltertest/Makefile.am
@@ -14,7 +14,7 @@ miltertest_CPPFLAGS = -I$(srcdir)/../libopendkim $(LIBMILTER_INCDIRS) $(LIBLUA_I
 miltertest_LDFLAGS = ../libopendkim/libopendkim.la $(LIBLUA_LIBDIRS)
 miltertest_LDADD = $(LIBLUA_LIBS) $(LIBNSL_LIBS)
 
-man_MANS = miltertest.8
+man_MANS = miltertest.1
 endif
 
-EXTRA_DIST = miltertest.8
+EXTRA_DIST = miltertest.1

--- a/miltertest/miltertest.1
+++ b/miltertest/miltertest.1
@@ -1,4 +1,4 @@
-.TH miltertest 8 "The Trusted Domain Project"
+.TH miltertest 1 "The Trusted Domain Project"
 .SH NAME
 .B miltertest
 \- milter unit test utility

--- a/www/docs.html
+++ b/www/docs.html
@@ -53,7 +53,7 @@
   </ul> </li>
  <li> miltertest
   <ul>
-   <li> <a href="miltertest.8.html">miltertest(8)</a> </li>
+   <li> <a href="miltertest.1.html">miltertest(1)</a> </li>
   </ul> </li>
 </ul>
 <h3>Snapshot Documentation</h3>


### PR DESCRIPTION
miltertest is a general-purpose program that is installed for non-root users in /usr/bin. Its man page should therefore be located in section 1, not 8, as it currently is.

The proposed change moves the man page to section 1.