### PR TITLE
Use a functional test for OpenSSL ed25519 support

### DIFF
--- a/opendkim/opendkim-genkey.in
+++ b/opendkim/opendkim-genkey.in
@@ -130,10 +130,10 @@ umask(077);
 
 if ($ed25519)
 {
-	$status = system("openssl version 2>/dev/null | grep --silent --ignore-case '^openssl 1.1.1'");
+	$status = system("openssl genpkey -algorithm ed25519 > /dev/null 2>&1");
 	if ($status != 0)
 	{
-		print STDERR "$progname: OpenSSL 1.1.1 is required for ED25519 support\n";
+		print STDERR "$progname: OpenSSL 1.1.1 or newer is required for ED25519 support\n";
 		exit(1);
 	}
 }

--- a/opendkim/opendkim-genkey.in
+++ b/opendkim/opendkim-genkey.in
@@ -130,7 +130,7 @@ umask(077);
 
 if ($ed25519)
 {
-	$status = system("openssl genpkey -algorithm ed25519 > /dev/null 2>&1");
+	$status = system("openssl genpkey -algorithm ed25519 2> /dev/null | grep -q -w 'BEGIN PRIVATE KEY'");
 	if ($status != 0)
 	{
 		print STDERR "$progname: OpenSSL 1.1.1 or newer is required for ED25519 support\n";


### PR DESCRIPTION
rather than a hardcoded openssl version check, for openssl 3.0+ compatibility.