### PR TITLE
Upgrade to OpenSSL 3

### DIFF
--- a/libopendkim/base32.c
+++ b/libopendkim/base32.c
@@ -158,22 +158,21 @@ dkim_base32_encode(char *buf, size_t *buflen, const void *data, size_t size)
 
 #ifdef TEST
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 
 int
 main(int argc, char **argv)
 {
 	int x;
 	size_t buflen;
-	SHA_CTX sha;
 	char buf[128];
 	unsigned char shaout[SHA_DIGEST_LENGTH];
 
 	memset(buf, '\0', sizeof buf);
 	buflen = sizeof buf;
 
-	SHA1_Init(&sha);
-	SHA1_Update(&sha, argv[1], strlen(argv[1]));
-	SHA1_Final(shaout, &sha);
+	(void) EVP_Digest(argv[1], strlen(argv[1]), shaout, NULL, EVP_sha1(),
+	                  NULL);
 
 	x = dkim_base32_encode(buf, &buflen, shaout, SHA_DIGEST_LENGTH);
 

--- a/libopendkim/dkim-atps.c
+++ b/libopendkim/dkim-atps.c
@@ -37,6 +37,7 @@
 #else /* USE_GNUTLS */
 /* openssl includes */
 # include <openssl/sha.h>
+# include <openssl/evp.h>
 #endif /* USE_GNUTLS */
 
 /* prototypes */
@@ -113,11 +114,6 @@ dkim_atps_check(DKIM *dkim, DKIM_SIGINFO *sig, struct timeval *timeout,
 	u_char *eom;
 #ifdef USE_GNUTLS
 	gnutls_hash_hd_t ctx;
-#else /* USE_GNUTLS */
-        SHA_CTX ctx;
-# ifdef HAVE_SHA256
-	SHA256_CTX ctx2;
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 	struct timeval to;
 	HEADER hdr;
@@ -198,16 +194,14 @@ dkim_atps_check(DKIM *dkim, DKIM_SIGINFO *sig, struct timeval *timeout,
 		switch (hash)
 		{
 		  case DKIM_HASHTYPE_SHA1:
-			SHA1_Init(&ctx);
-			SHA1_Update(&ctx, sdomain, strlen(sdomain));
-			SHA1_Final(digest, &ctx);
+			(void) EVP_Digest(sdomain, strlen(sdomain), digest,
+			                  NULL, EVP_sha1(), NULL);
 			break;
 
 #  ifdef HAVE_SHA256
 		  case DKIM_HASHTYPE_SHA256:
-			SHA256_Init(&ctx2);
-			SHA256_Update(&ctx2, sdomain, strlen(sdomain));
-			SHA256_Final(digest, &ctx2);
+			(void) EVP_Digest(sdomain, strlen(sdomain), digest,
+			                  NULL, EVP_sha256(), NULL);
 			break;
 #  endif /* HAVE_SHA256 */
 

--- a/libopendkim/dkim-test.c
+++ b/libopendkim/dkim-test.c
@@ -432,7 +432,7 @@ dkim_test_key(DKIM_LIB *lib, char *selector, char *domain,
 			return -1;
 		}
 
-		crypto->crypto_keysize = EVP_PKEY_get_size(crypto->crypto_pkey);
+		crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
 
 		outkey = BIO_new(BIO_s_mem());
 		if (outkey == NULL)

--- a/libopendkim/dkim-test.c
+++ b/libopendkim/dkim-test.c
@@ -27,6 +27,7 @@
 # include <openssl/bio.h>
 # include <openssl/rsa.h>
 # include <openssl/evp.h>
+# include <openssl/x509.h>
 #endif /* USE_GNUTLS */
 
 /* libopendkim includes */
@@ -431,21 +432,7 @@ dkim_test_key(DKIM_LIB *lib, char *selector, char *domain,
 			return -1;
 		}
 
-		crypto->crypto_key = EVP_PKEY_get1_RSA(crypto->crypto_pkey);
-		if (crypto->crypto_key == NULL)
-		{
-			BIO_free(keybuf);
-			(void) dkim_free(dkim);
-			if (err != NULL)
-			{
-				strlcpy(err, "EVP_PKEY_get1_RSA() failed",
-				        errlen);
-			}
-			return -1;
-		}
-	
-		crypto->crypto_keysize = RSA_size(crypto->crypto_key);
-		crypto->crypto_pad = RSA_PKCS1_PADDING;
+		crypto->crypto_keysize = EVP_PKEY_get_size(crypto->crypto_pkey);
 
 		outkey = BIO_new(BIO_s_mem());
 		if (outkey == NULL)
@@ -457,7 +444,7 @@ dkim_test_key(DKIM_LIB *lib, char *selector, char *domain,
 			return -1;
 		}
 
-		status = i2d_RSA_PUBKEY_bio(outkey, crypto->crypto_key);
+		status = i2d_PUBKEY_bio(outkey, crypto->crypto_pkey);
 		if (status == 0)
 		{
 			BIO_free(keybuf);

--- a/libopendkim/dkim-types.h
+++ b/libopendkim/dkim-types.h
@@ -207,12 +207,10 @@ struct dkim_crypto
 	gnutls_datum_t 		crypto_rsaout;
 	gnutls_datum_t 		crypto_keydata;
 #else /* USE_GNUTLS */
-	u_char			crypto_pad;
 	int			crypto_keysize;
 	size_t			crypto_inlen;
 	size_t			crypto_outlen;
 	EVP_PKEY *		crypto_pkey;
-	void *			crypto_key;
 	BIO *			crypto_keydata;
 	u_char *		crypto_in;
 	u_char *		crypto_out;

--- a/libopendkim/dkim-types.h
+++ b/libopendkim/dkim-types.h
@@ -37,6 +37,7 @@
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/sha.h>
+# include <openssl/evp.h>
 #endif /* USE_GNUTLS */
 
 #ifdef QUERY_CACHE
@@ -151,36 +152,22 @@ struct dkim_siginfo
 	struct dkim_dstring *	sig_sslerrbuf;
 };
 
-#ifdef USE_GNUTLS
 /* struct dkim_sha -- stuff needed to do a sha hash */
 struct dkim_sha
 {
+#ifdef USE_GNUTLS
 	int			sha_tmpfd;
 	u_int			sha_outlen;
 	gnutls_hash_hd_t	sha_hd;
 	u_char *		sha_out;
-};
 #else /* USE_GNUTLS */
-/* struct dkim_sha1 -- stuff needed to do a sha1 hash */
-struct dkim_sha1
-{
-	int			sha1_tmpfd;
-	BIO *			sha1_tmpbio;
-	SHA_CTX			sha1_ctx;
-	u_char			sha1_out[SHA_DIGEST_LENGTH];
-};
-
-# ifdef HAVE_SHA256
-/* struct dkim_sha256 -- stuff needed to do a sha256 hash */
-struct dkim_sha256
-{
-	int			sha256_tmpfd;
-	BIO *			sha256_tmpbio;
-	SHA256_CTX		sha256_ctx;
-	u_char			sha256_out[SHA256_DIGEST_LENGTH];
-};
-# endif /* HAVE_SHA256 */
+	int			sha_tmpfd;
+	BIO *			sha_tmpbio;
+	EVP_MD_CTX *		sha_ctx;
+	u_char			sha_out[EVP_MAX_MD_SIZE];
+	u_int			sha_outlen;
 #endif /* USE_GNUTLS */
+};
 
 /* struct dkim_canon -- a canonicalization status handle */
 struct dkim_canon

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -1265,7 +1265,7 @@ dkim_privkey_load(DKIM *dkim)
 		}
 	}
 
-	crypto->crypto_outlen = EVP_PKEY_get_size(crypto->crypto_pkey);
+	crypto->crypto_outlen = EVP_PKEY_size(crypto->crypto_pkey);
 	crypto->crypto_keysize = crypto->crypto_outlen * 8;
 
 	crypto->crypto_out = DKIM_MALLOC(dkim, crypto->crypto_outlen);
@@ -5793,7 +5793,7 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 		{
 			EVP_MD_CTX *md_ctx;
 
-			if (EVP_PKEY_get_id(crypto->crypto_pkey) != EVP_PKEY_ED25519)
+			if (EVP_PKEY_id(crypto->crypto_pkey) != EVP_PKEY_ED25519)
 			{
 				dkim_error(dkim,
 				           "s=%s d=%s: not an ED25519 key",
@@ -5847,12 +5847,12 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 
 			EVP_MD_CTX_free(md_ctx);
 
-			crypto->crypto_keysize = EVP_PKEY_get_size(crypto->crypto_pkey);
+			crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
 		}
 		else
 # endif /* HAVE_ED25519 */
 		{
-			if (EVP_PKEY_get_base_id(crypto->crypto_pkey) != EVP_PKEY_RSA)
+			if (EVP_PKEY_base_id(crypto->crypto_pkey) != EVP_PKEY_RSA)
 			{
 				dkim_error(dkim,
 				           "s=%s d=%s: not an RSA key",
@@ -5866,7 +5866,7 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 				return DKIM_STAT_OK;
 			}
 
-			crypto->crypto_keysize = EVP_PKEY_get_size(crypto->crypto_pkey);
+			crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
 
 			crypto->crypto_in = sig->sig_sig;
 			crypto->crypto_inlen = sig->sig_siglen;

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -75,6 +75,7 @@
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/sha.h>
+# include <openssl/evp.h>
 #endif /* USE_GNUTLS */
 
 /* libopendkim includes */
@@ -200,12 +201,6 @@ void dkim_error __P((DKIM *, const char *, ...));
 # define BIO_CLOBBER(x)	if ((x) != NULL) \
 			{ \
 				BIO_free((x)); \
-				(x) = NULL; \
-			}
-
-# define RSA_CLOBBER(x)	if ((x) != NULL) \
-			{ \
-				RSA_free((x)); \
 				(x) = NULL; \
 			}
 
@@ -1270,32 +1265,14 @@ dkim_privkey_load(DKIM *dkim)
 		}
 	}
 
-	if (dkim->dkim_signalg == DKIM_SIGN_ED25519SHA256)
-	{
-		crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey) * 8;
-	}
-	else
-	{
-		crypto->crypto_key = EVP_PKEY_get1_RSA(crypto->crypto_pkey);
-		if (crypto->crypto_key == NULL)
-		{
-			dkim_load_ssl_errors(dkim, 0);
-			dkim_error(dkim, "EVP_PKEY_get1_RSA() failed");
-			BIO_CLOBBER(crypto->crypto_keydata);
-			return DKIM_STAT_NORESOURCE;
-		}
+	crypto->crypto_outlen = EVP_PKEY_get_size(crypto->crypto_pkey);
+	crypto->crypto_keysize = crypto->crypto_outlen * 8;
 
-		crypto->crypto_keysize = RSA_size(crypto->crypto_key) * 8;
-		crypto->crypto_pad = RSA_PKCS1_PADDING;
-	}
-
-	crypto->crypto_outlen = crypto->crypto_keysize / 8;
 	crypto->crypto_out = DKIM_MALLOC(dkim, crypto->crypto_outlen);
 	if (crypto->crypto_out == NULL)
 	{
 		dkim_error(dkim, "unable to allocate %d byte(s)",
-		           crypto->crypto_keysize / 8);
-		RSA_free(crypto->crypto_key);
+		           crypto->crypto_outlen);
 		BIO_CLOBBER(crypto->crypto_keydata);
 		return DKIM_STAT_NORESOURCE;
 	}
@@ -3675,7 +3652,6 @@ static DKIM_STAT
 dkim_eom_sign(DKIM *dkim)
 {
 	int status;
-	size_t l = 0;
 	size_t diglen;
 	size_t siglen = 0;
 	size_t len;
@@ -3811,9 +3787,7 @@ dkim_eom_sign(DKIM *dkim)
 #ifdef USE_GNUTLS
 	if (crypto->crypto_privkey == NULL)
 #else /* USE_GNUTLS */
-	if (!(crypto->crypto_key != NULL ||
-	      (sig->sig_signalg == DKIM_SIGN_ED25519SHA256 &&
-	       crypto->crypto_pkey != NULL)))
+	if (crypto->crypto_pkey == NULL)
 #endif /* USE_GNUTLS */
 	{
 		dkim_error(dkim, "private key load failed");
@@ -3949,38 +3923,82 @@ dkim_eom_sign(DKIM *dkim)
 	  case DKIM_SIGN_RSASHA1:
 	  case DKIM_SIGN_RSASHA256:
 	  {
-		int nid;
 		struct dkim_crypto *crypto;
+		EVP_PKEY_CTX *pkey_ctx;
+		const EVP_MD *md;
 
 		crypto = (struct dkim_crypto *) sig->sig_signature;
 
-		nid = NID_sha1;
+		pkey_ctx = EVP_PKEY_CTX_new(crypto->crypto_pkey, NULL);
 
-		if (dkim_libfeature(dkim->dkim_libhandle,
-		                    DKIM_FEATURE_SHA256) &&
-		    sig->sig_hashtype == DKIM_HASHTYPE_SHA256)
-			nid = NID_sha256;
+		if (pkey_ctx == NULL)
+		{
+			dkim_error(dkim, "failed to allocate EVP_PKEY context");
+			BIO_CLOBBER(crypto->crypto_keydata);
+			return DKIM_STAT_NORESOURCE;
+		}
 
-		status = RSA_sign(nid, digest, diglen,
-	                          crypto->crypto_out, (int *) &l,
-		                  crypto->crypto_key);
-		if (status != 1 || l == 0)
+		if (EVP_PKEY_sign_init(pkey_ctx) <= 0)
 		{
 			dkim_load_ssl_errors(dkim, 0);
 			dkim_error(dkim,
-			           "signature generation failed (status %d, length %d)",
-			           status, l);
+			           "failed to initialize EVP_PKEY context");
 
-			RSA_free(crypto->crypto_key);
+			EVP_PKEY_CTX_free(pkey_ctx);
 			BIO_CLOBBER(crypto->crypto_keydata);
 
 			return DKIM_STAT_INTERNAL;
 		}
 
-		crypto->crypto_outlen = l;
+		if (EVP_PKEY_CTX_set_rsa_padding(pkey_ctx, RSA_PKCS1_PADDING) <= 0)
+		{
+			dkim_load_ssl_errors(dkim, 0);
+			dkim_error(dkim, "failed to set RSA padding mode");
+
+			EVP_PKEY_CTX_free(pkey_ctx);
+			BIO_CLOBBER(crypto->crypto_keydata);
+
+			return DKIM_STAT_INTERNAL;
+		}
+
+		md = EVP_sha1();
+
+		if (dkim_libfeature(dkim->dkim_libhandle,
+		                    DKIM_FEATURE_SHA256) &&
+		    sig->sig_hashtype == DKIM_HASHTYPE_SHA256)
+			md = EVP_sha256();
+
+		if (EVP_PKEY_CTX_set_signature_md(pkey_ctx, md) <= 0)
+		{
+			dkim_load_ssl_errors(dkim, 0);
+			dkim_error(dkim, "failed to set message digest type");
+
+			EVP_PKEY_CTX_free(pkey_ctx);
+			BIO_CLOBBER(crypto->crypto_keydata);
+
+			return DKIM_STAT_INTERNAL;
+		}
+
+		status = EVP_PKEY_sign(pkey_ctx, crypto->crypto_out,
+		                       &crypto->crypto_outlen, digest, diglen);
+
+		if (status != 1 || crypto->crypto_outlen == 0)
+		{
+			dkim_load_ssl_errors(dkim, 0);
+			dkim_error(dkim,
+			           "signature generation failed (status %d, length %d)",
+			           status, crypto->crypto_outlen);
+
+			EVP_PKEY_CTX_free(pkey_ctx);
+			BIO_CLOBBER(crypto->crypto_keydata);
+
+			return DKIM_STAT_INTERNAL;
+		}
 
 		signature = crypto->crypto_out;
 		siglen = crypto->crypto_outlen;
+
+		EVP_PKEY_CTX_free(pkey_ctx);
 
 		break;
 	  }
@@ -4000,7 +4018,6 @@ dkim_eom_sign(DKIM *dkim)
 			dkim_error(dkim,
 			           "failed to initialize digest context");
 
-			RSA_free(crypto->crypto_key);
 			BIO_CLOBBER(crypto->crypto_keydata);
 
 			return DKIM_STAT_INTERNAL;
@@ -4010,9 +4027,9 @@ dkim_eom_sign(DKIM *dkim)
 		                            NULL, NULL, crypto->crypto_pkey);
 		if (status == 1)
 		{
-			l = crypto->crypto_outlen;
-			status = EVP_DigestSign(md_ctx, crypto->crypto_out, &l,
-		                                digest, diglen);
+			status = EVP_DigestSign(md_ctx, crypto->crypto_out,
+			                        &crypto->crypto_outlen, digest,
+			                        diglen);
 		}
 
 		if (status != 1)
@@ -4020,15 +4037,13 @@ dkim_eom_sign(DKIM *dkim)
 			/* dkim_load_ssl_errors(dkim, 0); */
 			dkim_error(dkim,
 			           "signature generation failed (status %d, length %d, %s)",
-			           status, l, ERR_error_string(ERR_get_error(), NULL));
+			           status, crypto->crypto_outlen,
+			           ERR_error_string(ERR_get_error(), NULL));
 
