### PR TITLE
Fix issue #229: fix db handling on verification of SigningTable in dkimf_config_load

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -8333,20 +8333,23 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 			char selector[BUFRSZ + 1];
 			char keydata[BUFRSZ + 1];
 			char signer[BUFRSZ + 1];
+			int db_stat;
 
-			dbd[0].dbdata_flags = 0;
-			
 			memset(keyname, '\0', sizeof keyname);
+			/*
+			** As we don't care signer values here,
+			** we don't need to clear it.
+			*/
 
 			dbd[0].dbdata_buffer = keyname;
 			dbd[0].dbdata_buflen = sizeof keyname - 1;
 			dbd[0].dbdata_flags = 0;
 			dbd[1].dbdata_buffer = signer;
 			dbd[1].dbdata_buflen = sizeof signer - 1;
-			dbd[1].dbdata_flags = 0;
+			dbd[1].dbdata_flags = DKIMF_DB_DATA_OPTIONAL;
 
-			while (dkimf_db_walk(conf->conf_signtabledb, first,
-			                     NULL, NULL, dbd, 2) == 0)
+			while ((db_stat = dkimf_db_walk(conf->conf_signtabledb,
+			                                first, NULL, NULL, dbd, 2)) == 0)
 			{
 				first = FALSE;
 				found = FALSE;
@@ -8359,6 +8362,11 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 				dbd[2].dbdata_buffer = keydata;
 				dbd[2].dbdata_buflen = sizeof keydata - 1;
 				dbd[2].dbdata_flags = DKIMF_DB_DATA_BINARY;
+				/*
+				** As we don't care for values of the entry
+				** in KeyTable here, we don't need to clear
+				** buffers for them.
+				*/
 
 				if (dkimf_db_get(conf->conf_keytabledb,	
 				                 keyname, strlen(keyname),
@@ -8379,6 +8387,16 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 				dbd[0].dbdata_buffer = keyname;
 				dbd[0].dbdata_buflen = sizeof keyname - 1;
 				dbd[0].dbdata_flags = 0;
+				dbd[1].dbdata_buffer = signer;
+				dbd[1].dbdata_buflen = sizeof signer - 1;
+				dbd[1].dbdata_flags = DKIMF_DB_DATA_OPTIONAL;
+			}
+			if (db_stat == -1)
+			{
+				snprintf(err, errlen,
+				         "error on retrieving an entry from \"%s\"",
+				         conf->conf_signtable);
+				return -1;
 			}
 		}
 	}

--- a/opendkim/tests/t-sign-rs-tables-bad.conf
+++ b/opendkim/tests/t-sign-rs-tables-bad.conf
@@ -5,4 +5,4 @@ Background		No
 Canonicalization	relaxed/simple
 RequireSafeKeys		No
 KeyTable		file:t-sign-rs-tables-bad.keys
-SigningTable		file:t-sign-rs-tables.sign
+SigningTable		refile:t-sign-rs-tables.sign


### PR DESCRIPTION
This is a PR for fixing the issue #229

- check error on calling dkimf_db_walk()
- fix request parameter for "signer" field in SigningTable