### PR TITLE
Use comma instead of semicolon in AR header comment

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -10766,7 +10766,7 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, struct dkimf_dstring *tmpstr,
  				                     " (%u-bit key%s%s)",
  				                     keybits,
  				                     dnssec == NULL ? ""
- 				                                    : "; ",
+ 				                                    : ", ",
  				                     dnssec == NULL ? ""
  				                                    : dnssec);
  			}


### PR DESCRIPTION
opendmarc has been emitting these warning messages for quite some
time, and does not further process the AAR header:

  ignoring invalid ARC-Authentication-Results header "i=1; mail.example.com; dkim=pass (2048-bit key; unprotected)
     header.d=mail.example-sender.com
     header.i=editor@mail.example-sender.com header.a=rsa-sha256
     header.s=cpm header.b=n+hM2AZB"

which was traced to the opendmarc code that tokenizes the AAR header
by splitting it up by semicolons, not recognizing parenthesis as
comments and skipping over them as part of the tokenization.

The AAR header is added by openarc, taking the content from the
Authentication-Results header added by opendkim.

The DKIM EBNF doesn't specify anything about the format of the
comments, so it's fair for opendkim to have used a semicolon in that
comment string.  However, it's just as fair for opendkim to use a
comma instead of a semicolon in that comment.

Patch replaces the semicolon with a comma.  Now opendmarc no longer
emits the above warning.