### PR TITLE
configure.ac: Improve Lua detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1503,145 +1503,59 @@ AC_SUBST([LIBTRE_LIBS])
 #
 # liblua
 #
-AC_ARG_WITH([lua],
-            AS_HELP_STRING([--with-lua],
-                           [location of Lua includes and library]),
-            [luapath="$withval"], [luapath="no"])
+# Detection strategy: try pkg-config first (versioned names in preference
+# order), then fall back to AC_SEARCH_LIBS for systems without pkg-config.
+# The user can pass LUA_CFLAGS and LUA_LIBS on the command line to override.
+#
+# Note: we evaluated AX_PROG_LUA from the GNU Autoconf Archive but it
+# requires a Lua interpreter to be present at configure time in order to
+# determine the version. OpenDKIM embeds Lua as a library; build systems
+# may have only the development headers and library installed (e.g.
+# liblua5.4-dev) with no interpreter. The pkg-config + AC_SEARCH_LIBS
+# approach below covers that case without the interpreter dependency.
+#
+AC_ARG_ENABLE([lua],
+              AS_HELP_STRING([--enable-lua],
+                             [enable Lua scripting support]),
+              [enable_lua="$enableval"], [enable_lua="no"])
 
-LIBLUA_INCDIRS=""
-LIBLUA_LIBDIRS=""
-LIBLUA_LIBS=""
+LUA_CFLAGS=""
+LUA_LIBS=""
 lua_found="no"
 
-if test \(  x"$luapath" = x"auto" -o x"$luapath" = x"yes" \) -a x"$PKG_CONFIG" != x""
-then
-  PKG_CHECK_MODULES([LIBLUA], [lua5.1], [
-      LIBLUA_INCDIRS="$LIBLUA_CFLAGS"
-      lua_found="yes"
-    ],
-    [
-      AC_MSG_WARN([pkg-config for lua5.1 not found, trying lua...])
-      PKG_CHECK_MODULES([LIBLUA], [lua], [
-          LIBLUA_INCDIRS="$LIBLUA_CFLAGS"
-          lua_found="yes"
-        ],
-	[AC_MSG_WARN([pkg-config for lua not found, trying manual search...])]
-      )
-    ]
-  )
-fi
+AS_IF([test x"$enable_lua" = x"yes"], [
+  AS_IF([test x"$PKG_CONFIG" != x""], [
+    for luapkg in lua lua5.4 lua-5.4 lua5.3 lua-5.3 lua5.2 lua-5.2 lua5.1 lua-5.1
+    do
+      AS_IF([test x"$lua_found" != x"yes"], [
+        PKG_CHECK_MODULES([LUA], [$luapkg], [lua_found="yes"], [:])
+      ])
+    done
+    AS_IF([test x"$lua_found" = x"no"],
+      [AC_MSG_WARN([pkg-config for Lua not found, trying manual search...])])
+  ])
 
-if test \( x"$luapath" = x"yes" -o x"$luapath" = x"auto" \) -a x"$lua_found" = x"no"
-then
-	AC_MSG_CHECKING([for Lua])
-	luadirs="/usr /usr/local"
-	for d in $luadirs
-	do
-		if test -f $d/include/lua51/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include/lua51"
-			LIBLUA_LIBDIRS="-L$d/lib/lua51"
-			LIBLUA_LIBS="-llua -lm"
-			lua_found="yes"
-			break
-		elif test -f $d/include/lua52/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include/lua52"
-			LIBLUA_LIBDIRS="-L$d/lib/lua52"
-			LIBLUA_LIBS="-llua -lm"
-			lua_found="yes"
-			break
-		elif test -f $d/include/lua5.1/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include/lua5.1"
-			LIBLUA_LIBDIRS="-L$d/lib"
-			LIBLUA_LIBS="-llua5.1 -lm"
-			lua_found="yes"
-			break
-		elif test -f $d/include/lua5.2/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include/lua5.2"
-			LIBLUA_LIBDIRS="-L$d/lib"
-			LIBLUA_LIBS="-llua5.2 -lm"
-			lua_found="yes"
-			break
-		elif test -f $d/include/lua.h
-		then
-			AC_MSG_RESULT($d)
-			LIBLUA_INCDIRS="-I$d/include"
-			LIBLUA_LIBDIRS="-L$d/lib"
-			LIBLUA_LIBS="-llua -lm"
-			lua_found="yes"
-			break
-		fi
-	done
-	if test x"$LIBLUA_LIBS" = x""
-	then
-		LIBLUA_INCDIRS=""
-		LIBLUA_LIBDIRS=""
-		LIBLUA_LIBS=""
-		AC_MSG_ERROR(not found)
-	else
-		lua_found="yes"
-	fi
-fi
+  AS_IF([test x"$lua_found" != x"yes"], [
+    AC_SEARCH_LIBS([lua_load],
+                   [lua lua5.4 lua-5.4 lua5.3 lua-5.3 lua5.2 lua-5.2 lua5.1 lua-5.1],
+      [ lua_found="yes"
+        AS_IF([test "x$ac_cv_search_lua_load" != "xnone required"],
+          [LUA_LIBS="$ac_cv_search_lua_load"])
+      ])
+  ])
 
-if test x"$luapath" != x"yes" -a x"$luapath" != x"auto" -a x"$luapath" != x"no"
-then
-	AC_MSG_CHECKING([for Lua])
-	if test -f $luapath/include/lua51/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include/lua51"
-		LIBLUA_LIBDIRS="-L$luapath/lib/lua51"
-		LIBLUA_LIBS="-llua -lm"
-		lua_found="yes"
-	elif test -f $luapath/include/lua52/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include/lua52"
-		LIBLUA_LIBDIRS="-L$luapath/lib/lua52"
-		LIBLUA_LIBS="-llua -lm"
-		lua_found="yes"
-	elif test -f $luapath/include/lua5.1/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include/lua5.1"
-		LIBLUA_LIBDIRS="-L$luapath/lib"
-		LIBLUA_LIBS="-llua5.1 -lm"
-		lua_found="yes"
-	elif test -f $luapath/include/lua5.2/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include/lua5.2"
-		LIBLUA_LIBDIRS="-L$luapath/lib"
-		LIBLUA_LIBS="-llua5.2 -lm"
-		lua_found="yes"
-	elif test -f $luapath/include/lua.h
-	then
-		AC_MSG_RESULT($luapath)
-		LIBLUA_INCDIRS="-I$luapath/include"
-		LIBLUA_LIBDIRS="-L$luapath/lib"
-		LIBLUA_LIBS="-llua -lm"
-		lua_found="yes"
-	else
-		AC_MSG_ERROR(not found at $luapath)
-	fi
-fi
+  AS_IF([test x"$lua_found" != x"yes"],
+    [AC_MSG_ERROR([Lua enabled but not found])])
+])
 
