### PR TITLE
Support ed25519 in opendkim tools, fix orphaned opendkim-genzone bug

### DIFF
--- a/libopendkim/base32.c
+++ b/libopendkim/base32.c
@@ -158,22 +158,21 @@ dkim_base32_encode(char *buf, size_t *buflen, const void *data, size_t size)
 
 #ifdef TEST
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 
 int
 main(int argc, char **argv)
 {
 	int x;
 	size_t buflen;
-	SHA_CTX sha;
 	char buf[128];
 	unsigned char shaout[SHA_DIGEST_LENGTH];
 
 	memset(buf, '\0', sizeof buf);
 	buflen = sizeof buf;
 
-	SHA1_Init(&sha);
-	SHA1_Update(&sha, argv[1], strlen(argv[1]));
-	SHA1_Final(shaout, &sha);
+	(void) EVP_Digest(argv[1], strlen(argv[1]), shaout, NULL, EVP_sha1(),
+	                  NULL);
 
 	x = dkim_base32_encode(buf, &buflen, shaout, SHA_DIGEST_LENGTH);
 

--- a/libopendkim/dkim-atps.c
+++ b/libopendkim/dkim-atps.c
@@ -37,6 +37,7 @@
 #else /* USE_GNUTLS */
 /* openssl includes */
 # include <openssl/sha.h>
+# include <openssl/evp.h>
 #endif /* USE_GNUTLS */
 
 /* prototypes */
@@ -113,11 +114,6 @@ dkim_atps_check(DKIM *dkim, DKIM_SIGINFO *sig, struct timeval *timeout,
 	u_char *eom;
 #ifdef USE_GNUTLS
 	gnutls_hash_hd_t ctx;
-#else /* USE_GNUTLS */
-        SHA_CTX ctx;
-# ifdef HAVE_SHA256
-	SHA256_CTX ctx2;
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 	struct timeval to;
 	HEADER hdr;
@@ -198,16 +194,14 @@ dkim_atps_check(DKIM *dkim, DKIM_SIGINFO *sig, struct timeval *timeout,
 		switch (hash)
 		{
 		  case DKIM_HASHTYPE_SHA1:
-			SHA1_Init(&ctx);
-			SHA1_Update(&ctx, sdomain, strlen(sdomain));
-			SHA1_Final(digest, &ctx);
+			(void) EVP_Digest(sdomain, strlen(sdomain), digest,
+			                  NULL, EVP_sha1(), NULL);
 			break;
 
 #  ifdef HAVE_SHA256
 		  case DKIM_HASHTYPE_SHA256:
-			SHA256_Init(&ctx2);
-			SHA256_Update(&ctx2, sdomain, strlen(sdomain));
-			SHA256_Final(digest, &ctx2);
+			(void) EVP_Digest(sdomain, strlen(sdomain), digest,
+			                  NULL, EVP_sha256(), NULL);
 			break;
 #  endif /* HAVE_SHA256 */
 

--- a/libopendkim/dkim-test.c
+++ b/libopendkim/dkim-test.c
@@ -27,6 +27,7 @@
 # include <openssl/bio.h>
 # include <openssl/rsa.h>
 # include <openssl/evp.h>
+# include <openssl/x509.h>
 #endif /* USE_GNUTLS */
 
 /* libopendkim includes */
@@ -431,21 +432,7 @@ dkim_test_key(DKIM_LIB *lib, char *selector, char *domain,
 			return -1;
 		}
 
-		crypto->crypto_key = EVP_PKEY_get1_RSA(crypto->crypto_pkey);
-		if (crypto->crypto_key == NULL)
-		{
-			BIO_free(keybuf);
-			(void) dkim_free(dkim);
-			if (err != NULL)
-			{
-				strlcpy(err, "EVP_PKEY_get1_RSA() failed",
-				        errlen);
-			}
-			return -1;
-		}
-	
-		crypto->crypto_keysize = RSA_size(crypto->crypto_key);
-		crypto->crypto_pad = RSA_PKCS1_PADDING;
+		crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
 
 		outkey = BIO_new(BIO_s_mem());
 		if (outkey == NULL)
@@ -457,7 +444,7 @@ dkim_test_key(DKIM_LIB *lib, char *selector, char *domain,
 			return -1;
 		}
 
-		status = i2d_RSA_PUBKEY_bio(outkey, crypto->crypto_key);
+		status = i2d_PUBKEY_bio(outkey, crypto->crypto_pkey);
 		if (status == 0)
 		{
 			BIO_free(keybuf);

--- a/libopendkim/dkim-types.h
+++ b/libopendkim/dkim-types.h
@@ -37,6 +37,7 @@
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/sha.h>
+# include <openssl/evp.h>
 #endif /* USE_GNUTLS */
 
 #ifdef QUERY_CACHE
@@ -151,36 +152,22 @@ struct dkim_siginfo
 	struct dkim_dstring *	sig_sslerrbuf;
 };
 
-#ifdef USE_GNUTLS
 /* struct dkim_sha -- stuff needed to do a sha hash */
 struct dkim_sha
 {
+#ifdef USE_GNUTLS
 	int			sha_tmpfd;
 	u_int			sha_outlen;
 	gnutls_hash_hd_t	sha_hd;
 	u_char *		sha_out;
-};
 #else /* USE_GNUTLS */
-/* struct dkim_sha1 -- stuff needed to do a sha1 hash */
-struct dkim_sha1
-{
-	int			sha1_tmpfd;
-	BIO *			sha1_tmpbio;
-	SHA_CTX			sha1_ctx;
-	u_char			sha1_out[SHA_DIGEST_LENGTH];
-};
-
-# ifdef HAVE_SHA256
-/* struct dkim_sha256 -- stuff needed to do a sha256 hash */
-struct dkim_sha256
-{
-	int			sha256_tmpfd;
-	BIO *			sha256_tmpbio;
-	SHA256_CTX		sha256_ctx;
-	u_char			sha256_out[SHA256_DIGEST_LENGTH];
-};
-# endif /* HAVE_SHA256 */
+	int			sha_tmpfd;
+	BIO *			sha_tmpbio;
+	EVP_MD_CTX *		sha_ctx;
+	u_char			sha_out[EVP_MAX_MD_SIZE];
+	u_int			sha_outlen;
 #endif /* USE_GNUTLS */
+};
 
 /* struct dkim_canon -- a canonicalization status handle */
 struct dkim_canon
@@ -220,12 +207,10 @@ struct dkim_crypto
 	gnutls_datum_t 		crypto_rsaout;
 	gnutls_datum_t 		crypto_keydata;
 #else /* USE_GNUTLS */
-	u_char			crypto_pad;
 	int			crypto_keysize;
 	size_t			crypto_inlen;
 	size_t			crypto_outlen;
 	EVP_PKEY *		crypto_pkey;
-	void *			crypto_key;
 	BIO *			crypto_keydata;
 	u_char *		crypto_in;
 	u_char *		crypto_out;

--- a/opendkim/opendkim-atpszone.c
+++ b/opendkim/opendkim-atpszone.c
@@ -144,11 +144,6 @@ main(int argc, char **argv)
 	DKIMF_DB db;
 #ifdef USE_GNUTLS
 	gnutls_hash_hd_t sha;
-#else /* USE_GNUTLS */
-	SHA_CTX sha;
-# ifdef HAVE_SHA256
-	SHA256_CTX sha256;
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 	char domain[DKIM_MAXHOSTNAMELEN + 1];
 	char hostname[DKIM_MAXHOSTNAMELEN + 1];
@@ -443,20 +438,19 @@ main(int argc, char **argv)
 # ifdef HAVE_SHA256
 			if (hash == NULL || strcasecmp(hash, "sha256") == 0)
 			{
-				SHA256_Init(&sha256);
-				SHA256_Update(&sha256, domain, strlen(domain));
-				SHA256_Final(shaout, &sha256);
+				(void) EVP_Digest(domain, strlen(domain),
+				                  shaout, NULL, EVP_sha256(),
+				                  NULL);
 			}
 			else
 			{
-				SHA1_Init(&sha);
-				SHA1_Update(&sha, domain, strlen(domain));
-				SHA1_Final(shaout, &sha);
+				(void) EVP_Digest(domain, strlen(domain),
+				                  shaout, NULL, EVP_sha1(),
+				                  NULL);
 			}
 # else /* HAVE_SHA256 */
-			SHA1_Init(&sha);
-			SHA1_Update(&sha, domain, strlen(domain));
-			SHA1_Final(shaout, &sha);
+			(void) EVP_Digest(domain, strlen(domain), shaout, NULL,
+			                  EVP_sha1(), NULL);
 # endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 

--- a/opendkim/opendkim-genkey.8.in
+++ b/opendkim/opendkim-genkey.8.in
@@ -50,6 +50,7 @@ Instructs the tool to change to the named
 prior to creating files.  By default the current directory is used.
 
 .TP
+.I \-e
 .I \-\-ed25519
 generate a ed25519 key.
 

--- a/opendkim/opendkim-genkey.8.in
+++ b/opendkim/opendkim-genkey.8.in
@@ -51,8 +51,8 @@ prior to creating files.  By default the current directory is used.
 
 .TP
 .I \-e
-.I \-\-ed25519
-generate a ed25519 key.
+(\-\-ed25519)
+Generate an ed25519 key.
 
 .TP
 .I \-h algorithms

--- a/opendkim/opendkim-genkey.in
+++ b/opendkim/opendkim-genkey.in
@@ -91,7 +91,7 @@ my $opt_retval = &Getopt::Long::GetOptions('a|append-domain!' => \$append,
                                            'b|bits=i' => \$bits,
                                            'D|directory=s' => \$outdir,
                                            'd|domain=s' => \$domain,
-                                           'ed25519' => \$ed25519,
+                                           'e|ed25519' => \$ed25519,
                                            'h|hash-algorithms=s' => \$hashalgs,
                                            'help!' => \$helponly,
                                            'n|note=s' => \$note,
@@ -130,10 +130,10 @@ umask(077);
 
 if ($ed25519)
 {
-	$status = system("openssl version 2>/dev/null | grep --silent --ignore-case '^openssl 1.1.1'");
+	$status = system("openssl genpkey -algorithm ed25519 > /dev/null 2>&1");
 	if ($status != 0)
 	{
-		print STDERR "$progname: OpenSSL 1.1.1 is required for ED25519 support\n";
+		print STDERR "$progname: At least OpenSSL 1.1.1 is required for ED25519 support\n";
 		exit(1);
 	}
 }

--- a/opendkim/opendkim-genzone.c
+++ b/opendkim/opendkim-genzone.c
@@ -26,7 +26,6 @@
 # include <gnutls/abstract.h>
 # include <gnutls/x509.h>
 #else /* USE_GNUTLS */
-# include <openssl/rsa.h>
 # include <openssl/pem.h>
 # include <openssl/evp.h>
 # include <openssl/bio.h>
@@ -264,7 +263,6 @@ main(int argc, char **argv)
 	BIO *private;
 	BIO *outbio = NULL;
 	EVP_PKEY *pkey;
-	RSA *rsa;
 #endif /* USE_GNUTLS */
 	DKIMF_DB db;
 	char keyname[BUFRSZ + 1];
@@ -837,12 +835,9 @@ main(int argc, char **argv)
 			}
 		}
 
-		rsa = EVP_PKEY_get1_RSA(pkey);
-		if (rsa == NULL)
+		if (EVP_PKEY_base_id(pkey) != EVP_PKEY_RSA)
 		{
-			fprintf(stderr,
-			        "%s: EVP_PKEY_get1_RSA() failed\n",
-			        progname);
+			fprintf(stderr, "%s: not an RSA key\n", progname);
 			(void) dkimf_db_close(db);
 			(void) BIO_free(private);
 			(void) EVP_PKEY_free(pkey);
@@ -851,11 +846,11 @@ main(int argc, char **argv)
 		}
 
 		/* convert private to public */
-		status = PEM_write_bio_RSA_PUBKEY(outbio, rsa);
+		status = PEM_write_bio_PUBKEY(outbio, pkey);
 		if (status == 0)
 		{
 			fprintf(stderr,
-			        "%s: PEM_write_bio_RSA_PUBKEY() failed\n",
+			        "%s: PEM_write_bio_PUBKEY() failed\n",
 			        progname);
 			(void) dkimf_db_close(db);
 			(void) BIO_free(private);

--- a/opendkim/opendkim-genzone.c
+++ b/opendkim/opendkim-genzone.c
@@ -51,7 +51,7 @@
 
 /* definitions */
 #define	BUFRSZ		1024
-#define	CMDLINEOPTS	"C:d:DE:Fo:N:r:R:sSt:T:uvx:"
+#define	CMDLINEOPTS	"C:d:DME:Fo:N:r:R:sSt:T:uvx:"
 #define	DEFCONFFILE	CONFIG_BASE "/opendkim.conf"
 #define	DEFEXPIRE	604800
 #define	DEFREFRESH	10800
@@ -194,6 +194,7 @@ usage(void)
 	                "\t-D          \tinclude '._domainkey' suffix\n"
 	                "\t-E secs     \tuse specified expiration time in SOA\n"
 	                "\t-F          \tinclude '._domainkey' suffix and domainname\n"
+			"\t-M          \trestricts the keys for use in e-mail signing only\n"
 	                "\t-o file     \toutput file\n"
 	                "\t-N ns[,...] \tlist NS records\n"
 	                "\t-r secs     \tuse specified refresh time in SOA\n"
@@ -229,6 +230,7 @@ main(int argc, char **argv)
 	_Bool fqdnsuffix = FALSE;
 	_Bool subdomains = FALSE;
 	_Bool writesoa = FALSE;
+	_Bool mailrestrict = FALSE;
 	int c;
 	int status;
 	int verbose = 0;
@@ -273,6 +275,8 @@ main(int argc, char **argv)
 	char keydata[LARGEBUFRSZ];
 	char derdata[LARGEBUFRSZ];
 	struct dkimf_db_data dbd[3];
+	_Bool key_is_ed25519 = FALSE;
+	int ed25519_keyskip;
 
 	progname = (p = strrchr(argv[0], '/')) == NULL ? argv[0] : p + 1;
 
@@ -305,6 +309,10 @@ main(int argc, char **argv)
 		  case 'F':
 			suffix = TRUE;
 			fqdnsuffix = TRUE;
+			break;
+
+		  case 'M':
+			mailrestrict = TRUE;
 			break;
 
 		  case 'N':
@@ -729,6 +737,21 @@ main(int argc, char **argv)
 			return -1;
 		}
 
+		switch (gnutls_x509_privkey_get_pk_algorithm(xprivkey))
+		{
+		  case GNUTLS_PK_RSA:
+		  	key_is_ed25519 = FALSE;
+			break;
+		  case GNUTLS_PK_EDDSA_ED25519:
+		  	key_is_ed25519 = TRUE;
+			break;
+		  default:
+			fprintf(stderr, "%s: key for '%s' invalid algorithm\n",
+			        progname, keyname);
+			(void) gnutls_x509_privkey_deinit(xprivkey);
+			return -1;
+		}
+
 		status = gnutls_privkey_init(&privkey);
 		if (status != GNUTLS_E_SUCCESS)
 		{
@@ -835,9 +858,17 @@ main(int argc, char **argv)
 			}
 		}
 
-		if (EVP_PKEY_base_id(pkey) != EVP_PKEY_RSA)
+		switch (EVP_PKEY_base_id(pkey))
 		{
-			fprintf(stderr, "%s: not an RSA key\n", progname);
+		  case EVP_PKEY_RSA:
+		  	key_is_ed25519 = FALSE;
+			break;
+		  case EVP_PKEY_ED25519:
+		  	key_is_ed25519 = TRUE;
+			break;
+		  default:
+			fprintf(stderr, "%s: key for '%s' invalid algorithm\n",
+			        progname, keyname);
 			(void) dkimf_db_close(db);
 			(void) BIO_free(private);
 			(void) EVP_PKEY_free(pkey);
@@ -866,33 +897,39 @@ main(int argc, char **argv)
 			fprintf(out, "zone %s\n", domain);
 
 			snprintf(tmpbuf, sizeof tmpbuf,
-			         "update add %s%s%s%s%s %d TXT \"",
+			         "update add %s%s%s%s%s %d TXT \"v=DKIM1\\;k=%s\\;%sp=",
 			         selector, suffix ? DKIMZONE : "",
 			         fqdnsuffix ? "." : "",
 			         fqdnsuffix ? domain : "",
 			         fqdnsuffix ? "." : "",
-			         ttl == -1 ? defttl : ttl);
+ 			         ttl == -1 ? defttl : ttl,
+				 key_is_ed25519 ? "ed25519" : "rsa",
+ 				 mailrestrict ? "s=email\\;" : "");
 		}
 		else
 		{
 			if (ttl == -1)
 			{
 				snprintf(tmpbuf, sizeof tmpbuf,
-				         "%s%s%s%s%s\tIN\tTXT\t( \"v=DKIM1; k=rsa; p=",
+				         "%s%s%s%s%s\tIN\tTXT\t( \"v=DKIM1\\;k=%s\\;%sp=",
 				         selector, suffix ? DKIMZONE : "",
 				         fqdnsuffix ? "." : "",
 				         fqdnsuffix ? domain : "",
-				         fqdnsuffix ? "." : "");
+ 				         fqdnsuffix ? "." : "",
+					 key_is_ed25519 ? "ed25519" : "rsa",
+ 					 mailrestrict ? "s=email\\;" : "");
 			}
 			else
 			{
 				snprintf(tmpbuf, sizeof tmpbuf,
-				         "%s%s%s%s%s\t%d\tIN\tTXT\t( \"v=DKIM1; k=rsa; p=",
+				         "%s%s%s%s%s\t%d\tIN\tTXT\t( \"v=DKIM1\\;k=%s\\;%sp=",
 				         selector, suffix ? DKIMZONE : "",
 				         fqdnsuffix ? "." : "",
 				         fqdnsuffix ? domain : "",
 				         fqdnsuffix ? "." : "",
-				         ttl);
+ 				         ttl,
+					 key_is_ed25519 ? "ed25519" : "rsa",
+ 				         mailrestrict ? "s=email\\;" : "");
 			}
 		}
 
