### PR TITLE
libvbr/vbr.c: include <stdio.h> for vsnprintf()

### DIFF
--- a/libvbr/vbr.c
+++ b/libvbr/vbr.c
@@ -18,6 +18,7 @@
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
 #include <netdb.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>


### PR DESCRIPTION
This fixes an implicit declaration error with newer compilers and on musl where stdio.h does not incidentally get included by some other header.

Bug: https://bugs.gentoo.org/936591