### PR TITLE
Fix: do not use strlcpy() if buffers overlap

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -12105,8 +12105,10 @@ mlfi_eoh(SMFICTX *ctx)
 
 				if (domainok)
 				{
-					strlcpy((char *) dfc->mctx_domain, p,
-					        sizeof dfc->mctx_domain);
+					// We must not use strlcpy() here since
+					// src and dst overlap.
+					char* p2 = dfc->mctx_domain;
+					while( (*p2++ = *p++) );
 					break;
 				}
 			}


### PR DESCRIPTION
When checking if signing for a subdomain should be done, the matching domain is copied using strlcpy().
This is wrong since src and dst overlap and in this case the behavior is undefined.
