### PR TITLE
Fix leak in dkimf_db_mkarray_base

### DIFF
--- a/opendkim/opendkim-db.c
+++ b/opendkim/opendkim-db.c
@@ -6580,6 +6580,20 @@ dkimf_db_mkarray_base(DKIMF_DB db, char ***a, const char **base)
 		out[nout] = NULL;
 	}
 
+	if (db->db_array != NULL)
+	{
+		int d;
+
+		if ((db->db_iflags & DKIMF_DB_IFLAG_FREEARRAY) != 0)
+		{
+			for (d = 0; db->db_array[d] != NULL; d++)
+				free(db->db_array[d]);
+		}
+		free(db->db_array);
+	}
+	db->db_array = out;
+	db->db_iflags |= DKIMF_DB_IFLAG_FREEARRAY;
+
 	*a = out;
 	return nout;
 }


### PR DESCRIPTION
`dkimf_db_mkarray_base` allocates a new `char**` array with `strdup`'d strings but never stores it in `db->db_array`.  Every other allocation path in `dkimf_db_mkarray` stores its result there so that `dkimf_db_close` frees it — `dkimf_db_mkarray_base` was the sole exception.

Callers that store the result in `conf_omithdrs`, `conf_signhdrs`, or `conf_senderhdrs` leak the array and all its strings on every config reload when a wildcard (`*`) entry is present in the DB.

Fix stores the result in `db->db_array` with `DKIMF_DB_IFLAG_FREEARRAY`, consistent with the BDB/DSN path.  If a previous array is cached in `db->db_array`, it is freed first.

Part of issue #272.