### PR TITLE
Define __P() macro in libvbr

### DIFF
--- a/libvbr/vbr.h
+++ b/libvbr/vbr.h
@@ -12,6 +12,16 @@
 /* system includes */
 #include <sys/types.h>
 
+#ifdef __STDC__
+# ifndef __P
+#  define __P(x)  x
+# endif /* ! __P */
+#else /* __STDC__ */
+# ifndef __P
+#  define __P(x)  ()
+# endif /* ! __P */
+#endif /* __STDC__ */
+
 /* strings */
 #define	VBR_ALL			"all"
 #define	VBR_INFOHEADER		"VBR-Info"


### PR DESCRIPTION
Definitions for this macro have been added throughout the codebase in
commits 91e7407d, 705948fd, 227fa252, 842c1733, and b730bdc0, but one
was still missing from libvbr. glibc contains a definition for legacy
reasons, but other libcs might not. Particularly, the musl libc does not
contain it, leading to build errors when enabling support for VBR.

Add a definition for `__P()` to vbr.h to fix this.