-if test x"$lua_found" = x"yes"
-then
-	AC_SUBST([LUA_MANNOTICE], "")
-	AC_DEFINE([USE_LUA], 1, [support for Lua scripting])
-	AC_SEARCH_LIBS([dlopen], [dl])
-	saved_CPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$outer_CPPFLAGS $LIBLUA_INCDIRS"
-	AC_MSG_CHECKING([Lua version])
-	AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+AS_IF([test x"$lua_found" = x"yes"], [
+  AC_SUBST([LUA_MANNOTICE], "")
+  AC_DEFINE([USE_LUA], 1, [support for Lua scripting])
+  AC_SEARCH_LIBS([dlopen], [dl])
+  saved_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$outer_CPPFLAGS $LUA_CFLAGS"
+  AC_MSG_CHECKING([Lua version])
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 #include <lua.h>
 
 #if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501
@@ -1653,35 +1567,26 @@ main()
 {
 	return 0;
 }
-				])],
-				AC_MSG_RESULT([ok]), 
-				AC_MSG_ERROR([Lua version 5.1 or later required]))
-	CPPFLAGS="$saved_CPPFLAGS"
-	AC_DEFINE([USE_LUA], 1, [support for Lua scripting])
-	AC_SUBST([LUA_MANNOTICE], "")
-else
-	AC_SUBST([LUA_MANNOTICE], "(Not enabled for this installation.)")
-fi
+  ])],
+    AC_MSG_RESULT([ok]),
+    AC_MSG_ERROR([Lua version 5.1 or later required]))
+  CPPFLAGS="$saved_CPPFLAGS"
+], [
+  AC_SUBST([LUA_MANNOTICE], "(Not enabled for this installation.)")
+])
 
