### PR TITLE
configure.ac: Improve lua detection with/without pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1653,8 +1653,8 @@ then
 	AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 #include <lua.h>
 
-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501
-# error Lua version 5.1 or later is required
+#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM >= 505
+# error Lua version 5.1 - 5.4 is required
 #endif
 
 int
@@ -1664,7 +1664,7 @@ main()
 }
 				])],
 				AC_MSG_RESULT([ok]), 
-				AC_MSG_ERROR([Lua version 5.1 or later required]))
+				AC_MSG_ERROR([Lua version 5.1 - 5.4 is required]))
 	CPPFLAGS="$saved_CPPFLAGS"
 	AC_DEFINE([USE_LUA], 1, [support for Lua scripting])
 	AC_SUBST([LUA_MANNOTICE], "")

--- a/configure.ac
+++ b/configure.ac
@@ -1504,8 +1504,8 @@ AC_SUBST([LIBTRE_LIBS])
 # liblua
 #
 AC_ARG_WITH([lua],
-            AS_HELP_STRING([--with-lua],
-                           [location of Lua includes and library]),
+            AS_HELP_STRING([--with-lua@<:@=PKG|PATH|auto|yes|no@:>@],
+                           [Lua pkg-config name or path, or location of Lua includes and library]),
             [luapath="$withval"], [luapath="no"])
 
 LIBLUA_INCDIRS=""
@@ -1513,22 +1513,31 @@ LIBLUA_LIBDIRS=""
 LIBLUA_LIBS=""
 lua_found="no"
 
-if test \(  x"$luapath" = x"auto" -o x"$luapath" = x"yes" \) -a x"$PKG_CONFIG" != x""
+if test x"$PKG_CONFIG" != x""
 then
-  PKG_CHECK_MODULES([LIBLUA], [lua5.1], [
-      LIBLUA_INCDIRS="$LIBLUA_CFLAGS"
-      lua_found="yes"
-    ],
-    [
-      AC_MSG_WARN([pkg-config for lua5.1 not found, trying lua...])
-      PKG_CHECK_MODULES([LIBLUA], [lua], [
-          LIBLUA_INCDIRS="$LIBLUA_CFLAGS"
-          lua_found="yes"
-        ],
-	[AC_MSG_WARN([pkg-config for lua not found, trying manual search...])]
-      )
-    ]
-  )
+	if test x"$luapath" = x"auto" -o x"$luapath" = x"yes"
+	then
+		for luapkg in lua lua5.4 lua-5.4 lua5.3 lua-5.3 lulua5.2 lua-5.2 lua5.1 lua-5.1
+		do
+			PKG_CHECK_MODULES([LIBLUA], [$luapkg], [
+				LIBLUA_INCDIRS="$LIBLUA_CFLAGS"
+				lua_found="yes"
+				break
+				],
+				[AC_MSG_WARN([pkg-config for $luapkg not found, trying next...])])
+		done
+		if test x"${lua_found}" = x"no"
+		then
+			AC_MSG_WARN([pkg-config for lua not found, trying manual search...])
+		fi
+	elif test x"$luapath" != x"no"
+	then
+		PKG_CHECK_MODULES([LIBLUA], [$luapath], [
+		LIBLUA_INCDIRS="$LIBLUA_CFLAGS"
+		lua_found="yes"
+		],
+		[AC_MSG_WARN([pkg-config for $luapath not found])])
+	fi
 fi
 
 if test \( x"$luapath" = x"yes" -o x"$luapath" = x"auto" \) -a x"$lua_found" = x"no"
@@ -1590,7 +1599,7 @@ then
 	fi
 fi
 
-if test x"$luapath" != x"yes" -a x"$luapath" != x"auto" -a x"$luapath" != x"no"
+if test x"$luapath" != x"yes" -a x"$luapath" != x"auto" -a x"$luapath" != x"no" -a x"$lua_found" = x"no"
 then
 	AC_MSG_CHECKING([for Lua])
 	if test -f $luapath/include/lua51/lua.h

--- a/configure.ac
+++ b/configure.ac
@@ -1540,45 +1540,18 @@ then
 	fi
 fi
 
-if test \( x"$luapath" = x"yes" -o x"$luapath" = x"auto" \) -a x"$lua_found" = x"no"
+if test x"$lua_found" = x"no" -a x"$luapath" != x"no"
 then
 	AC_MSG_CHECKING([for Lua])
