### PR TITLE
Update opendkim.service.in

### DIFF
--- a/contrib/systemd/opendkim.service.in
+++ b/contrib/systemd/opendkim.service.in
@@ -5,7 +5,7 @@
 [Unit]
 Description=DomainKeys Identified Mail (DKIM) Milter
 Documentation=man:opendkim(8) man:opendkim.conf(5) man:opendkim-genkey(8) man:opendkim-genzone(8) man:opendkim-testadsp(8) man:opendkim-testkey http://www.opendkim.org/docs.html
-After=network.target nss-lookup.target syslog.target
+After=network-online.target nss-lookup.target syslog.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
At present contrib/systemd/opendkim.service.in uses a network.target dependency this should be network-online.target to ensure the network is fully up and all IPs bound.
(per issue  #141)