### PR TITLE
opendkim-genkey: let openssl write errors to stderr

### DIFF
--- a/opendkim/opendkim-genkey.in
+++ b/opendkim/opendkim-genkey.in
@@ -151,11 +151,11 @@ if ((!$ed25519) and ($bits < 1024))
 
 if ($ed25519)
 {
-	$status = system("openssl genpkey -algorithm ed25519 -outform PEM -out " . $selector . ".private > /dev/null 2>&1");
+	$status = system("openssl genpkey -algorithm ed25519 -outform PEM -out " . $selector . ".private > /dev/null");
 }
 else
 {
-	$status = system("openssl genrsa -out " . $selector . ".private " . $bits . " > /dev/null 2>&1");
+	$status = system("openssl genrsa -out " . $selector . ".private " . $bits . " > /dev/null");
 }
 if ($status != 0)
 {
@@ -190,7 +190,7 @@ if ($ed25519)
 }
 else
 {
-	$status = system("openssl rsa -in " . $selector . ".private -pubout -out " . $selector . ".public -outform PEM > /dev/null 2>&1");
+	$status = system("openssl rsa -in " . $selector . ".private -pubout -out " . $selector . ".public -outform PEM > /dev/null");
 }
 if ($status != 0)
 {


### PR DESCRIPTION
Fixes #94.

Removes `2>&1` from the three `openssl` invocations in `opendkim-genkey`. stdout is still redirected to `/dev/null` (suppressing normal progress output), but stderr is now left open so error messages are visible to the user.

Previously a failure produced only:
```
opendkim-genkey: openssl exited with status %d
```
with no indication of the actual cause. Now the user sees the actual openssl error (e.g. `Can't open "default.private" for writing, Is a directory`).

Exit codes and stdout behaviour are unchanged, so this is safe for any automation that captures the exit status.