### PR TITLE
Liblua redux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1517,20 +1517,10 @@ lua_found="no"
 
 if test \(  x"$luapath" = x"auto" -o x"$luapath" = x"yes" \) -a x"$PKG_CONFIG" != x""
 then
-  PKG_CHECK_MODULES([LIBLUA], [lua5.1], [
+  PKG_CHECK_MODULES([LIBLUA], [lua], [
       LIBLUA_INCDIRS="$LIBLUA_CFLAGS"
       lua_found="yes"
-    ],
-    [
-      AC_MSG_WARN([pkg-config for lua5.1 not found, trying lua...])
-      PKG_CHECK_MODULES([LIBLUA], [lua], [
-          LIBLUA_INCDIRS="$LIBLUA_CFLAGS"
-          lua_found="yes"
-        ],
-	[AC_MSG_WARN([pkg-config for lua not found, trying manual search...])]
-      )
-    ]
-  )
+    ])
 fi
 
 if test \( x"$luapath" = x"yes" -o x"$luapath" = x"auto" \) -a x"$lua_found" = x"no"

--- a/configure.ac
+++ b/configure.ac
@@ -1505,135 +1505,71 @@ AC_SUBST([LIBTRE_LIBS])
 #
 # liblua
 #
-AC_ARG_WITH([lua],
-            AS_HELP_STRING([--with-lua],
-                           [location of Lua includes and library]),
-            [luapath="$withval"], [luapath="no"])
+AC_ARG_ENABLE([lua],
+            AS_HELP_STRING([--enable-lua],
+                           [enable the Lua scripting language]),
+            [enable_lua="$enableval"], [enable_lua="no"])
 
-LIBLUA_INCDIRS=""
-LIBLUA_LIBDIRS=""
-LIBLUA_LIBS=""
+# We inherit these misnomers from pkg-config. The "CFLAGS" variable
+# contains preprocessor (CPP) flags; the "LIBS" variable contains
+# both -l and -L flags, suitable for foo_LDADD.
+LUA_CFLAGS=""
+LUA_LIBS=""
 lua_found="no"
 
