### PR TITLE
libopendkim/util.c: include stdio.h for snprintf.

### DIFF
--- a/libopendkim/util.c
+++ b/libopendkim/util.c
@@ -17,6 +17,7 @@
 # include <stdbool.h>
 #endif /* HAVE_STDBOOL_H */
 #include <ctype.h>
+#include <stdio.h>
 #include <assert.h>
 #include <string.h>
 #include <errno.h>


### PR DESCRIPTION
This fixes a build failure on musl, reported at

  https://bugs.gentoo.org/896048
