### PR TITLE
opendkim-genkey(8): Fixed typo option "restricted" to "restrict"

### DIFF
--- a/opendkim/opendkim-genkey.8.in
+++ b/opendkim/opendkim-genkey.8.in
@@ -69,7 +69,7 @@ text in the key record.  By default, no such text is included.
 
 .TP
 .I \-r
-(\-\-restricted)
+(\-\-restrict)
 Restricts the key for use in e-mail signing only.  The default is to allow
 the key to be used for any service.
 


### PR DESCRIPTION
In the man page the option `--restrict` was called `--restricted`. This PR fixes the name of the option in the man page.

PS: Bug was originally reported at Debian's Bug Tracker, see [bug 960447](https://bugs.debian.org/960447). Because the typo seems easy to fix, I think creating this pull request seems faster than creating an explicit upstream issue.

PPS: This is the redirected pull request of #82 