### PR TITLE
Fix leak of lg_name in Lua global cleanup

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -9340,6 +9340,7 @@ dkimf_cleanup(SMFICTX *ctx)
 				    cur->lg_type == LUA_TSTRING)
 					free(cur->lg_value);
 
+				free(cur->lg_name);
 				free(cur);
 
 				cur = next;


### PR DESCRIPTION
In `dkimf_cleanup`, the loop that frees the `lua_global` list freed `lg_value` (for numeric/string types) and the struct itself, but never freed `lg_name` — the `strdup`'d string set when `odkim.export()` is called from a Lua setup or screen script.

This is a per-message leak on any site using Lua scripts with `odkim.export()`.  At high message volume it accumulates proportionally to the number of exported globals per message.

Fix is a one-line addition of `free(cur->lg_name)` before `free(cur)`.

Part of issue #272.