### PR TITLE
Fix signedness bug in RSA_Sign call

### DIFF
--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -3951,6 +3951,7 @@ dkim_eom_sign(DKIM *dkim)
 	  {
 		int nid;
 		struct dkim_crypto *crypto;
+		unsigned int ui_l = 0;
 
 		crypto = (struct dkim_crypto *) sig->sig_signature;
 
@@ -3961,9 +3962,11 @@ dkim_eom_sign(DKIM *dkim)
 		    sig->sig_hashtype == DKIM_HASHTYPE_SHA256)
 			nid = NID_sha256;
 
+		/* use variable ui_l to savely get the length (unsigned int *) out of RSA_sign and into size_t type l */
 		status = RSA_sign(nid, digest, diglen,
-	                          crypto->crypto_out, (int *) &l,
+	                          crypto->crypto_out, &ui_l,
 		                  crypto->crypto_key);
+		l = ui_l;
 		if (status != 1 || l == 0)
 		{
 			dkim_load_ssl_errors(dkim, 0);


### PR DESCRIPTION
In libopendkim's `dkim_eom_sign`, the call to `RSA_Sign` uses a variable of a signed type where an unsigned type is required. This manifested as a failure to sign on an S/390 machine and was reported in the Debian bug tracker.

The problem was analysed and patched by Martin Grimm.

This bug is forwarded from https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1012506