### PR TITLE
Fix screen.lua.sample off-by-one error and function name

### DIFF
--- a/opendkim/screen.lua.sample
+++ b/opendkim/screen.lua.sample
@@ -24,7 +24,7 @@ end
 
 --  for each signature, ignore it if it's not from the sender's domain
 for n = 1, nsigs do
-	sig = odkim.get_signhandle(ctx, n)
+	sig = odkim.get_sighandle(ctx, n - 1)
 	sdomain = odkim.sig_getdomain(sig)
 	if fdomain ~= sdomain then
 		odkim.sig_ignore(sig)


### PR DESCRIPTION
Function is named get_sighandle() rather than get_signhandle() and accepts indices starting with 0.
This is correctly documented in opendkim-lua man page. Attempting to access signatures outside the range leads to errors.