### PR TITLE
issue #233: opendkim: Use "policy" for dkim result of ignored sig, instead of "fail"

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -10638,6 +10638,7 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, struct dkimf_dstring *tmpstr,
 
 		for (c = 0; c < nsigs; c++)
 		{
+			unsigned int sigflag;
 			dnssec = NULL;
 
 			memset(comment, '\0', sizeof comment);
@@ -10659,7 +10660,12 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, struct dkimf_dstring *tmpstr,
 				                           &ssl);
 			}
 
-			if ((dkim_sig_getflags(sigs[c]) & DKIM_SIGFLAG_PASSED) != 0 &&
+			sigflag = dkim_sig_getflags(sigs[c]);
+			if (sigflag & DKIM_SIGFLAG_IGNORE)
+			{
+				result = "policy";
+			}
+			else if ((sigflag & DKIM_SIGFLAG_PASSED) != 0 &&
 			    dkim_sig_getbh(sigs[c]) == DKIM_SIGBH_MATCH)
 			{
 				result = "pass";
@@ -10683,8 +10689,8 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, struct dkimf_dstring *tmpstr,
 					         " reason=\"%s\"", err);
 				}
 			}
-			else if ((dkim_sig_getflags(sigs[c]) & DKIM_SIGFLAG_PROCESSED) != 0 &&
-			         ((dkim_sig_getflags(sigs[c]) & DKIM_SIGFLAG_PASSED) == 0 ||
+			else if ((sigflag & DKIM_SIGFLAG_PROCESSED) != 0 &&
+			         ((sigflag & DKIM_SIGFLAG_PASSED) == 0 ||
 			          dkim_sig_getbh(sigs[c]) != DKIM_SIGBH_MATCH))
 			{
 				const char *err;


### PR DESCRIPTION
FIx issue #233: use "`dkim=policy`" for the result of DKIM signature which is marked as "ignore" by `dkim_sig_ignore()`, instead of "`dikim=fail`".

* opendkim/opendkim.c (dkim_ar_all_sigs)
  - as above
  - reduce dkim_sig_getflags() calls