### PR TITLE
Fix orphaned signreq list entries with MultipleSignatures

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -5126,11 +5126,11 @@ dkimf_add_signrequest(struct msgctx *dfc, DKIMF_DB keytable, char *keyname,
 
 	if (dfc->mctx_srtail != NULL)
 		dfc->mctx_srtail->srq_next = new;
-	else
-		dfc->mctx_srtail = new;
 
 	if (dfc->mctx_srhead == NULL)
 		dfc->mctx_srhead = new;
+
+	dfc->mctx_srtail = new;
 
 	return 0;
 }


### PR DESCRIPTION
## Bug

In `dkimf_add_signrequest`, the tail pointer `mctx_srtail` was only set on the very first call and never advanced thereafter.  On each subsequent call, `srtail->srq_next = new` always overwrote the *first* entry's next pointer rather than appending to the actual tail, making all intermediate entries unreachable.

With N signing requests (A, B, C, ...):
- The linked list as seen from `mctx_srhead` would be: A -> last entry
- All entries between A and the last were orphaned, never freed, and never signed

This affects any site using `MultipleSignatures` with a `SigningTable` that produces 3 or more matches for a given sender.  Each orphaned `signreq` leaks its `srq_domain`, `srq_selector`, `srq_keydata`, and `srq_signer` strings, and the corresponding signature is silently skipped.

## Fix

Move `mctx_srtail = new` outside the conditional so it is always updated after linking the new entry, regardless of whether the list was previously empty.

Part of issue #272.