### PR TITLE
Add missing space in Authentication-Results header

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -13512,7 +13512,8 @@ mlfi_eom(SMFICTX *ctx)
 			/* NOTREACHED */
 		}
 
-		snprintf(header, sizeof header, "%s; dkim=%s (%s)",
+		snprintf((char *) header, sizeof header, "%s%s; dkim=%s (%s)",
+		         cc->cctx_noleadspc ? " " : "",
 		         authservid, ar,
 		         dkimf_lookup_inttostr(dfc->mctx_status,
 		                               dkimf_statusstrings));


### PR DESCRIPTION
When the opendkim milter adds an `Authentication-Results` header after it ran into an error case such as bad signature format, the header value may be lacking leading whitespace:

    Authentication-Results:mail.mydomain.org; dkim=permerror (bad message/signature format)

This is because in the early return case in `mlfi_eom` in *opendkim/opendkim.c* it is neglected to take into account the `cctx_noleadspc` setting.

The proposed change fixes this by adding the space character as is done elsewhere in this function.