### PR TITLE
Fix leaks on OOM error paths

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -5117,6 +5117,9 @@ dkimf_add_signrequest(struct msgctx *dfc, DKIMF_DB keytable, char *keyname,
 		new->srq_keydata = (void *) malloc(keydatasz + 1);
 		if (new->srq_keydata == NULL)
 		{
+			TRYFREE(new->srq_signer);
+			TRYFREE(new->srq_domain);
+			TRYFREE(new->srq_selector);
 			free(new);
 			return -1;
 		}
@@ -13138,6 +13141,8 @@ mlfi_eoh(SMFICTX *ctx)
 					       dfc->mctx_jobid,
 					       strerror(errno));
 					TRYFREE(newhdr->hdr_hdr);
+					TRYFREE(newhdr->hdr_val);
+					free(newhdr);
 					dkimf_cleanup(ctx);
 					return SMFIS_TEMPFAIL;
 				}


### PR DESCRIPTION
Two OOM-only leak fixes bundled together as neither warrants its own PR.

**`dkimf_add_signrequest`**: when `malloc` fails for `srq_keydata`, `srq_signer`, `srq_domain`, and `srq_selector` had already been `strdup`'d but were not freed before returning -1.  Only the `signreq` struct itself was freed.

**`mlfi_eom` VBR path (`_FFR_VBR`)**: when `strdup` fails for `hdr_hdr` or `hdr_val`, `newhdr` itself was not freed.  Also adds a missing `TRYFREE(newhdr->hdr_val)` for the case where `hdr_hdr` succeeds but `hdr_val` fails.

Both are triggered only under memory pressure and have no impact on normal operation.

Part of issue #272.