### PR TITLE
dkim-canon: fix missing check before assert in dkim_sig_gethashes

### DIFF
--- a/libopendkim/dkim-canon.c
+++ b/libopendkim/dkim-canon.c
@@ -2131,6 +2131,10 @@ dkim_canon_gethashes(DKIM_SIGINFO *sig, void **hh, size_t *hhlen,
 	hdc = sig->sig_hdrcanon;
 	bdc = sig->sig_bodycanon;
 
+	if (hdc == NULL || bdc == NULL) {
+		return DKIM_STAT_INVALID;
+	}
+
 	status = dkim_canon_getfinal(hdc, &hd, &hdlen);
 	if (status != DKIM_STAT_OK)
 		return status;


### PR DESCRIPTION
Coming from dkim_sig_gethashes-->dkim_canon_gethashes, the following assertion in dkim_canon_getfinal seems unreasonably harsh. Instead, return a corresponding error code in dkim_canon_gethashes, so that the caller has a chance to fail gracefully.