### PR TITLE
systemd: use Type=simple and no fork to avoid PIDFile race

### DIFF
--- a/contrib/systemd/opendkim.service.in
+++ b/contrib/systemd/opendkim.service.in
@@ -12,6 +12,7 @@ Type=simple
 EnvironmentFile=-@sysconfdir@/sysconfig/opendkim
 ExecStart=@sbindir@/opendkim -f $OPTIONS
 ExecReload=/bin/kill -USR1 $MAINPID
+Restart=on-abnormal
 User=opendkim
 Group=opendkim
 

--- a/contrib/systemd/opendkim.service.in
+++ b/contrib/systemd/opendkim.service.in
@@ -8,10 +8,9 @@ Documentation=man:opendkim(8) man:opendkim.conf(5) man:opendkim-genkey(8) man:op
 After=network.target nss-lookup.target syslog.target
 
 [Service]
-Type=forking
-PIDFile=@localstatedir@/run/opendkim/opendkim.pid
+Type=simple
 EnvironmentFile=-@sysconfdir@/sysconfig/opendkim
-ExecStart=@sbindir@/opendkim $OPTIONS
+ExecStart=@sbindir@/opendkim -f $OPTIONS
 ExecReload=/bin/kill -USR1 $MAINPID
 User=opendkim
 Group=opendkim


### PR DESCRIPTION
[Red Hat BZ#2056209](https://bugzilla.redhat.com/show_bug.cgi?id=2056209)