### PR TITLE
opendkim-ar: Accept AR header with a no-result as valid syntax.

### DIFF
--- a/opendkim/opendkim-ar.c
+++ b/opendkim/opendkim-ar.c
@@ -454,7 +454,7 @@ ares_parse(u_char *hdr, struct authres *ar)
 			if (tokens[c][0] == ';')
 			{
 				prevstate = state;
-				state = 3;
+				state = 14;
 			}
 			else if (isascii(tokens[c][0]) &&
 			         isdigit(tokens[c][0]))
@@ -479,9 +479,19 @@ ares_parse(u_char *hdr, struct authres *ar)
 				return -1;
 
 			prevstate = state;
-			state = 3;
+			state = 14;
 
 			break;
+
+		  case 14:				/* method or "none" */
+			if (strcasecmp((char *) tokens[c], "none") == 0)
+			{
+				prevstate = state;
+				state = 15;
+				continue;
+			}
+
+			/* FALLTHROUGH */
 
 		  case 3:				/* method */
 			if (n == 0 || !ares_dedup(ar, n))
@@ -651,6 +661,10 @@ ares_parse(u_char *hdr, struct authres *ar)
 			state = 9;
 
 			break;
+
+		  case 15:				/* terminal state after no-result */
+			/* no token should not appear */
+			return -1;
 		}
 	}
 

--- a/opendkim/opendkim-ar.c
+++ b/opendkim/opendkim-ar.c
@@ -663,7 +663,7 @@ ares_parse(u_char *hdr, struct authres *ar)
 			break;
 
 		  case 15:				/* terminal state after no-result */
-			/* no token should not appear */
+			/* any token should not appear */
 			return -1;
 		}
 	}


### PR DESCRIPTION
Current parser for Authentication header does not accept the case that `authres-payloa`d contains `no-result` in [RFC8601 section 2.2](https://datatracker.ietf.org/doc/html/rfc8601#section-2.2).

This is a fix for it.