-if test \(  x"$luapath" = x"auto" -o x"$luapath" = x"yes" \) -a x"$PKG_CONFIG" != x""
-then
-  PKG_CHECK_MODULES([LIBLUA], [lua], [
-      LIBLUA_INCDIRS="$LIBLUA_CFLAGS"
-      lua_found="yes"
+AS_IF([test x"$enable_lua" = x"yes"], [
+  AS_IF([test x"$PKG_CONFIG" != x""], [
+    # If pkg-config is available, try to use that! This automatically
+    # defines LUA_CFLAGS and LUA_LIBS if it succeeds.
+    PKG_CHECK_MODULES([LUA], [lua >= 5.1], [lua_found="yes"],[
+      # Try debian-specific module names if the official one didn't work.
+      # This isn't strictly necessary, but is extremely convenient for
+      # debian users and doesn't cost us anything except two lines of code.
+      PKG_CHECK_MODULES([LUA], [lua5.2], [lua_found="yes"],[
+        PKG_CHECK_MODULES([LUA], [lua5.1], [lua_found="yes"])
+      ])
     ])
-fi
+  ])
 
-if test \( x"$luapath" = x"yes" -o x"$luapath" = x"auto" \) -a x"$lua_found" = x"no"
-then
-	AC_MSG_CHECKING([for Lua])
-	luadirs="/usr /usr/local"
-	for d in $luadirs
-	do
-		if test -f $d/include/lua51/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include/lua51"
-			LIBLUA_LIBDIRS="-L$d/lib/lua51"
-			LIBLUA_LIBS="-llua -lm"
-			lua_found="yes"
-			break
-		elif test -f $d/include/lua52/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include/lua52"
-			LIBLUA_LIBDIRS="-L$d/lib/lua52"
-			LIBLUA_LIBS="-llua -lm"
-			lua_found="yes"
-			break
-		elif test -f $d/include/lua5.1/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include/lua5.1"
-			LIBLUA_LIBDIRS="-L$d/lib"
-			LIBLUA_LIBS="-llua5.1 -lm"
-			lua_found="yes"
-			break
-		elif test -f $d/include/lua5.2/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include/lua5.2"
-			LIBLUA_LIBDIRS="-L$d/lib"
-			LIBLUA_LIBS="-llua5.2 -lm"
-			lua_found="yes"
-			break
-		elif test -f $d/include/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include"
-			LIBLUA_LIBDIRS="-L$d/lib"
-			LIBLUA_LIBS="-llua -lm"
-			lua_found="yes"
-			break
-		fi
-	done
-	if test x"$LIBLUA_LIBS" = x""
-	then
-		LIBLUA_INCDIRS=""
-		LIBLUA_LIBDIRS=""
-		LIBLUA_LIBS=""
-		AC_MSG_ERROR(not found)
-	else
-		lua_found="yes"
-	fi
-fi
+  AS_IF([test x"$lua_found" != x"yes"], [
+    # Ok, either we don't have pkg-config, or it didn't find Lua.
+    # Let's just try to link against it. The user should have
+    # passed the correct -I and -L flags to the build system if
+    # his headers/libraries are located in a non-standard path...
+    AC_MSG_CHECKING([for Lua manually])
+    AC_SEARCH_LIBS([lua_load], [lua], [lua_found="yes"])
+  ])
 
-if test x"$luapath" != x"yes" -a x"$luapath" != x"auto" -a x"$luapath" != x"no"
-then
-	AC_MSG_CHECKING([for Lua])
-	if test -f $luapath/include/lua51/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include/lua51"
-		LIBLUA_LIBDIRS="-L$luapath/lib/lua51"
-		LIBLUA_LIBS="-llua -lm"
-		lua_found="yes"
-	elif test -f $luapath/include/lua52/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include/lua52"
-		LIBLUA_LIBDIRS="-L$luapath/lib/lua52"
-		LIBLUA_LIBS="-llua -lm"
-		lua_found="yes"
-	elif test -f $luapath/include/lua5.1/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include/lua5.1"
-		LIBLUA_LIBDIRS="-L$luapath/lib"
-		LIBLUA_LIBS="-llua5.1 -lm"
-		lua_found="yes"
-	elif test -f $luapath/include/lua5.2/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include/lua5.2"
-		LIBLUA_LIBDIRS="-L$luapath/lib"
-		LIBLUA_LIBS="-llua5.2 -lm"
-		lua_found="yes"
-	elif test -f $luapath/include/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include"
-		LIBLUA_LIBDIRS="-L$luapath/lib"
-		LIBLUA_LIBS="-llua -lm"
-		lua_found="yes"
-	else
-		AC_MSG_ERROR(not found at $luapath)
-	fi
-fi
+  AS_IF([test x"$lua_found" != x"yes"], [
+    AC_MSG_ERROR([Lua enabled but not found])
+  ])
+])
 
-if test x"$lua_found" = x"yes"
-then
-	AC_SUBST([LUA_MANNOTICE], "")
-	AC_DEFINE([USE_LUA], 1, [support for Lua scripting])
-	AC_SEARCH_LIBS([dlopen], [dl])
-	saved_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$outer_CPPFLAGS $LIBLUA_INCDIRS"
-	AC_MSG_CHECKING([Lua version])
-	AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+AS_IF([test x"$lua_found" != x"yes"],[
+  # Lua not enabled or not found. Throw errors for all the invalid
+  # flag combinations that can arise from that.
+  AS_IF([test x"$enable_lua_only_signing" = x"yes"],[
+    AC_MSG_ERROR([--enable-lua_only_signing requires Lua support])
+  ])
+
+  AS_IF([test x"$enable_statsext" = x"yes"],[
+    AC_MSG_ERROR([--enable-statsext requires Lua support])
+  ])
+
+  AS_IF([test x"$enable_rbl" = x"yes"],[
+    AC_MSG_ERROR([--enable-rbl requires Lua support])
+  ])
+])
+
+
+AS_IF([test x"$lua_found" = x"yes"],[
+  AC_SUBST([LUA_MANNOTICE], "")
+  AC_DEFINE([USE_LUA], 1, [support for Lua scripting])
+  AC_SEARCH_LIBS([dlopen], [dl])
+  saved_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$outer_CPPFLAGS $LUA_CFLAGS"
+  AC_MSG_CHECKING([Lua version])
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 #include <lua.h>
 
 #if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501
@@ -1645,35 +1581,24 @@ main()
 {
 	return 0;
 }
-				])],
-				AC_MSG_RESULT([ok]), 
-				AC_MSG_ERROR([Lua version 5.1 or later required]))
-	CPPFLAGS="$saved_CPPFLAGS"
-	AC_DEFINE([USE_LUA], 1, [support for Lua scripting])
-	AC_SUBST([LUA_MANNOTICE], "")
-else
-	AC_SUBST([LUA_MANNOTICE], "(Not enabled for this installation.)")
-fi
+  ])],
+    AC_MSG_RESULT([ok]),
+    AC_MSG_ERROR([Lua version 5.1 or later required]))
+  CPPFLAGS="$saved_CPPFLAGS"
+  AC_DEFINE([USE_LUA], 1, [support for Lua scripting])
+  AC_SUBST([LUA_MANNOTICE], "")], [
+  # Lua not found!
+  AC_SUBST([LUA_MANNOTICE], "(Not enabled for this installation.)")
+])
 
