### PR TITLE
libopendkim: verify ed25519-sha256 signatures with GnuTLS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -757,6 +757,19 @@ then
 	               AC_MSG_RESULT(ok),
 	               AC_MSG_FAILURE([GnuTLS must be at least version 2.11.7]))
 
+	ed25519check='
+		#include <gnutls/gnutls.h>
+		int main()
+		{
+			int x = GNUTLS_PK_EDDSA_ED25519;
+		}'
+	AC_MSG_CHECKING([whether your GnuTLS supports ED25519])
+	AC_LINK_IFELSE([AC_LANG_SOURCE([$ed25519check])],
+	               AC_MSG_RESULT(yes)
+	               AC_DEFINE([HAVE_ED25519], 1,
+	                        [Define to 1 if your crypto library has ED25519 support]),
+	               AC_MSG_RESULT(no))
+
 	sha256check='
 		#include <gnutls/gnutls.h>
 		int main()

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -5691,7 +5691,15 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 
 			return DKIM_STAT_OK;
 		}
-
+#if HAVE_ED25519
+		if (sig->sig_signalg == DKIM_SIGN_ED25519SHA256)
+		{
+			status = gnutls_pubkey_import_ecc_raw(crypto->crypto_pubkey,
+			                                      GNUTLS_ECC_CURVE_ED25519,
+			                                      &key, NULL);
+		}
+		else
+#endif
 		status = gnutls_pubkey_import(crypto->crypto_pubkey, &key,
 		                              GNUTLS_X509_FMT_DER);
 		if (status != GNUTLS_E_SUCCESS)
@@ -5712,19 +5720,27 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 		                                  &crypto->crypto_digest,
 		                                  &crypto->crypto_sig);
 # else /* GNUTLS_VERSION_MAJOR == 2 */
-		hash = dkim_libfeature(dkim->dkim_libhandle,
-		                       DKIM_FEATURE_SHA256);
-		hash = (hash && sig->sig_hashtype == DKIM_HASHTYPE_SHA256)
-		       ? GNUTLS_DIG_SHA256
-		       : GNUTLS_DIG_SHA1;
+#if HAVE_ED25519
+		if (sig->sig_signalg == DKIM_SIGN_ED25519SHA256)
+			vstat = gnutls_pubkey_verify_data2(crypto->crypto_pubkey,
+							   GNUTLS_SIGN_EDDSA_ED25519, 0,
+							   &crypto->crypto_digest,
+							   &crypto->crypto_sig);
+		else
+#endif
+		{
+			hash = dkim_libfeature(dkim->dkim_libhandle,
+					       DKIM_FEATURE_SHA256);
+			hash = (hash && sig->sig_hashtype == DKIM_HASHTYPE_SHA256)
+			       ? GNUTLS_DIG_SHA256 : GNUTLS_DIG_SHA1;
 
-		signalg = gnutls_pk_to_sign(GNUTLS_PK_RSA, hash);
-		assert(signalg != GNUTLS_SIGN_UNKNOWN);
-
-		vstat = gnutls_pubkey_verify_hash2(crypto->crypto_pubkey,
+			signalg = gnutls_pk_to_sign(GNUTLS_PK_RSA, hash);
+			assert(signalg != GNUTLS_SIGN_UNKNOWN);
+			vstat = gnutls_pubkey_verify_hash2(crypto->crypto_pubkey,
 		                                   signalg, 0,
 		                                   &crypto->crypto_digest,
 		                                   &crypto->crypto_sig);
+		}
 # endif /* GNUTLS_VERSION_MAJOR == 2 */
 		if (vstat < 0)
 			dkim_sig_load_ssl_errors(dkim, sig, vstat);


### PR DESCRIPTION
Closes #33.

The GnuTLS code path in `dkim_sig_process` only handled RSA key import and verification. Ed25519 keys cannot be imported with `gnutls_pubkey_import()` (which expects DER-encoded RSA keys), so any ed25519-sha256 signature received by a GnuTLS build would fail silently.

This adds:
- An `HAVE_ED25519` configure check for GnuTLS builds, testing for `GNUTLS_PK_EDDSA_ED25519` (requires GnuTLS >= 3.6.0). Mirrors the existing OpenSSL `EVP_PKEY_ED25519` check; the same symbol is safe since GnuTLS and OpenSSL are mutually exclusive in configure.ac.
- In `dkim_sig_process`, when `HAVE_ED25519` is set and the signature algorithm is ed25519-sha256: use `gnutls_pubkey_import_ecc_raw()` with `GNUTLS_ECC_CURVE_ED25519` for key import, and `gnutls_pubkey_verify_data2()` with `GNUTLS_SIGN_EDDSA_ED25519` for verification.

GnuTLS builds without Ed25519 support (< 3.6.0) are unaffected — `HAVE_ED25519` won't be defined and the existing RSA-only path compiles as before.

Both `gnutls_pubkey_import_ecc_raw` and `gnutls_pubkey_verify_data2` are current and non-deprecated in GnuTLS 3.8.x.

Based on a patch by @dilyanpalauzov.