### PR TITLE
miltertest: Correct MT_HDRDELETE documentation in man page

### DIFF
--- a/miltertest/miltertest.8
+++ b/miltertest/miltertest.8
@@ -314,7 +314,8 @@ modified to have the specified new value.
 Checks to see if an existing header field was deleted.  If no parameters
 are given, the function returns true if any header field was deleted.  If
 one parameter was given, the function returns true only if the named
-header field was deleted.
+header field was deleted.  If two parameters are given, the function returns
+true only if the named header field was deleted at the specified index.
 .TP
 .I MT_HDRINSERT
 Checks to see if a header field was inserted into the message.  If no


### PR DESCRIPTION
The proposed change corrects the man page documentation for the MT_HDRDELETE EOM check by also describing the case where two parameters are given.