-	luadirs="/usr /usr/local"
+	if test \( x"$luapath" = x"yes" -o x"$luapath" = x"auto" \)
+	then
+		luadirs="/usr /usr/local"
+        else
+		luadirs="$luapath"
+	fi
 	for d in $luadirs
 	do
-		if test -f $d/include/lua51/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include/lua51"
-			LIBLUA_LIBDIRS="-L$d/lib/lua51"
-			LIBLUA_LIBS="-llua -lm"
-			lua_found="yes"
-			break
-		elif test -f $d/include/lua52/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include/lua52"
-			LIBLUA_LIBDIRS="-L$d/lib/lua52"
-			LIBLUA_LIBS="-llua -lm"
-			lua_found="yes"
-			break
-		elif test -f $d/include/lua5.1/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include/lua5.1"
-			LIBLUA_LIBDIRS="-L$d/lib"
-			LIBLUA_LIBS="-llua5.1 -lm"
-			lua_found="yes"
-			break
-		elif test -f $d/include/lua5.2/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include/lua5.2"
-			LIBLUA_LIBDIRS="-L$d/lib"
-			LIBLUA_LIBS="-llua5.2 -lm"
-			lua_found="yes"
-			break
-		elif test -f $d/include/lua.h
+		if test -f $luapath/include/lua.h
 		then
 			AC_MSG_RESULT($d)
 			LIBLUA_INCDIRS="-I$d/include"
@@ -1588,57 +1561,84 @@ then
 			break
 		fi
 	done
-	if test x"$LIBLUA_LIBS" = x""
+	if test x"$lua_found" = x"no"
 	then
-		LIBLUA_INCDIRS=""
-		LIBLUA_LIBDIRS=""
-		LIBLUA_LIBS=""
-		AC_MSG_ERROR(not found)
-	else
-		lua_found="yes"
-	fi
-fi
-
-if test x"$luapath" != x"yes" -a x"$luapath" != x"auto" -a x"$luapath" != x"no" -a x"$lua_found" = x"no"
-then
-	AC_MSG_CHECKING([for Lua])
-	if test -f $luapath/include/lua51/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include/lua51"
-		LIBLUA_LIBDIRS="-L$luapath/lib/lua51"
-		LIBLUA_LIBS="-llua -lm"
-		lua_found="yes"
-	elif test -f $luapath/include/lua52/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include/lua52"
-		LIBLUA_LIBDIRS="-L$luapath/lib/lua52"
-		LIBLUA_LIBS="-llua -lm"
-		lua_found="yes"
-	elif test -f $luapath/include/lua5.1/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include/lua5.1"
-		LIBLUA_LIBDIRS="-L$luapath/lib"
-		LIBLUA_LIBS="-llua5.1 -lm"
-		lua_found="yes"
-	elif test -f $luapath/include/lua5.2/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include/lua5.2"
-		LIBLUA_LIBDIRS="-L$luapath/lib"
-		LIBLUA_LIBS="-llua5.2 -lm"
-		lua_found="yes"
-	elif test -f $luapath/include/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include"
-		LIBLUA_LIBDIRS="-L$luapath/lib"
-		LIBLUA_LIBS="-llua -lm"
-		lua_found="yes"
-	else
-		AC_MSG_ERROR(not found at $luapath)
+		for verminor in 4 3 2 1
+		do
+			for d in $luadirs
+			do
+				if test -f $d/include/lua5${verminor}/lua.h
+				then
+					LIBLUA_INCDIRS="-I$d/include/lua5${verminor}"
+				elif test -f $d/include/lua5.${verminor}/lua.h
+				then
+					LIBLUA_INCDIRS="-I$d/include/lua5.${verminor}"
+				else
+					continue
+				fi
+				if (found_lualib=$(find "$d/lib/lua5${verminor}" -depth 1 -name "liblua.*" 2> /dev/null); test x"${fond_lualib}" != x"")
+				then
+					LIBLUA_LIBDIRS="-L$d/lib/lua5${verminor}"
+					LIBLUA_LIBS="-llua -lm"
+					lua_found="yes"
+					break
+				elif (found_lualib=$(find "$d/lib/lua5.${verminor}" -depth 1 -name "liblua.*" 2> /dev/null); test x"${fond_lualib}" != x"")
+				then
+					LIBLUA_LIBDIRS="-L$d/lib/lua5.${verminor}"
+					LIBLUA_LIBS="-llua -lm"
+					lua_found="yes"
+					break
+				elif (found_lualib=$(find "$d/lib/lua-5${verminor}" -depth 1 -name "liblua.*" 2> /dev/null); test x"${fond_lualib}" != x"")
+				then
+					LIBLUA_LIBDIRS="-L$d/lib/lua-5${verminor}"
+					LIBLUA_LIBS="-llua -lm"
+					lua_found="yes"
+					break
+				elif (found_lualib=$(find "$d/lib/lua-5.${verminor}" -depth 1 -name "liblua.*" 2> /dev/null); test x"${fond_lualib}" != x"")
+				then
+					LIBLUA_LIBDIRS="-L$d/lib/lua-5.${verminor}"
+					LIBLUA_LIBS="-llua -lm"
+					lua_found="yes"
+					break
+				elif (found_lualib=$(find "$d/lib/" -name "liblua5${verminor}.*"); test x"${found_lualib}" != x"")
+				then
+					LIBLUA_LIBDIRS="-L$d/lib"
+					LIBLUA_LIBS="-llua5${verminor} -lm"
+					lua_found="yes"
+					break
+				elif (found_lualib=$(find "$d/lib/" -name "liblua5.${verminor}.*"); test x"${found_lualib}" != x"")
+				then
+					LIBLUA_LIBDIRS="-L$d/lib"
+					LIBLUA_LIBS="-llua5.${verminor} -lm"
+					lua_found="yes"
+					break
+				elif (found_lualib=$(find "$d/lib/" -name "liblua-5${verminor}.*"); test "${found_lualib}" != "")
+				then
+					LIBLUA_LIBDIRS="-L$d/lib"
+					LIBLUA_LIBS="-llua-5${verminor} -lm"
+					lua_found="yes"
+					break
+				elif (found_lualib=$(find "$d/lib/" -name "liblua-5.${verminor}.*"); test x"${found_lualib}" != x"")
+				then
+					LIBLUA_LIBDIRS="-L$d/lib"
+					LIBLUA_LIBS="-llua-5.${verminor} -lm"
+					lua_found="yes"
+					break
+				fi
+			done
+			if test x"$lua_found" = x"yes"
+			then
+				AC_MSG_RESULT($d)
+				break
+			fi
+		done
+		if test x"$lua_found" = x"no"
+		then
+			LIBLUA_INCDIRS=""
+			LIBLUA_LIBDIRS=""
+			LIBLUA_LIBS=""
+			AC_MSG_ERROR(not found)
+		fi
 	fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1508,12 +1508,18 @@ AC_ARG_WITH([lua],
                            [Lua pkg-config name or path, or location of Lua includes and library]),
             [luapath="$withval"], [luapath="no"])
 
