### PR TITLE
Lua fixes for dkimf_lua_writer and lua_pop placement

### DIFF
--- a/miltertest/miltertest.c
+++ b/miltertest/miltertest.c
@@ -4018,8 +4018,8 @@ main(int argc, char **argv)
 	lua_setglobal(l, "mt");
 #else /* LUA_VERSION_NUM >= 502 */
 	luaL_register(l, "mt", mt_library);
-#endif /* LUA_VERSION_NUM >= 502 */
 	lua_pop(l, 1);
+#endif /* LUA_VERSION_NUM >= 502 */
 
 	/* register constants */
 	lua_pushnumber(l, MT_HDRINSERT);

--- a/opendkim/opendkim-lua.c
+++ b/opendkim/opendkim-lua.c
@@ -232,8 +232,8 @@ dkimf_lua_writer(lua_State *l, const void *buf, size_t sz, void *data)
 	assert(l != NULL);
 	assert(data != NULL);
 
-	/* Lua 5.5 calls the writer once with sz=0 to signal end of dump. */
-	if (sz == 0)
+	/* Lua 5.5 calls the writer once with buf=NULL to signal end of dump. */
+	if (buf == NULL)
 		return 0;
 
 	assert(buf != NULL);
@@ -499,8 +499,8 @@ dkimf_lua_setup_hook(void *ctx, const char *script, size_t scriptlen,
 	lua_setglobal(l, "odkim");
 # else /* LUA_VERSION_NUM >= 502 */
 	luaL_register(l, "odkim", dkimf_lua_lib_setup);
-# endif /* LUA_VERSION_NUM >= 502 */
 	lua_pop(l, 1);
+# endif /* LUA_VERSION_NUM >= 502 */
 
 	/*
 	**  Register constants.
@@ -662,8 +662,8 @@ dkimf_lua_screen_hook(void *ctx, const char *script, size_t scriptlen,
 	lua_setglobal(l, "odkim");
 # else /* LUA_VERSION_NUM >= 502 */
 	luaL_register(l, "odkim", dkimf_lua_lib_screen);
-# endif /* LUA_VERSION_NUM >= 502 */
 	lua_pop(l, 1);
+# endif /* LUA_VERSION_NUM >= 502 */
 
 	/*
 	**  Register constants.
@@ -815,8 +815,8 @@ dkimf_lua_stats_hook(void *ctx, const char *script, size_t scriptlen,
 	lua_setglobal(l, "odkim");
 # else /* LUA_VERSION_NUM >= 502 */
 	luaL_register(l, "odkim", dkimf_lua_lib_stats);
-# endif /* LUA_VERSION_NUM >= 502 */
 	lua_pop(l, 1);
+# endif /* LUA_VERSION_NUM >= 502 */
 
 	/*
 	**  Register constants.
@@ -1060,8 +1060,8 @@ dkimf_lua_final_hook(void *ctx, const char *script, size_t scriptlen,
 	lua_setglobal(l, "odkim");
 # else /* LUA_VERSION_NUM >= 502 */
 	luaL_register(l, "odkim", dkimf_lua_lib_final);
-# endif /* LUA_VERSION_NUM >= 502 */
 	lua_pop(l, 1);
+# endif /* LUA_VERSION_NUM >= 502 */
 
 	/*
 	**  Register constants.


### PR DESCRIPTION
Follow-up to #267 with two corrections identified after merge.

## Changes

**`dkimf_lua_writer`: use `buf == NULL` not `sz == 0`**

PR #267 guarded against Lua 5.5's end-of-dump writer call by checking `sz == 0`. Lua 5.5 actually passes `buf=NULL` to signal end of dump, so the guard should check `buf == NULL` instead. Caught by futatuki in a comment on #267.

**`lua_pop` stack corruption in Lua >= 5.2** (incorporates #201)

`lua_setglobal()` already pops the stack in Lua >= 5.2, so the unconditional `lua_pop(l, 1)` that followed the `#endif` was popping from an empty stack, causing an `abort()` in Lua 5.4. Fixed in all four hook functions in `opendkim-lua.c` and in `miltertest.c` by moving `lua_pop` inside the `luaL_register` (`< 5.2`) branch only.

## Test plan

- [ ] `make check` passes with Lua 5.4 (previously aborted due to stack corruption)
- [ ] Lua 5.5 `lua_dump` writer no longer triggers assert