### PR TITLE
opendkim: fix FD leak from missing endpwent() in key safety checks

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -4515,6 +4515,7 @@ dkimf_checkfsnode(const char *path, uid_t myuid, char *myname, ino_t *ino,
 						         path, s.st_gid,
 						         pw->pw_name);
 					}
+					endpwent();
 					pthread_mutex_unlock(&pwdb_lock);
 					return 0;
 				}
@@ -4600,10 +4601,12 @@ dkimf_checkfsnode(const char *path, uid_t myuid, char *myname, ino_t *ino,
 						         pw->pw_name);
 					}
 
+					endpwent();
 					pthread_mutex_unlock(&pwdb_lock);
 					return 0;
 				}
 			}
+			endpwent();
 
 			/* check if this group contains anyone else */
 			gr = getgrgid(s.st_gid);
@@ -4802,6 +4805,7 @@ dkimf_securefile(const char *path, ino_t *ino, uid_t myuid, char *err,
 		{
 			if (pw->pw_uid != myuid && pw->pw_gid == s.st_gid)
 			{
+				endpwent();
 				pthread_mutex_unlock(&pwdb_lock);
 				return 0;
 			}


### PR DESCRIPTION
Fixes #198.

## Root cause

`dkimf_checkfsnode()` and `dkimf_securefile()` enumerate the password database via `setpwent()`/`getpwent()` to verify that key files are not accessible by other users (the `SafeKeys` feature). Several early-return paths inside those loops skipped `endpwent()`.

With SSSD >= 2.9.1, the NSS client library keeps its Unix socket to `sssd` open until `endpwent()` is explicitly called. On systems with many key files (e.g. 50+ signing keys), each key file check that hits an early-return path leaks one FD, eventually exhausting the process FD limit and causing milter connection failures requiring a restart.

This explains why the issue only appeared after upgrading to SSSD 2.9.1 — older SSSD closed the socket more aggressively regardless of whether `endpwent()` was called.

## Fix

Four changes in `opendkim.c`:
1. `dkimf_checkfsnode()` regular-file block: add `endpwent()` before early `return 0`
2. `dkimf_checkfsnode()` directory block: add `endpwent()` before early `return 0`
3. `dkimf_checkfsnode()` directory block: add missing `endpwent()` after loop completes normally (before `getgrgid()` call)
4. `dkimf_securefile()` no-realpath path: add `endpwent()` before early `return 0`