### PR TITLE
configure.ac: Relax configure version to >= 2.69

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@
 #
 # Setup
 #
-AC_PREREQ([2.71])
+AC_PREREQ([2.69])
 
 #
 # Package version


### PR DESCRIPTION
Other part of this configure.ac can be processed by autoconf ver 2.69 without error. This may help some old environments.