### PR TITLE
Lua 5.5 C API compatibility

### DIFF
--- a/miltertest/miltertest.c
+++ b/miltertest/miltertest.c
@@ -3883,7 +3883,11 @@ main(int argc, char **argv)
 	rusage = FALSE;
 	nowait = FALSE;
 
+#if LUA_VERSION_NUM >= 505
+	l = lua_newstate(mt_lua_alloc, NULL, 0);
+#else
 	l = lua_newstate(mt_lua_alloc, NULL);
+#endif
 	if (l == NULL)
 	{
 		fprintf(stderr, "%s: unable to allocate new Lua state\n",

--- a/opendkim/opendkim-lua.c
+++ b/opendkim/opendkim-lua.c
@@ -230,8 +230,13 @@ dkimf_lua_writer(lua_State *l, const void *buf, size_t sz, void *data)
 	struct dkimf_lua_io *io;
 
 	assert(l != NULL);
-	assert(buf != NULL);
 	assert(data != NULL);
+
+	/* Lua 5.5 calls the writer once with sz=0 to signal end of dump. */
+	if (sz == 0)
+		return 0;
+
+	assert(buf != NULL);
 
 	io = (struct dkimf_lua_io *) data;
 
@@ -475,7 +480,11 @@ dkimf_lua_setup_hook(void *ctx, const char *script, size_t scriptlen,
 	gc.gc_head = NULL;
 	gc.gc_tail = NULL;
 
+#if LUA_VERSION_NUM >= 505
+	l = lua_newstate(dkimf_lua_alloc, NULL, 0);
+#else
 	l = lua_newstate(dkimf_lua_alloc, NULL);
+#endif
 	if (l == NULL)
 		return -1;
 
@@ -634,7 +643,11 @@ dkimf_lua_screen_hook(void *ctx, const char *script, size_t scriptlen,
 	gc.gc_head = NULL;
 	gc.gc_tail = NULL;
 
+#if LUA_VERSION_NUM >= 505
+	l = lua_newstate(dkimf_lua_alloc, NULL, 0);
+#else
 	l = lua_newstate(dkimf_lua_alloc, NULL);
+#endif
 	if (l == NULL)
 		return -1;
 
@@ -783,7 +796,11 @@ dkimf_lua_stats_hook(void *ctx, const char *script, size_t scriptlen,
 	gc.gc_head = NULL;
 	gc.gc_tail = NULL;
 
+#if LUA_VERSION_NUM >= 505
+	l = lua_newstate(dkimf_lua_alloc, NULL, 0);
+#else
 	l = lua_newstate(dkimf_lua_alloc, NULL);
+#endif
 	if (l == NULL)
 		return -1;
 
@@ -1024,7 +1041,11 @@ dkimf_lua_final_hook(void *ctx, const char *script, size_t scriptlen,
 	gc.gc_head = NULL;
 	gc.gc_tail = NULL;
 
+#if LUA_VERSION_NUM >= 505
+	l = lua_newstate(dkimf_lua_alloc, NULL, 0);
+#else
 	l = lua_newstate(dkimf_lua_alloc, NULL);
+#endif
 	if (l == NULL)
 		return -1;
 
@@ -1255,7 +1276,11 @@ dkimf_lua_db_hook(const char *script, size_t scriptlen, const char *query,
 	else
 		io.lua_io_len = scriptlen;
 
+#if LUA_VERSION_NUM >= 505
+	l = lua_newstate(dkimf_lua_alloc, NULL, 0);
+#else
 	l = lua_newstate(dkimf_lua_alloc, NULL);
+#endif
 	if (l == NULL)
 		return -1;
 


### PR DESCRIPTION
Closes #265. Incorporates fix from PR #201.

## Changes

**`lua_newstate` signature change** (`lua_newstate` gained a third `seed` parameter in 5.5):
- Wrap all six call sites in `opendkim/opendkim-lua.c` and the one in `miltertest/miltertest.c` with `#if LUA_VERSION_NUM >= 505` guards, passing `0` as the seed (uses Lua's default string hashing behavior).

**`lua_dump` behavioral change** (`lua_dump` now calls the writer with `buf=NULL` to signal end of dump):
- Add an early `return 0` in `dkimf_lua_writer()` when `buf == NULL`, and move the `assert(buf != NULL)` below that guard.

**`lua_pop` stack corruption in Lua >= 5.2** (PR #201):
- `lua_setglobal()` already pops the stack in Lua >= 5.2, so the unconditional `lua_pop(l, 1)` after the `#endif` was popping from an empty stack, causing an abort() in Lua 5.4. Fixed in all four hook functions in `opendkim-lua.c` and in `miltertest.c` by moving the `lua_pop` inside the `luaL_register` (`< 5.2`) branch only.

## Test plan

- [ ] Builds cleanly against Lua 5.1, 5.2, 5.3, 5.4
- [ ] Builds cleanly against Lua 5.5
- [ ] `make check` passes with Lua 5.4 (previously aborted due to stack corruption)
- [ ] `lua_dump`-based script caching works correctly under Lua 5.5