### PR TITLE
Update SASL and LDAP pkgconfig names

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1890,7 +1890,7 @@ sasl_found="no"
 if test \( x"$saslpath" = x"auto" -o x"$saslpath" = x"yes" \) -a \
 	x"$PKG_CONFIG" != x""
 then
-        PKG_CHECK_MODULES([SASL], [cyrussasl >= 2.1.0],
+        PKG_CHECK_MODULES([SASL], [libsasl2 >= 2.1.0],
 	[
 		sasl_found="yes"
 		SASL_CPPFLAGS="$SASL_CFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -1800,7 +1800,7 @@ OPENLDAP_LIBS=""
 if test \( x"$ldappath" = x"auto" -o x"$ldappath" = x"yes" \) -a \
 	x"$PKG_CONFIG" != x""
 then
-        PKG_CHECK_MODULES([OPENLDAP], [openldap >= 2.0.0],
+        PKG_CHECK_MODULES([OPENLDAP], [ldap >= 2.0.0],
 	[
 		ldap_found="yes"
 		OPENLDAP_CPPFLAGS="$OPENLDAP_CFLAGS"


### PR DESCRIPTION
The names of the pkgconfig files we use to look up libsasl2 and libldap are outdated(?). In any case, they're wrong now. The commit messages give pointers to the upstream files. We update the two lines in `configure.ac` to use the right names.