### PR TITLE
Insert initial headers like Authentication-Results before the MTA’s Received header

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -3670,7 +3670,7 @@ dkimf_xs_addheader(lua_State *l)
 
 	if (ctx == NULL)
 		lua_pushnil(l);
-	else if (dkimf_insheader(ctx, 1, name, value) == MI_SUCCESS)
+	else if (dkimf_insheader(ctx, 0, name, value) == MI_SUCCESS)
 		lua_pushnumber(l, 1);
 	else
 		lua_pushnil(l);
@@ -4246,7 +4246,7 @@ dkimf_add_ar_fields(struct msgctx *dfc, struct dkimf_config *conf,
 	assert(conf != NULL);
 	assert(ctx != NULL);
 
-	if (dkimf_insheader(ctx, 1, AUTHRESULTSHDR,
+	if (dkimf_insheader(ctx, 0, AUTHRESULTSHDR,
 	                    (char *) dfc->mctx_dkimar) == MI_FAILURE)
 	{
 		if (conf->conf_dolog)
@@ -13518,7 +13518,7 @@ mlfi_eom(SMFICTX *ctx)
 		         dkimf_lookup_inttostr(dfc->mctx_status,
 		                               dkimf_statusstrings));
 
-		if (dkimf_insheader(ctx, 1, AUTHRESULTSHDR,
+		if (dkimf_insheader(ctx, 0, AUTHRESULTSHDR,
 		                    (char *) header) == MI_FAILURE)
 		{
 			if (conf->conf_dolog)
@@ -14963,7 +14963,7 @@ mlfi_eom(SMFICTX *ctx)
 						        sizeof header);
 					}
 		
-					if (dkimf_insheader(ctx, 1,
+					if (dkimf_insheader(ctx, 0,
 					                    AUTHRESULTSHDR,
 					                    (char *) header) == MI_FAILURE)
 					{
@@ -15166,7 +15166,7 @@ mlfi_eom(SMFICTX *ctx)
 			dkimf_stripcr((char *) start);
 			dkimf_dstring_cat(dfc->mctx_tmpstr, start);
 
-			if (dkimf_insheader(ctx, 1, DKIM_SIGNHEADER,
+			if (dkimf_insheader(ctx, 0, DKIM_SIGNHEADER,
 			                    (char *) dkimf_dstring_get(dfc->mctx_tmpstr)) == MI_FAILURE)
 			{
 				if (conf->conf_dolog)
@@ -15202,7 +15202,7 @@ mlfi_eom(SMFICTX *ctx)
 		/* add VBR-Info header if generated */
 		if (dfc->mctx_vbrinfo != NULL)
 		{
-			if (dkimf_insheader(ctx, 1, VBR_INFOHEADER,
+			if (dkimf_insheader(ctx, 0, VBR_INFOHEADER,
 			                    dfc->mctx_vbrinfo) == MI_FAILURE)
 			{
 				if (conf->conf_dolog)
@@ -15252,7 +15252,7 @@ mlfi_eom(SMFICTX *ctx)
 		         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
 		                                 : (u_char *) JOBIDUNKNOWN);
 
-		if (dkimf_insheader(ctx, 1, SWHEADERNAME, xfhdr) != MI_SUCCESS)
+		if (dkimf_insheader(ctx, 0, SWHEADERNAME, xfhdr) != MI_SUCCESS)
 		{
 			if (conf->conf_dolog)
 			{


### PR DESCRIPTION
The proposed change moves the generated `Authentication-Results` (et al.) header *before* the MTA’s `Received` header. This is achieved by calling the milter library’s `smfi_insheader` function with index 0 instead of 1, patch provided by @fanto666. This fixes #24.

The `Authentication-Results` header is specified in RFC 8601. It is a trace header field and therefore expected to come before the `Received` header. See the explicit requirements on this in sections 4 and 7.1 of RFC 8601, and also the numerous examples in appendix B:

> For MTAs that add this header field, adding header fields in order (at the top), per Section 3.6 of [MAIL], is particularly important. Moreover, this header field SHOULD be inserted above any other trace header fields such MTAs might prepend.  This placement allows easy detection of header fields that can be trusted.

> 5. On the presumption that internal MTAs are fully compliant with Section 3.6 of [MAIL] and the compliant internal MTAs are using their own hostnames or the ADMD's DNS domain name as the authserv-id token, this header field should always appear above a Received header added by a trusted MTA.  This can be used as a test for header field validity.

Other software such as SpamAssassin also assumes that trusted `Authentication-Results` headers come before the trusted `Received` header.