-			RSA_free(crypto->crypto_key);
 			BIO_CLOBBER(crypto->crypto_keydata);
 
 			return DKIM_STAT_INTERNAL;
 		}
-
-		crypto->crypto_outlen = l;
 
 		signature = crypto->crypto_out;
 		siglen = crypto->crypto_outlen;
@@ -5146,7 +5161,6 @@ dkim_free(DKIM *dkim)
 #else /* USE_GNUTLS */
 					BIO_CLOBBER(crypto->crypto_keydata);
 					EVP_CLOBBER(crypto->crypto_pkey);
-					RSA_CLOBBER(crypto->crypto_key);
 					CLOBBER(crypto->crypto_out);
 #endif /* USE_GNUTLS */
 				}
@@ -5558,6 +5572,8 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 # endif /* GNUTLS_VERSION_MAJOR == 3 */
 #else /* USE_GNUTLS */
 	BIO *key;
+	EVP_PKEY_CTX *pkey_ctx;
+	const EVP_MD *md;
 #endif /* USE_GNUTLS */
 	u_char *digest = NULL;
 	struct dkim_crypto *crypto;
@@ -5777,7 +5793,7 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 		{
 			EVP_MD_CTX *md_ctx;
 
-			if (EVP_PKEY_id(crypto->crypto_pkey) != EVP_PKEY_ED25519)
+			if (EVP_PKEY_get_id(crypto->crypto_pkey) != EVP_PKEY_ED25519)
 			{
 				dkim_error(dkim,
 				           "s=%s d=%s: not an ED25519 key",
@@ -5831,17 +5847,15 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 
 			EVP_MD_CTX_free(md_ctx);
 
-			crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
+			crypto->crypto_keysize = EVP_PKEY_get_size(crypto->crypto_pkey);
 		}
 		else
 # endif /* HAVE_ED25519 */
 		{
-			crypto->crypto_key = EVP_PKEY_get1_RSA(crypto->crypto_pkey);
-			if (crypto->crypto_key == NULL)
+			if (EVP_PKEY_get_base_id(crypto->crypto_pkey) != EVP_PKEY_RSA)
 			{
-				dkim_sig_load_ssl_errors(dkim, sig, 0);
 				dkim_error(dkim,
-				           "s=%s d=%s: EVP_PKEY_get1_RSA() failed",
+				           "s=%s d=%s: not an RSA key",
 				           dkim_sig_getselector(sig),
 				           dkim_sig_getdomain(sig));
 
@@ -5852,23 +5866,69 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 				return DKIM_STAT_OK;
 			}
 
-			crypto->crypto_keysize = RSA_size(crypto->crypto_key);
-			crypto->crypto_pad = RSA_PKCS1_PADDING;
+			crypto->crypto_keysize = EVP_PKEY_get_size(crypto->crypto_pkey);
 
 			crypto->crypto_in = sig->sig_sig;
 			crypto->crypto_inlen = sig->sig_siglen;
 
-			nid = NID_sha1;
+			pkey_ctx = EVP_PKEY_CTX_new(crypto->crypto_pkey, NULL);
+
+			if (pkey_ctx == NULL)
+			{
+				dkim_error(dkim,
+				           "failed to allocate EVP_PKEY context");
+				BIO_CLOBBER(key);
+				return DKIM_STAT_NORESOURCE;
+			}
+
+			if (EVP_PKEY_verify_init(pkey_ctx) <= 0)
+			{
+				dkim_sig_load_ssl_errors(dkim, sig, 0);
+				dkim_error(dkim,
+				           "failed to initialize EVP_PKEY context");
+
+				EVP_PKEY_CTX_free(pkey_ctx);
+				BIO_CLOBBER(key);
+
+				return DKIM_STAT_INTERNAL;
+			}
+
+			if (EVP_PKEY_CTX_set_rsa_padding(pkey_ctx, RSA_PKCS1_PADDING) <= 0)
+			{
+				dkim_sig_load_ssl_errors(dkim, sig, 0);
+				dkim_error(dkim,
+				           "failed to set RSA padding mode");
+
+				EVP_PKEY_CTX_free(pkey_ctx);
+				BIO_CLOBBER(key);
+
+				return DKIM_STAT_INTERNAL;
+			}
+
+			md = EVP_sha1();
 
 			if (dkim_libfeature(dkim->dkim_libhandle,
 			                    DKIM_FEATURE_SHA256) &&
 			    sig->sig_hashtype == DKIM_HASHTYPE_SHA256)
-				nid = NID_sha256;
+				md = EVP_sha256();
 
-			vstat = RSA_verify(nid, digest, diglen,
-			                   crypto->crypto_in,
-			                   crypto->crypto_inlen,
-			                   crypto->crypto_key);
+			if (EVP_PKEY_CTX_set_signature_md(pkey_ctx, md) <= 0)
+			{
+				dkim_sig_load_ssl_errors(dkim, sig, 0);
+				dkim_error(dkim,
+				           "failed to set message digest type");
+
+				EVP_PKEY_CTX_free(pkey_ctx);
+				BIO_CLOBBER(key);
+
+				return DKIM_STAT_INTERNAL;
+			}
+
+			vstat = EVP_PKEY_verify(pkey_ctx, crypto->crypto_in,
+			                        crypto->crypto_inlen, digest,
+			                        diglen);
+
+			EVP_PKEY_CTX_free(pkey_ctx);
 		}
 
 		dkim_sig_load_ssl_errors(dkim, sig, 0);
@@ -5876,13 +5936,7 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 		sig->sig_keybits = 8 * crypto->crypto_keysize;
 
 		BIO_CLOBBER(key);
-		EVP_PKEY_free(crypto->crypto_pkey);
-		crypto->crypto_pkey = NULL;
-		if (crypto->crypto_key != NULL)
-		{
-			RSA_free(crypto->crypto_key);
-			crypto->crypto_key = NULL;
-		}
+		EVP_CLOBBER(crypto->crypto_pkey);
 #endif /* USE_GNUTLS */
 
 		if (vstat == 1)

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -7598,40 +7598,22 @@ dkim_sig_getreportinfo(DKIM *dkim, DKIM_SIGINFO *sig,
 		  }
 #else /* USE_GNUTLS */
 		  case DKIM_HASHTYPE_SHA1:
-		  {
-			struct dkim_sha1 *sha1;
-
-			sha1 = (struct dkim_sha1 *) sig->sig_hdrcanon->canon_hash;
-			if (hfd != NULL)
-				*hfd = sha1->sha1_tmpfd;
-
-			if (bfd != NULL)
-			{
-				sha1 = (struct dkim_sha1 *) sig->sig_bodycanon->canon_hash;
-				*bfd = sha1->sha1_tmpfd;
-			}
-
-			break;
-		  }
-
-# ifdef HAVE_SHA256
 		  case DKIM_HASHTYPE_SHA256:
 		  {
-			struct dkim_sha256 *sha256;
+			struct dkim_sha *sha;
 
-			sha256 = (struct dkim_sha256 *) sig->sig_hdrcanon->canon_hash;
+			sha = (struct dkim_sha *) sig->sig_hdrcanon->canon_hash;
 			if (hfd != NULL)
-				*hfd = sha256->sha256_tmpfd;
+				*hfd = sha->sha_tmpfd;
 
 			if (bfd != NULL)
 			{
-				sha256 = (struct dkim_sha256 *) sig->sig_bodycanon->canon_hash;
-				*bfd = sha256->sha256_tmpfd;
+				sha = (struct dkim_sha *) sig->sig_bodycanon->canon_hash;
+				*bfd = sha->sha_tmpfd;
 			}
 
 			break;
 		  }
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 
 		  default:

--- a/opendkim/opendkim-atpszone.c
+++ b/opendkim/opendkim-atpszone.c
@@ -144,11 +144,6 @@ main(int argc, char **argv)
 	DKIMF_DB db;
 #ifdef USE_GNUTLS
 	gnutls_hash_hd_t sha;
-#else /* USE_GNUTLS */
-	SHA_CTX sha;
-# ifdef HAVE_SHA256
-	SHA256_CTX sha256;
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 	char domain[DKIM_MAXHOSTNAMELEN + 1];
 	char hostname[DKIM_MAXHOSTNAMELEN + 1];
@@ -443,20 +438,19 @@ main(int argc, char **argv)
 # ifdef HAVE_SHA256
 			if (hash == NULL || strcasecmp(hash, "sha256") == 0)
 			{
-				SHA256_Init(&sha256);
-				SHA256_Update(&sha256, domain, strlen(domain));
-				SHA256_Final(shaout, &sha256);
+				(void) EVP_Digest(domain, strlen(domain),
+				                  shaout, NULL, EVP_sha256(),
+				                  NULL);
 			}
 			else
 			{
-				SHA1_Init(&sha);
-				SHA1_Update(&sha, domain, strlen(domain));
-				SHA1_Final(shaout, &sha);
+				(void) EVP_Digest(domain, strlen(domain),
+				                  shaout, NULL, EVP_sha1(),
+				                  NULL);
 			}
 # else /* HAVE_SHA256 */
-			SHA1_Init(&sha);
-			SHA1_Update(&sha, domain, strlen(domain));
-			SHA1_Final(shaout, &sha);
+			(void) EVP_Digest(domain, strlen(domain), shaout, NULL,
+			                  EVP_sha1(), NULL);
 # endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 

--- a/opendkim/opendkim-genzone.c
+++ b/opendkim/opendkim-genzone.c
@@ -835,7 +835,7 @@ main(int argc, char **argv)
 			}
 		}
 
