### PR TITLE
Add missing ReplaceHeaders definition

### DIFF
--- a/opendkim/opendkim-config.h
+++ b/opendkim/opendkim-config.h
@@ -147,6 +147,7 @@ struct configdef dkimf_config[] =
 	{ "RemoveARFrom",		CONFIG_TYPE_STRING,	FALSE },
 	{ "RemoveOldSignatures",	CONFIG_TYPE_BOOLEAN,	FALSE },
 #ifdef _FFR_REPLACE_RULES
+	{ "ReplaceHeaders",		CONFIG_TYPE_STRING,	FALSE },
 	{ "ReplaceRules",		CONFIG_TYPE_STRING,	FALSE },
 #endif /* _FFR_REPLACE_RULES */
 	{ "ReportAddress",		CONFIG_TYPE_STRING,	FALSE },


### PR DESCRIPTION
The proposed change adds the missing `ReplaceHeaders` entry to the config definitions in opendkim/opendkim-config.h.

Patch from Toby Ovod-Everett, https://sourceforge.net/p/opendkim/bugs/257/. Reported again by Harald Dunkel, https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=986878.