### PR TITLE
Fix cfg leak on deprecated-setting abort in dkimf_config_reload

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -8901,6 +8901,7 @@ dkimf_config_reload(void)
 
 			if (!allowdeprecated)
 			{
+				config_free(cfg);
 				dkimf_config_free(new);
 				err = TRUE;
 			}


### PR DESCRIPTION
When `config_load` succeeded but the config file contained deprecated settings and `AllowDeprecated` was not set, `dkimf_config_free(new)` was called but `config_free(cfg)` was not — leaking the parsed config tree on every such reload attempt (SIGHUP).

The identical abort path in `main()` correctly calls `config_free(cfg)`.  Fix adds the missing call.

Part of issue #272.