-AM_CONDITIONAL(LUA, test x"$lua_found" = x"yes")
-AC_SUBST(LIBLUA_INCDIRS)
-AC_SUBST(LIBLUA_LIBDIRS)
-AC_SUBST(LIBLUA_LIBS)
+AS_IF([test x"$lua_found" != x"yes"], [
+  AS_IF([test x"$enable_lua_only_signing" = x"yes"],
+    [AC_MSG_ERROR([--enable-lua_only_signing requires Lua support])])
+  AS_IF([test x"$enable_statsext" = x"yes"],
+    [AC_MSG_ERROR([--enable-statsext requires Lua support])])
+  AS_IF([test x"$enable_rbl" = x"yes"],
+    [AC_MSG_ERROR([--enable-rbl requires Lua support])])
+])
 
-if test x"$enable_lua_only_signing" = x"yes" -a x"$lua_found" != x"yes"
-then
-	AC_MSG_ERROR([--enable-lua_only_signing requires Lua support])
-fi
-
-if test x"$enable_statsext" = x"yes" -a x"$lua_found" != x"yes"
-then
-	AC_MSG_ERROR([--enable-statsext requires Lua support])
-fi
-
-if test x"$enable_rbl" = x"yes" -a x"$lua_found" != x"yes"
-then
-	AC_MSG_ERROR([--enable-rbl requires Lua support])
-fi
+AM_CONDITIONAL([LUA], [test x"$lua_found" = x"yes"])
+AC_SUBST([LUA_CFLAGS])
+AC_SUBST([LUA_LIBS])
 
 AC_ARG_WITH([sql-backend],
             AS_HELP_STRING([--with-sql-backend],
@@ -2608,7 +2513,7 @@ fi
 if test x"$lua_found" = x"yes"
 then
 	installbin="yes"
-	specconfig="$specconfig --with-lua=$luapath"
+	specconfig="$specconfig --enable-lua"
 	specrequries="$specrequires lua"
 	specbuildrequries="$specbuildrequires lua-devel"
 fi

--- a/miltertest/Makefile.am
+++ b/miltertest/Makefile.am
@@ -10,9 +10,8 @@ if LUA
 bin_PROGRAMS = miltertest
 
 miltertest_SOURCES = miltertest.c
-miltertest_CPPFLAGS = -I$(srcdir)/../libopendkim $(LIBMILTER_INCDIRS) $(LIBLUA_INCDIRS)
-miltertest_LDFLAGS = ../libopendkim/libopendkim.la $(LIBLUA_LIBDIRS)
-miltertest_LDADD = $(LIBLUA_LIBS) $(LIBNSL_LIBS)
+miltertest_CPPFLAGS = -I$(srcdir)/../libopendkim $(LIBMILTER_INCDIRS) $(LUA_CFLAGS)
+miltertest_LDADD = ../libopendkim/libopendkim.la $(LUA_LIBS) $(LIBNSL_LIBS)
 
 man_MANS = miltertest.8
 endif

--- a/opendkim/Makefile.am
+++ b/opendkim/Makefile.am
@@ -46,9 +46,8 @@ opendkim_LDADD += $(LIBMEMCACHED_LIBS)
 endif
 if LUA
 SUBDIRS=tests
-opendkim_CPPFLAGS += $(LIBLUA_INCDIRS) -DDKIMF_LUA_CONTEXT_HOOKS
-opendkim_LDFLAGS += $(LIBLUA_LIBDIRS)
-opendkim_LDADD += $(LIBLUA_LIBS)
+opendkim_CPPFLAGS += $(LUA_CFLAGS) -DDKIMF_LUA_CONTEXT_HOOKS
+opendkim_LDADD += $(LUA_LIBS)
 endif
 if USE_SASL
 opendkim_CPPFLAGS += $(SASL_CPPFLAGS)
@@ -108,9 +107,8 @@ opendkim_testkey_CFLAGS = $(LIBCRYPTO_CFLAGS) $(COV_CFLAGS) $(PTHREAD_CFLAGS)
 opendkim_testkey_LDFLAGS = $(LIBCRYPTO_LIBDIRS) $(COV_LDFLAGS) $(PTHREAD_CFLAGS)
 opendkim_testkey_LDADD = ../libopendkim/libopendkim.la $(LIBCRYPTO_LIBS) $(LIBRESOLV) $(COV_LIBADD) $(PTHREAD_LIBS)
 if LUA
-opendkim_testkey_CPPFLAGS += $(LIBLUA_INCDIRS) $(LIBMILTER_INCDIRS)
-opendkim_testkey_LDFLAGS += $(LIBLUA_LIBDIRS)
-opendkim_testkey_LDADD += $(LIBLUA_LIBS)
+opendkim_testkey_CPPFLAGS += $(LUA_CFLAGS) $(LIBMILTER_INCDIRS)
+opendkim_testkey_LDADD += $(LUA_LIBS)
 endif
 if USE_DB_OPENDKIM
 opendkim_testkey_CPPFLAGS += $(LIBDB_INCDIRS)
@@ -200,9 +198,8 @@ opendkim_genzone_CPPFLAGS += $(OPENLDAP_CPPFLAGS)
 opendkim_genzone_LDADD += $(OPENLDAP_LIBS)
 endif
 if LUA
-opendkim_genzone_CPPFLAGS += $(LIBLUA_INCDIRS) $(LIBMILTER_INCDIRS)
-opendkim_genzone_LDFLAGS += $(LIBLUA_LIBDIRS)
-opendkim_genzone_LDADD += $(LIBLUA_LIBS)
+opendkim_genzone_CPPFLAGS += $(LUA_CFLAGS) $(LIBMILTER_INCDIRS)
+opendkim_genzone_LDADD += $(LUA_LIBS)
 endif
 if REPUTE
 opendkim_genzone_CPPFLAGS += -I$(srcdir)/../reputation
@@ -250,9 +247,8 @@ opendkim_atpszone_CPPFLAGS += $(OPENLDAP_CPPFLAGS)
 opendkim_atpszone_LDADD += $(OPENLDAP_LIBS)
 endif
 if LUA
-opendkim_atpszone_CPPFLAGS += $(LIBLUA_INCDIRS) $(LIBMILTER_INCDIRS)
-opendkim_atpszone_LDFLAGS += $(LIBLUA_LIBDIRS)
-opendkim_atpszone_LDADD += $(LIBLUA_LIBS)
+opendkim_atpszone_CPPFLAGS += $(LUA_CFLAGS) $(LIBMILTER_INCDIRS)
+opendkim_atpszone_LDADD += $(LUA_LIBS)
 endif
 if REPUTE
 opendkim_atpszone_CPPFLAGS += -I$(srcdir)/../reputation


### PR DESCRIPTION
## Summary

- Replaces `--with-lua` (path-based) with `--enable-lua` (boolean flag), since we no longer do manual path crawling
- Uses pkg-config with a versioned name search covering current Debian/Ubuntu naming conventions: `lua`, `lua5.4`, `lua-5.4`, `lua5.3`, `lua-5.3`, `lua5.2`, `lua-5.2`, `lua5.1`, `lua-5.1`
- Falls back to `AC_SEARCH_LIBS` for systems without pkg-config, trusting the user to have set `CPPFLAGS`/`LDFLAGS` for non-standard paths
- Renames `LIBLUA_INCDIRS`/`LIBLUA_LIBDIRS`/`LIBLUA_LIBS` → `LUA_CFLAGS`/`LUA_LIBS` throughout `configure.ac` and all `Makefile.am` files, following pkg-config conventions
- Fixes undefined `$(LUA_INCDIRS)` and `$(LUA_LIBDIRS)` variable references in PR #112
- Switches to `AS_IF` throughout, following autoconf style conventions
- Closes #111; supersedes #112 and #264

## Notes

`AX_PROG_LUA` from the GNU Autoconf Archive was evaluated but not used. It requires a Lua interpreter at configure time to determine the version, which is not guaranteed when only development headers and libraries are installed (e.g. `liblua5.4-dev` without `lua5.4`). A comment in `configure.ac` records this decision.

Lua 5.5 support requires C API changes (`lua_newstate` signature, `lua_dump` behavior) and is tracked in #265.

## Test plan

- [ ] `autoreconf -fi && ./configure --enable-lua` on a system with Lua via pkg-config
- [ ] `./configure --enable-lua` on a system with only `liblua-dev` (no pkg-config entry), relying on `AC_SEARCH_LIBS` fallback
- [ ] `./configure` (no Lua) still builds cleanly
- [ ] `LUA_CFLAGS` and `LUA_LIBS` can be passed on the command line to override detection