-AM_CONDITIONAL(LUA, test x"$lua_found" = x"yes")
-AC_SUBST(LIBLUA_INCDIRS)
-AC_SUBST(LIBLUA_LIBDIRS)
-AC_SUBST(LIBLUA_LIBS)
+# This has got to be redundant; we already define USE_LUA above.
+AM_CONDITIONAL([LUA], [test x"$lua_found" = x"yes"])
 
-if test x"$enable_lua_only_signing" = x"yes" -a x"$lua_found" != x"yes"
-then
-	AC_MSG_ERROR([--enable-lua_only_signing requires Lua support])
-fi
+# Probably not needed any more (pkg-config does it for a long time),
+# but harmless in any case.
+AC_SUBST(LUA_CFLAGS)
+AC_SUBST(LUA_LIBS)
 
-if test x"$enable_statsext" = x"yes" -a x"$lua_found" != x"yes"
-then
-	AC_MSG_ERROR([--enable-statsext requires Lua support])
-fi
-
-if test x"$enable_rbl" = x"yes" -a x"$lua_found" != x"yes"
-then
-	AC_MSG_ERROR([--enable-rbl requires Lua support])
-fi
 
 AC_ARG_WITH([sql-backend],
             AS_HELP_STRING([--with-sql-backend],
@@ -2600,7 +2525,7 @@ fi
 if test x"$lua_found" = x"yes"
 then
 	installbin="yes"
-	specconfig="$specconfig --with-lua=$luapath"
+	specconfig="$specconfig --enable-lua"
 	specrequries="$specrequires lua"
 	specbuildrequries="$specbuildrequires lua-devel"
 fi

--- a/miltertest/Makefile.am
+++ b/miltertest/Makefile.am
@@ -10,9 +10,8 @@ if LUA
 bin_PROGRAMS = miltertest
 
 miltertest_SOURCES = miltertest.c
-miltertest_CPPFLAGS = -I$(srcdir)/../libopendkim $(LIBMILTER_INCDIRS) $(LIBLUA_INCDIRS)
-miltertest_LDFLAGS = ../libopendkim/libopendkim.la $(LIBLUA_LIBDIRS)
-miltertest_LDADD = $(LIBLUA_LIBS) $(LIBNSL_LIBS)
+miltertest_CPPFLAGS = -I$(srcdir)/../libopendkim $(LIBMILTER_INCDIRS) $(LUA_CFLAGS)
+miltertest_LDADD = ../libopendkim/libopendkim.la $(LUA_LIBS) $(LIBNSL_LIBS)
 
 man_MANS = miltertest.8
 endif

--- a/opendkim/Makefile.am
+++ b/opendkim/Makefile.am
@@ -46,9 +46,9 @@ opendkim_LDADD += $(LIBMEMCACHED_LIBS)
 endif
 if LUA
 SUBDIRS=tests
-opendkim_CPPFLAGS += $(LIBLUA_INCDIRS) -DDKIMF_LUA_CONTEXT_HOOKS
-opendkim_LDFLAGS += $(LIBLUA_LIBDIRS)
-opendkim_LDADD += $(LIBLUA_LIBS)
+opendkim_CPPFLAGS += $(LUA_INCDIRS) -DDKIMF_LUA_CONTEXT_HOOKS
+opendkim_LDFLAGS += $(LUA_LIBDIRS)
+opendkim_LDADD += $(LUA_LIBS)
 endif
 if USE_SASL
 opendkim_CPPFLAGS += $(SASL_CPPFLAGS)
@@ -108,9 +108,8 @@ opendkim_testkey_CFLAGS = $(LIBCRYPTO_CFLAGS) $(COV_CFLAGS) $(PTHREAD_CFLAGS)
 opendkim_testkey_LDFLAGS = $(LIBCRYPTO_LIBDIRS) $(COV_LDFLAGS) $(PTHREAD_CFLAGS)
 opendkim_testkey_LDADD = ../libopendkim/libopendkim.la $(LIBCRYPTO_LIBS) $(LIBRESOLV) $(COV_LIBADD) $(PTHREAD_LIBS)
 if LUA
-opendkim_testkey_CPPFLAGS += $(LIBLUA_INCDIRS) $(LIBMILTER_INCDIRS)
-opendkim_testkey_LDFLAGS += $(LIBLUA_LIBDIRS)
-opendkim_testkey_LDADD += $(LIBLUA_LIBS)
+opendkim_testkey_CPPFLAGS += $(LUA_CFLAGS) $(LIBMILTER_INCDIRS)
+opendkim_testkey_LDADD += $(LUA_LIBS)
 endif
 if USE_DB_OPENDKIM
 opendkim_testkey_CPPFLAGS += $(LIBDB_INCDIRS)
@@ -200,9 +199,8 @@ opendkim_genzone_CPPFLAGS += $(OPENLDAP_CPPFLAGS)
 opendkim_genzone_LDADD += $(OPENLDAP_LIBS)
 endif
 if LUA
-opendkim_genzone_CPPFLAGS += $(LIBLUA_INCDIRS) $(LIBMILTER_INCDIRS)
-opendkim_genzone_LDFLAGS += $(LIBLUA_LIBDIRS)
-opendkim_genzone_LDADD += $(LIBLUA_LIBS)
+opendkim_genzone_CPPFLAGS += $(LUA_CFLAGS) $(LIBMILTER_INCDIRS)
+opendkim_genzone_LDADD += $(LUA_LIBS)
 endif
 if REPUTE
 opendkim_genzone_CPPFLAGS += -I$(srcdir)/../reputation
@@ -250,9 +248,8 @@ opendkim_atpszone_CPPFLAGS += $(OPENLDAP_CPPFLAGS)
 opendkim_atpszone_LDADD += $(OPENLDAP_LIBS)
 endif
 if LUA
-opendkim_atpszone_CPPFLAGS += $(LIBLUA_INCDIRS) $(LIBMILTER_INCDIRS)
-opendkim_atpszone_LDFLAGS += $(LIBLUA_LIBDIRS)
-opendkim_atpszone_LDADD += $(LIBLUA_LIBS)
+opendkim_atpszone_CPPFLAGS += $(LUA_CFLAGS) $(LIBMILTER_INCDIRS)
+opendkim_atpszone_LDADD += $(LUA_LIBS)
 endif
 if REPUTE
 opendkim_atpszone_CPPFLAGS += -I$(srcdir)/../reputation


### PR DESCRIPTION
The first commit here fixes the issue #111 that I reported recently. The second... well, someone has to do something about that mess.

Fortunately, it's all obsolete. Debian has pkg-config files now (albeit with nonstandard names), and even modulo that, it's better to pass `-I`, `-l`, and `-L` flags to the build system than it is to pass `--with-lua=<path>` and have the configure script reinvent the wheel. The new stuff is only lightly tested, but I'll soon add it to our Gentoo package to fix the lua-5.1 detection issue. The design is sound even if I've overlooked a detail or two. I'm happy to fix bugs down the road if people run into problems.

A few scenarios are described in the commit message, but I expect almost everyone to be covered by pkg-config out of the box.