### PR TITLE
Fix Lua odkim.del_header

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -3719,7 +3719,7 @@ dkimf_xs_delheader(lua_State *l)
 
 	if (ctx == NULL)
 		lua_pushnil(l);
-	else if (dkimf_chgheader(ctx, name, 1, NULL) == MI_SUCCESS)
+	else if (dkimf_chgheader(ctx, name, idx+1, NULL) == MI_SUCCESS)
 		lua_pushnumber(l, 1);
 	else
 		lua_pushnil(l);


### PR DESCRIPTION
Fix Lua odkim.del_header() according to trusteddomainproject/OpenDKIM#191 : delete the actual requested header number instead of the first one.