### PR TITLE
opendkim/opendkim.c: add two missing dkimf_dstring_get() calls

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -11656,8 +11656,8 @@ mlfi_eoh(SMFICTX *ctx)
 	    (status != 0 || user == NULL || domain == NULL ||
 	     user[0] == '\0' || domain[0] == '\0'))
 	{
-		strlcpy(addr, conf->conf_defsender, sizeof addr);
-		status = dkim_mail_parse(addr, &user, &domain);
+		strlcpy(dkimf_dstring_get(addr), conf->conf_defsender, sizeof addr);
+		status = dkim_mail_parse(dkimf_dstring_get(addr), &user, &domain);
 	}
 #endif /* _FFR_DEFAULT_SENDER */
 

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -11656,7 +11656,7 @@ mlfi_eoh(SMFICTX *ctx)
 	    (status != 0 || user == NULL || domain == NULL ||
 	     user[0] == '\0' || domain[0] == '\0'))
 	{
-		strlcpy(dkimf_dstring_get(addr), conf->conf_defsender, sizeof addr);
+		dkimf_dstring_copy(addr, conf->conf_defsender);
 		status = dkim_mail_parse(dkimf_dstring_get(addr), &user, &domain);
 	}
 #endif /* _FFR_DEFAULT_SENDER */


### PR DESCRIPTION
This fixes the build with CFLAGS="-Werror=incompatible-pointer-types", which some newer compilers are planning to make default.

Gentoo-Bug: https://bugs.gentoo.org/919366