@@ -904,6 +941,11 @@ main(int argc, char **argv)
 			olen = strflen(tmpbuf);
 
 		seenlf = FALSE;
+
+		/* Per RFC8463 the ed25519 key in the DNS TXT record doesn't have the ASN */
+		/* prefix that RSA keys have. The base64-encoded 12-byte ASN prefix is the */
+		/* first 16 characters in the PEM "PRIVATE KEY" key value. Skip over it. */
+		ed25519_keyskip = 16;
 
 #ifdef USE_GNUTLS
 		if (gnutls_pubkey_init(&pubkey) != GNUTLS_E_SUCCESS)
@@ -956,6 +998,10 @@ main(int argc, char **argv)
 			else if (!seenlf)
 			{
 				continue;
+			}
+			else if (key_is_ed25519 && ed25519_keyskip > 0)
+			{
+				ed25519_keyskip--;
 			}
 			else if (isascii(*p) && !isspace(*p))
 			{

--- a/opendkim/opendkim-testmsg.8.in
+++ b/opendkim/opendkim-testmsg.8.in
@@ -23,6 +23,15 @@ verified.  If some but not all are present, an error is returned.
 
 .SH OPTIONS
 .TP
+.I -1
+In signing mode, generate an RSA-SHA1 signature. The key must be an RSA key.
+.TP
+.I -2
+In signing mode, generate an RSA-SHA256 signature. The key must be an RSA key. (default)
+.TP
+.I -e
+In signing mode, generate an ED25519-SHA256 signature. The key must be an ED25519 key.
+.TP
 .I -C
 If specified, the signature header field generated in signing mode will
 be line-terminated with carriage-return line-feed, instead of just line-feed.

--- a/opendkim/opendkim-testmsg.c
+++ b/opendkim/opendkim-testmsg.c
@@ -32,7 +32,7 @@
 
 #define	BUFRSZ		1024
 #define	DEFTMPDIR	"/tmp"
-#define	CMDLINEOPTS	"Cd:Kk:s:t:"
+#define	CMDLINEOPTS	"12eCd:Kk:s:t:"
 #define STRORNULL(x)	((x) == NULL ? "(null)" : (x))
 #define	TMPTEMPLATE	"dkimXXXXXX"
 
@@ -57,6 +57,9 @@ usage(void)
 {
 	fprintf(stderr,
 	        "%s: usage: %s [options]\nValid options:\n"
+	        "\t-1         \tsign with RSA-SHA1\n"
+	        "\t-2         \tsign with RSA-SHA256 (default)\n"
+	        "\t-e         \tsign with Ed25519-SHA256\n"
 	        "\t-C         \tpreserve CRLFs\n"
 	        "\t-d domain  \tset signing domain\n"
 	        "\t-K         \tkeep temporary files\n"
@@ -120,7 +123,7 @@ main(int argc, char **argv)
 	ssize_t rlen;
 	ssize_t wlen;
 	ssize_t l = (ssize_t) -1;
-	dkim_alg_t sa = DKIM_SIGN_RSASHA1;
+	dkim_alg_t sa = DKIM_SIGN_RSASHA256;
 	dkim_canon_t bc = DKIM_CANON_SIMPLE;
 	dkim_canon_t hc = DKIM_CANON_RELAXED;
 	DKIM_LIB *lib;
@@ -140,6 +143,18 @@ main(int argc, char **argv)
 	{
 		switch (c)
 		{
+		  case '1':
+			sa = DKIM_SIGN_RSASHA1;
+			break;
+
+		  case '2':
+			sa = DKIM_SIGN_RSASHA256;
+			break;
+
+		  case 'e':
+			sa = DKIM_SIGN_ED25519SHA256;
+			break;
+
 		  case 'C':
 			keepcrlf = TRUE;
 			break;


### PR DESCRIPTION
Depends-On: https://github.com/trusteddomainproject/OpenDKIM/pull/162
This should be merged after PR #162, "Upgrade to OpenSSL 3".

1. opendkim-genkey: require openssl >= 1.1.1 for ed25519 instead of == 1.1.1.
2. opendkim-testkey: Add options 1, 2, and e to create an rsa-sha1, rsa-sha256, or ed25519 signature, respectively. Rsa-sha256 is the default. Previously the tool could only create rsa-sha1 signatures.
3. opendkim-genzone: Debian's opendkim includes nsupdate_output.patch which was added long ago for Debian bug
     [https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=849540](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=849540).
   The patch originally came from a bug reported against 2.10.3 in the opendkim sourceforge bug database:
     [https://sourceforge.net/p/opendkim/feature-requests/200](https://sourceforge.net/p/opendkim/feature-requests/200)
   Somehow that sourceforge bug report and fix didn't make it to opendkim github. That patch fixes nsupdate output formatting and adds a key usage option. This patch does that and also adds support for ed25519 keys.
