### PR TITLE
Cope with headers formatted as Name:\r\n\tValue

### DIFF
--- a/libopendkim/dkim-canon.c
+++ b/libopendkim/dkim-canon.c
@@ -387,8 +387,12 @@ dkim_canon_header_string(struct dkim_dstring *dstr, dkim_canon_t canon,
 			}
 		}
 
-		/* skip all spaces before first word */
-		while (*p != '\0' && DKIM_ISWSP(*p))
+		/*
+		 * skip all spaces before first word 
+		 * we also need to skip CRLF for long header formatted as
+		 * Header-Name:\r\n\tHeader-value
+		 */
+		while (*p != '\0' && DKIM_ISLWSP(*p))
 			p++;
 
 		space = FALSE;				/* just saw a space */


### PR DESCRIPTION
Without this change, the canonization of a header like Name:\r\n\tValue
wrongly leaves a space after the colon, and causing the signature
to be rejected.