### PR TITLE
Fix GnuTLS hash context leak on aborted messages

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -9351,6 +9351,15 @@ dkimf_cleanup(SMFICTX *ctx)
 		}
 #endif /* USE_LUA */
 
+#ifdef _FFR_REPUTATION
+# ifdef USE_GNUTLS
+		{
+			unsigned char digest[SHA_DIGEST_LENGTH];
+			(void) gnutls_hash_deinit(dfc->mctx_hash, digest);
+		}
+# endif /* USE_GNUTLS */
+#endif /* _FFR_REPUTATION */
+
 		free(dfc);
 		cc->cctx_msg = NULL;
 	}


### PR DESCRIPTION
Affects `_FFR_REPUTATION` + `USE_GNUTLS` builds only.

`gnutls_hash_init` is called for every message in `dkimf_initcontext`, but `gnutls_hash_deinit` was only called inside the reputation block in `mlfi_eom`.  Any message that aborted before end-of-message (RSET, client disconnect, early reject) leaked the GnuTLS hash context.

Fix adds the matching `gnutls_hash_deinit` call to `dkimf_cleanup`, which is the common teardown path for all message contexts regardless of how processing ended.  The digest output is discarded since we only need to release the handle.

Part of issue #272.