### PR TITLE
Fix use-after-free in mlfi_close under QUERY_CACHE

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -15411,6 +15411,9 @@ sfsistat
 mlfi_close(SMFICTX *ctx)
 {
 	connctx cc;
+#ifdef QUERY_CACHE
+	DKIM_LIB *cachestats_lib = NULL;
+#endif /* QUERY_CACHE */
 
 	dkimf_cleanup(ctx);
 
@@ -15425,6 +15428,10 @@ mlfi_close(SMFICTX *ctx)
 		    cc->cctx_config != curconf)
 			dkimf_config_free(cc->cctx_config);
 
+#ifdef QUERY_CACHE
+		cachestats_lib = cc->cctx_config->conf_libopendkim;
+#endif /* QUERY_CACHE */
+
 		pthread_mutex_unlock(&conf_lock);
 
 		free(cc);
@@ -15432,7 +15439,7 @@ mlfi_close(SMFICTX *ctx)
 	}
 
 #ifdef QUERY_CACHE
-	if (querycache)
+	if (querycache && cachestats_lib != NULL)
 	{
 		time_t now;
 
@@ -15445,7 +15452,7 @@ mlfi_close(SMFICTX *ctx)
 			u_int c_pct;
 			u_int c_keys;
 
-			dkim_getcachestats(cc->cctx_config->conf_libopendkim,
+			dkim_getcachestats(cachestats_lib,
 			                   &c_queries, &c_hits, &c_expired,
 			                   &c_keys, FALSE);
 


### PR DESCRIPTION
Affects `QUERY_CACHE` builds only.

In `mlfi_close`, `cc` was freed at line 15434 and then dereferenced inside the `#ifdef QUERY_CACHE` block (`cc->cctx_config->conf_libopendkim`).  The block also lacked a NULL guard, meaning it would dereference `cc` on connections where no context was ever established.

Fix captures `conf_libopendkim` in a local variable (`cachestats_lib`) while `cc` is still valid, inside the existing `cc != NULL` guard, then uses that variable in the `QUERY_CACHE` block.

Part of issue #272.