### PR TITLE
Delete Authentication-Results headers in reverse

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -13653,8 +13653,15 @@ mlfi_eom(SMFICTX *ctx)
 			return SMFIS_TEMPFAIL;
 		}
 
-		c = 0;
+		c = 1;
+
 		for (hdr = dfc->mctx_hqhead; hdr != NULL; hdr = hdr->hdr_next)
+		{
+			if (strcasecmp(hdr->hdr_hdr, AUTHRESULTSHDR) == 0)
+				c++;
+		}
+
+		for (hdr = dfc->mctx_hqtail; hdr != NULL; hdr = hdr->hdr_prev)
 		{
 			memset(ares, '\0', sizeof(struct authres));
 
@@ -13666,7 +13673,7 @@ mlfi_eom(SMFICTX *ctx)
 				char *slash;
 
 				/* remember index */
-				c++;
+				c--;
 
 				/* parse the header */
 				arstat = ares_parse((u_char *) hdr->hdr_val,


### PR DESCRIPTION
The proposed change reverses the direction in which undesired Authentication-Results headers are removed.

This fixes bug #148.