### PR TITLE
librbl, libopendkim: fix struct state -> struct __res_state typo

### DIFF
--- a/libopendkim/dkim-dns.c
+++ b/libopendkim/dkim-dns.c
@@ -272,7 +272,7 @@ dkim_res_nslist(void *srv, const char *nslist)
 # ifdef AF_INET6
 	struct sockaddr_in6 in6;
 # endif /* AF_INET6 */
-	struct state *res;
+	struct __res_state *res;
 	res_sockaddr_union nses[MAXNS];
 
 	assert(srv != NULL);

--- a/librbl/rbl.c
+++ b/librbl/rbl.c
@@ -258,7 +258,7 @@ rbl_res_nslist(void *srv, const char *nslist)
 # ifdef AF_INET6
 	struct sockaddr_in6 in6;
 # endif /* AF_INET6 */
-	struct state *res;
+	struct __res_state *res;
 	res_sockaddr_union nses[MAXNS];
 
 	assert(srv != NULL);
@@ -329,7 +329,7 @@ void
 rbl_res_close(void *srv)
 {
 #ifdef HAVE_RES_NINIT
-	struct state *res;
+	struct __res_state *res;
 
 	res = srv;
 


### PR DESCRIPTION
Fixes #224.

`struct state` is the old non-POSIX name for the resolver state struct; the correct name is `struct __res_state`. gcc 14 with `-Werror` rejects the old name.

Three occurrences fixed:
- `librbl/rbl.c` — `rbl_res_nslist()` and `rbl_res_close()`
- `libopendkim/dkim-dns.c` — `dkim_res_nslist()`

All are local variables cast from `void *srv`, so there is no ABI or API impact. `dkim_res_close()` in `dkim-dns.c` already used the correct type.

Note: PR #99 proposes removing the `nslist` functions entirely; that's a separate discussion.