### PR TITLE
Fix conf_remardb not closed in dkimf_config_free

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -5958,6 +5958,9 @@ dkimf_config_free(struct dkimf_config *conf)
 	if (conf->conf_dontsigntodb != NULL)
 		dkimf_db_close(conf->conf_dontsigntodb);
 
+	if (conf->conf_remardb != NULL)
+		dkimf_db_close(conf->conf_remardb);
+
 #ifdef _FFR_ATPS
 	if (conf->conf_atpsdb != NULL)
 		dkimf_db_close(conf->conf_atpsdb);


### PR DESCRIPTION
`conf_remardb` is opened when `RemoveARFrom` is configured but was absent from the `dkimf_db_close` calls in `dkimf_config_free`, leaking the handle and its internal memory on every config reload.

Fix adds the missing `dkimf_db_close(conf->conf_remardb)` call alongside the other DB handle cleanup.

Part of issue #272.