### PR TITLE
Suppress empty brackets in syslog startup message

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -17091,8 +17091,13 @@ main(int argc, char **argv)
 
 	if (curconf->conf_dolog)
 	{
-		syslog(LOG_INFO, "%s v%s starting (%s)", DKIMF_PRODUCT,
-		       VERSION, argstr);
+		_Bool noargs = strlen(argstr) == 0;
+
+		syslog(LOG_INFO, "%s v%s starting%s%s%s", DKIMF_PRODUCT,
+		       VERSION,
+		       noargs ? "" : " (",
+		       argstr,
+		       noargs ? "" : ")");
 	}
 
 	/* spawn the SIGUSR1 handler */


### PR DESCRIPTION
When opendkim is started normally with no arguments, a trailing empty pair of round brackets is printed to syslog.

    Dec 27 13:35:55 kes opendkim[26229]: OpenDKIM Filter v2.11.0 starting ()

To most readers this is not meaningful. The proposed change suppresses the brackets when there are no arguments to display.