### PR TITLE
Fix: do not use strlcpy() if buffers overlap

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -12303,8 +12303,10 @@ mlfi_eoh(SMFICTX *ctx)
 
 				if (domainok)
 				{
-					strlcpy((char *) dfc->mctx_domain, p,
-					        sizeof dfc->mctx_domain);
+					// We must not use strlcpy() here since
+					// src and dst overlap.
+					char* p2 = dfc->mctx_domain;
+					while( (*p2++ = *p++) );
 					break;
 				}
 			}


### PR DESCRIPTION
This resulted in messed up d= tags on FreeBSD. The result was that mails using the SubDomains feature were signed improperly.