### PR TITLE
Skip DNAME RRs in DNS answers

### DIFF
--- a/libopendkim/dkim-atps.c
+++ b/libopendkim/dkim-atps.c
@@ -376,7 +376,7 @@ dkim_atps_check(DKIM *dkim, DKIM_SIGINFO *sig, struct timeval *timeout,
 			cp += n;
 			continue;
 		}
-		else if (type == T_RRSIG)
+		else if ((type == T_RRSIG) || (type == T_DNAME))
 		{
 			/* get payload length */
 			if (cp + INT16SZ > eom)

--- a/libopendkim/dkim-keys.c
+++ b/libopendkim/dkim-keys.c
@@ -324,7 +324,7 @@ dkim_get_key_dns(DKIM *dkim, DKIM_SIGINFO *sig, u_char *buf, size_t buflen)
 			cp += n;
 			continue;
 		}
-		else if (type == T_RRSIG)
+		else if ((type == T_RRSIG) || (type == T_DNAME))
 		{
 			cp += n;
 			continue;

--- a/libopendkim/dkim-report.c
+++ b/libopendkim/dkim-report.c
@@ -224,7 +224,7 @@ dkim_repinfo(DKIM *dkim, DKIM_SIGINFO *sig, struct timeval *timeout,
 			cp += n;
 			continue;
 		}
-		else if (type == T_RRSIG)
+		else if ((type == T_RRSIG) || (type == T_DNAME))
 		{
 			/* get payload length */
 			if (cp + INT16SZ > eom)

--- a/librbl/rbl.c
+++ b/librbl/rbl.c
@@ -1128,7 +1128,7 @@ rbl_query_check(RBL *rbl, void *qh, struct timeval *timeout, uint32_t *res)
 			cp += n;
 			continue;
 		}
-		else if (type == T_RRSIG)
+		else if ((type == T_RRSIG) || (type == T_DNAME))
 		{
 			/* get payload length */
 			if (cp + INT16SZ > eom)


### PR DESCRIPTION
DKIM verification fails if the answer packet contains DNAME RRs.
Example:

    ;; ANSWER SECTION:
    rub.de.                                  1103 IN DNAME ruhr-uni-bochum.de.
    rub.de.                                  1103 IN RRSIG DNAME 13 2 3600 ... 
    mail-2017._domainkey.rub.de.                0 IN CNAME mail-2017._domainkey.ruhr-uni-bochum.de.
    mail-2017._domainkey.ruhr-uni-bochum.de. 3068 IN TXT "v=DKIM1; h=sha256; p=MIGfMA..."
    mail-2017._domainkey.ruhr-uni-bochum.de. 3068 IN RRSIG TXT 13 4 3600 ...

This currently causes some trouble at the support team because they have to explain to our clients and the receiving side that there is no problem with the DMARC/DKIM/SPF setup but with the verification process.