-		if (EVP_PKEY_get_base_id(pkey) != EVP_PKEY_RSA)
+		if (EVP_PKEY_base_id(pkey) != EVP_PKEY_RSA)
 		{
 			fprintf(stderr, "%s: not an RSA key\n", progname);
 			(void) dkimf_db_close(db);

--- a/opendkim/opendkim-genzone.c
+++ b/opendkim/opendkim-genzone.c
@@ -26,7 +26,6 @@
 # include <gnutls/abstract.h>
 # include <gnutls/x509.h>
 #else /* USE_GNUTLS */
-# include <openssl/rsa.h>
 # include <openssl/pem.h>
 # include <openssl/evp.h>
 # include <openssl/bio.h>
@@ -264,7 +263,6 @@ main(int argc, char **argv)
 	BIO *private;
 	BIO *outbio = NULL;
 	EVP_PKEY *pkey;
-	RSA *rsa;
 #endif /* USE_GNUTLS */
 	DKIMF_DB db;
 	char keyname[BUFRSZ + 1];
@@ -837,12 +835,9 @@ main(int argc, char **argv)
 			}
 		}
 
-		rsa = EVP_PKEY_get1_RSA(pkey);
-		if (rsa == NULL)
+		if (EVP_PKEY_get_base_id(pkey) != EVP_PKEY_RSA)
 		{
-			fprintf(stderr,
-			        "%s: EVP_PKEY_get1_RSA() failed\n",
-			        progname);
+			fprintf(stderr, "%s: not an RSA key\n", progname);
 			(void) dkimf_db_close(db);
 			(void) BIO_free(private);
 			(void) EVP_PKEY_free(pkey);
@@ -851,11 +846,11 @@ main(int argc, char **argv)
 		}
 
 		/* convert private to public */
-		status = PEM_write_bio_RSA_PUBKEY(outbio, rsa);
+		status = PEM_write_bio_PUBKEY(outbio, pkey);
 		if (status == 0)
 		{
 			fprintf(stderr,
-			        "%s: PEM_write_bio_RSA_PUBKEY() failed\n",
+			        "%s: PEM_write_bio_PUBKEY() failed\n",
 			        progname);
 			(void) dkimf_db_close(db);
 			(void) BIO_free(private);


### PR DESCRIPTION
The proposed change upgrades OpenSSL to version 3.

The change is not too big, it looks sensible to me, it is backwards compatible, and the test suite passes. I have done successful manual testing using `opendkim-testmsg` for both signing and verifying, using signature algorithms `rsa-sha256` and `ed25519-sha256`. `configure.ac` hasn’t been updated yet. Feedback welcome.
