### PR TITLE
Issue #257: remove SingleAuthResult config option from opendkim.conf.sample.

### DIFF
--- a/opendkim/opendkim.conf.sample
+++ b/opendkim/opendkim.conf.sample
@@ -632,16 +632,6 @@ Selector		my-selector-name
 
 # SigningTable		filename
 
-##  SingleAuthResult { yes | no}
-##  	default "no"
-##
-##  When DomainKeys verification is enabled, multiple Authentication-Results
-##  will be added, one for DK and one for DKIM.  With this enabled, only
-##  a DKIM result will be reported unless DKIM failed but DK passed, in which
-##  case only a DK result will be reported.
-
-# SingleAuthResult	no
-
 ##  SMTPURI uri
 ##
 ##  Specifies a URI (e.g., "smtp://localhost") to which mail should be sent


### PR DESCRIPTION
The config option SingleAuthResult was removed from code base and opendkim.conf(5) man page before v2.5.0,  but existed in opendkim.conf.sample file (issue #257).   This commit remove it.
