### PR TITLE
dkimf_db_walk: explicitly treat DKIMF_DB_MEMCACHE as unsupported db type.

### DIFF
--- a/opendkim/opendkim-db.c
+++ b/opendkim/opendkim-db.c
@@ -5806,6 +5806,32 @@ dkimf_db_strerror(DKIMF_DB db, char *err, size_t errlen)
 }
 
 /*
+**  DKIMF_CAN_DB_WALK -- check if the db supports dkimf_db_walk operation
+**
+**  Parameters:
+**  	db -- database
+**
+**  Return value:
+**  	TRUE  -- suppots
+**  	FALSE -- does not support
+*/
+
+_Bool
+dkimf_can_db_walk(DKIMF_DB db)
+{
+	switch (db->db_type)
+	{
+	  case DKIMF_DB_TYPE_REFILE:
+	  case DKIMF_DB_TYPE_SOCKET:
+	  case DKIMF_DB_TYPE_LUA:
+	  case DKIMF_DB_TYPE_MEMCACHE:
+	  case DKIMF_DB_TYPE_UNKNOWN:
+		return FALSE;
+	}
+	return TRUE;
+}
+
+/*
 **  DKIMF_DB_WALK -- walk a database
 **
 **  Parameters:

--- a/opendkim/opendkim-db.c
+++ b/opendkim/opendkim-db.c
@@ -5832,13 +5832,16 @@ dkimf_db_walk(DKIMF_DB db, _Bool first, void *key, size_t *keylen,
 	    (key == NULL && keylen != NULL))
 		return -1;
 
-	if (db->db_type == DKIMF_DB_TYPE_REFILE ||
-	    db->db_type == DKIMF_DB_TYPE_SOCKET ||
-	    db->db_type == DKIMF_DB_TYPE_LUA)
-		return -1;
-
 	switch (db->db_type)
 	{
+	  case DKIMF_DB_TYPE_REFILE:
+	  case DKIMF_DB_TYPE_SOCKET:
+	  case DKIMF_DB_TYPE_LUA:
+	  case DKIMF_DB_TYPE_MEMCACHE:
+	  {
+		/* This operation does not support these type of dbs. */
+		return -1;
+	  }
 	  case DKIMF_DB_TYPE_CSL:
 	  case DKIMF_DB_TYPE_FILE:
 	  {

--- a/opendkim/opendkim-db.c
+++ b/opendkim/opendkim-db.c
@@ -5819,6 +5819,8 @@ dkimf_db_strerror(DKIMF_DB db, char *err, size_t errlen)
 _Bool
 dkimf_db_can_walk(DKIMF_DB db)
 {
+	assert(db != NULL);
+
 	switch (db->db_type)
 	{
 	  case DKIMF_DB_TYPE_REFILE:

--- a/opendkim/opendkim-db.c
+++ b/opendkim/opendkim-db.c
@@ -5806,7 +5806,7 @@ dkimf_db_strerror(DKIMF_DB db, char *err, size_t errlen)
 }
 
 /*
-**  DKIMF_CAN_DB_WALK -- check if the db supports dkimf_db_walk operation
+**  DKIMF_DB_CAN_WALK -- check if the db supports dkimf_db_walk operation
 **
 **  Parameters:
 **  	db -- database
@@ -5817,7 +5817,7 @@ dkimf_db_strerror(DKIMF_DB db, char *err, size_t errlen)
 */
 
 _Bool
-dkimf_can_db_walk(DKIMF_DB db)
+dkimf_db_can_walk(DKIMF_DB db)
 {
 	switch (db->db_type)
 	{

--- a/opendkim/opendkim-db.h
+++ b/opendkim/opendkim-db.h
@@ -94,6 +94,7 @@ extern int dkimf_db_rewalk __P((DKIMF_DB, char *, DKIMF_DBDATA, unsigned int,
 extern void dkimf_db_set_ldap_param __P((int, char *));
 extern int dkimf_db_strerror __P((DKIMF_DB, char *, size_t));
 extern int dkimf_db_type __P((DKIMF_DB));
+extern _Bool dkimf_can_db_walk __P((DKIMF_DB));
 extern int dkimf_db_walk __P((DKIMF_DB, _Bool, void *, size_t *,
                               DKIMF_DBDATA, unsigned int));
 

--- a/opendkim/opendkim-db.h
+++ b/opendkim/opendkim-db.h
@@ -94,7 +94,7 @@ extern int dkimf_db_rewalk __P((DKIMF_DB, char *, DKIMF_DBDATA, unsigned int,
 extern void dkimf_db_set_ldap_param __P((int, char *));
 extern int dkimf_db_strerror __P((DKIMF_DB, char *, size_t));
 extern int dkimf_db_type __P((DKIMF_DB));
-extern _Bool dkimf_can_db_walk __P((DKIMF_DB));
+extern _Bool dkimf_db_can_walk __P((DKIMF_DB));
 extern int dkimf_db_walk __P((DKIMF_DB, _Bool, void *, size_t *,
                               DKIMF_DBDATA, unsigned int));
 

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -8323,7 +8323,8 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 		**  missing KeyTable entries.
 		*/
 
-		if (conf->conf_signtabledb != NULL)
+		if (conf->conf_signtabledb != NULL &&
+		    dkimf_can_db_walk(conf->conf_signtabledb))
 		{
 			_Bool first = TRUE;
 			_Bool found;

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -8324,7 +8324,7 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 		*/
 
 		if (conf->conf_signtabledb != NULL &&
-		    dkimf_can_db_walk(conf->conf_signtabledb))
+		    dkimf_db_can_walk(conf->conf_signtabledb))
 		{
 			_Bool first = TRUE;
 			_Bool found;


### PR DESCRIPTION
This saves incorrect usage of DKIMF_DB_MEMCACHE from assertion failure addressing to unknown DB type error,  although it still need that caller should handle the error properly. (see issue #218)