-LIBLUA_INCDIRS=""
-LIBLUA_LIBDIRS=""
-LIBLUA_LIBS=""
-lua_found="no"
+if test x"$luapath" = x"yes" -a \( x"$LIBLUA_INCDIRS" != x"" -o x"$LIBLUA_DIRS" != x"" -o x"$LIBLUA_LIBS" != x"" \)
+then
+	AC_MSG_NOTICE([for lua, using LIBLUA_INCDIRS, LIBLUA_DIRS, LIBLUA_LIBS values])
+	lua_found="yes"
+else
+	LIBLUA_INCDIRS=""
+	LIBLUA_LIBDIRS=""
+	LIBLUA_LIBS=""
+	lua_found="no"
+fi
 
-if test x"$PKG_CONFIG" != x""
+if test x"$lua_found" = x"no" -a x"$PKG_CONFIG" != x""
 then
 	if test x"$luapath" = x"auto" -o x"$luapath" = x"yes"
 	then


### PR DESCRIPTION
This is improvement of lua include file and library,  both in with and without pkg-config.  This will resolve issue #111, but conflict with PR #112.

With pkg-config:
- use _luapath_, optional argment for `--with-lua=`_luapath_, for package name or path to .pc file also.
- search for standard package name `lua` package name with version suffix, like 'lua54', 'lua5.4', 'lua-54', 'lua-5.4'. for version 5.4, 5.3, 5.2, and 5.1 (in this order).

Without pkg-config:
- search include file and library separately
- in autodetection, search renamed library with version number
- Allow to pass `LIBLUA_INCDIRS`, `LIBLUA_LIBDIRS`, and `LIBLUA_LIBS` via command line or environment variable, with `--with-lua` option.

Note:
- For using lua 5.4,  PR #201 is required.
- Even PR #201 is applied, Lua 5.5 cannot work by C API change.