### PR TITLE
Adjust output format

### DIFF
--- a/opendkim/opendkim-genkey.in
+++ b/opendkim/opendkim-genkey.in
@@ -271,7 +271,7 @@ if (!open($txtout, ">", $selector . ".txt"))
 	exit(1);
 }
 
-print $txtout $selector . "._domainkey" . ${domstr} . "\tIN\tTXT\t( \"v=DKIM1;" . $noteout . $hashout . " k=rsa; " . $flags . "\"\n\t  \"p=";
+print $txtout $selector . "._domainkey" . ${domstr} . "\tIN\tTXT\t\n( \"v=DKIM1;" . $noteout . $hashout . " k=rsa; " . $flags . "p=";
 
 $len = length($keydata);
 $cur = 0;
@@ -292,7 +292,7 @@ while ($len > 0)
 	}
 }
 
-print $txtout "\" ) " . $comment . "\n";
+print $txtout "\" ) \t" . $comment . "\n";
 
 close($txtout);
 


### PR DESCRIPTION
Changed the output format of genkey, this could make life easier for people that change their DNS records manually.
Now it should be possible to copy/paste the pubkey information right into the DNS record.