### PR TITLE
opendkim.service: harden systemd service

### DIFF
--- a/contrib/systemd/opendkim.service.in
+++ b/contrib/systemd/opendkim.service.in
@@ -16,5 +16,48 @@ ExecReload=/bin/kill -USR1 $MAINPID
 User=opendkim
 Group=opendkim
 
+# As the file system is mounted read-only with ProtectSystem=strict, adding
+# /var/spool/postfix/opendkim by default makes it possible to use opendkim
+# with postfix without further configuration.
+ReadWritePaths=-/var/spool/postfix/opendkim
+RuntimeDirectory=opendkim
+
+# Hardening - see systemd.exec(5)
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateMounts=true
+PrivateTmp=true
+PrivateUsers=true
+ProcSubset=pid
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectSystem=strict
+RemoveIPC=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~ @privileged @resources
+
+# This restricts this service from executing binaries other than opendkim
+# itself. This is really effective at e.g. making it impossible to an
+# attacker to spawn a shell on the system, but might be more restrictive
+# than desired. If you need to, you can permit the execution of extra
+# binaries by adding an extra ExecPaths= directive with the command
+# systemctl edit opendkim.service
+NoExecPaths=/
+ExecPaths=@sbindir@/opendkim /usr/lib
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The current `opendkim.service` file is not hardened, and `systemd-analyze security opendkim.service` reports an "UNSAFE" exposure level of 9.6.

With the help of that tool I've applied some more security hardenings to the unit file, and the exposure level dropped to an amazing 1.1!

Some of the most notable changes include:

- Setting `ProtectSystem=` to `strict`, so that the entire file system is mounted read-only; users can allow-list writable paths by overriding the config with `systemctl edit opendkim.service`, but it shouldn't be needed. OpenDKIM doesn't modify files at all, and only creates a unix socket at startup, usually in `/run/opendkim/opendkim.socket` or `/var/spool/postfix/opendkim/opendkim.socket`. Both paths are allowed by default.

- Denying execution of system binaries with `NoExecPaths=/`, and only allowing the `opendkim` binary itself with `ExecPaths=/usr/sbin/opendkim`, so that if an attacker is able to gain access to OpenDKIM they won't be able to do much, if anything, as spawing shells, listing files, etc won't be allowed, making RCE vulnerabilities much harder to exploit.

- Making home directories inaccessible with `ProtectHome=true`

- Hiding all the users of the system, with `PrivateUsers=true`

- Restricting the kind of permitted system calls with `SystemCallFilter=@system-service` and `SystemCallFilter=~ @privileged @resources`

Ported from https://salsa.debian.org/debian/opendkim/-/merge_requests/3

Related to #146 