### PR TITLE
Lua: Fix stack level after register odkim functions.

### DIFF
--- a/miltertest/miltertest.c
+++ b/miltertest/miltertest.c
@@ -4014,8 +4014,8 @@ main(int argc, char **argv)
 	lua_setglobal(l, "mt");
 #else /* LUA_VERSION_NUM >= 502 */
 	luaL_register(l, "mt", mt_library);
-#endif /* LUA_VERSION_NUM >= 502 */
 	lua_pop(l, 1);
+#endif /* LUA_VERSION_NUM >= 502 */
 
 	/* register constants */
 	lua_pushnumber(l, MT_HDRINSERT);

--- a/opendkim/opendkim-lua.c
+++ b/opendkim/opendkim-lua.c
@@ -490,8 +490,8 @@ dkimf_lua_setup_hook(void *ctx, const char *script, size_t scriptlen,
 	lua_setglobal(l, "odkim");
 # else /* LUA_VERSION_NUM >= 502 */
 	luaL_register(l, "odkim", dkimf_lua_lib_setup);
-# endif /* LUA_VERSION_NUM >= 502 */
 	lua_pop(l, 1);
+# endif /* LUA_VERSION_NUM >= 502 */
 
 	/*
 	**  Register constants.
@@ -649,8 +649,8 @@ dkimf_lua_screen_hook(void *ctx, const char *script, size_t scriptlen,
 	lua_setglobal(l, "odkim");
 # else /* LUA_VERSION_NUM >= 502 */
 	luaL_register(l, "odkim", dkimf_lua_lib_screen);
-# endif /* LUA_VERSION_NUM >= 502 */
 	lua_pop(l, 1);
+# endif /* LUA_VERSION_NUM >= 502 */
 
 	/*
 	**  Register constants.
@@ -798,8 +798,8 @@ dkimf_lua_stats_hook(void *ctx, const char *script, size_t scriptlen,
 	lua_setglobal(l, "odkim");
 # else /* LUA_VERSION_NUM >= 502 */
 	luaL_register(l, "odkim", dkimf_lua_lib_stats);
-# endif /* LUA_VERSION_NUM >= 502 */
 	lua_pop(l, 1);
+# endif /* LUA_VERSION_NUM >= 502 */
 
 	/*
 	**  Register constants.
@@ -1039,8 +1039,8 @@ dkimf_lua_final_hook(void *ctx, const char *script, size_t scriptlen,
 	lua_setglobal(l, "odkim");
 # else /* LUA_VERSION_NUM >= 502 */
 	luaL_register(l, "odkim", dkimf_lua_lib_final);
-# endif /* LUA_VERSION_NUM >= 502 */
 	lua_pop(l, 1);
+# endif /* LUA_VERSION_NUM >= 502 */
 
 	/*
 	**  Register constants.


### PR DESCRIPTION
When luaL_setfuncs() is replaced by luaL_newlib() + lua_setglobal() in commit 74b3374feee34fba14a0e15f89f049cbe4a3dafd, the commit did not take account that lua_setglobal() pops a value from the stack.

Thus, following lua pop(l, 1) tries to pop from empty stack in Lua >= 5.2, especially in Lua 5.4, it causes abort().

This fix it.

* miltertest/miltertest.c (main): Don't pop after lua_setglobal() in Lua >= 5.2

* opendkim/opendkim-lua.c (dkimf_lua_setup_hook, dkimf_lua_screen_hook, dkimf_lua_stats_hook, dkimf_lua_final_hook): As above.