### PR TITLE
opendkim-db: fix assert(0) crash when using memcache for SigningTable

### DIFF
--- a/opendkim/opendkim-db.c
+++ b/opendkim/opendkim-db.c
@@ -5806,6 +5806,34 @@ dkimf_db_strerror(DKIMF_DB db, char *err, size_t errlen)
 }
 
 /*
+**  DKIMF_DB_CAN_WALK -- check if the db supports dkimf_db_walk operation
+**
+**  Parameters:
+**  	db -- database
+**
+**  Return value:
+**  	TRUE  -- supports
+**  	FALSE -- does not support
+*/
+
+_Bool
+dkimf_db_can_walk(DKIMF_DB db)
+{
+	assert(db != NULL);
+
+	switch (db->db_type)
+	{
+	  case DKIMF_DB_TYPE_REFILE:
+	  case DKIMF_DB_TYPE_SOCKET:
+	  case DKIMF_DB_TYPE_LUA:
+	  case DKIMF_DB_TYPE_MEMCACHE:
+	  case DKIMF_DB_TYPE_UNKNOWN:
+		return FALSE;
+	}
+	return TRUE;
+}
+
+/*
 **  DKIMF_DB_WALK -- walk a database
 **
 **  Parameters:
@@ -5832,13 +5860,14 @@ dkimf_db_walk(DKIMF_DB db, _Bool first, void *key, size_t *keylen,
 	    (key == NULL && keylen != NULL))
 		return -1;
 
-	if (db->db_type == DKIMF_DB_TYPE_REFILE ||
-	    db->db_type == DKIMF_DB_TYPE_SOCKET ||
-	    db->db_type == DKIMF_DB_TYPE_LUA)
-		return -1;
-
 	switch (db->db_type)
 	{
+	  case DKIMF_DB_TYPE_REFILE:
+	  case DKIMF_DB_TYPE_SOCKET:
+	  case DKIMF_DB_TYPE_LUA:
+	  case DKIMF_DB_TYPE_MEMCACHE:
+		return -1;
+
 	  case DKIMF_DB_TYPE_CSL:
 	  case DKIMF_DB_TYPE_FILE:
 	  {

--- a/opendkim/opendkim-db.h
+++ b/opendkim/opendkim-db.h
@@ -94,6 +94,7 @@ extern int dkimf_db_rewalk __P((DKIMF_DB, char *, DKIMF_DBDATA, unsigned int,
 extern void dkimf_db_set_ldap_param __P((int, char *));
 extern int dkimf_db_strerror __P((DKIMF_DB, char *, size_t));
 extern int dkimf_db_type __P((DKIMF_DB));
+extern _Bool dkimf_db_can_walk __P((DKIMF_DB));
 extern int dkimf_db_walk __P((DKIMF_DB, _Bool, void *, size_t *,
                               DKIMF_DBDATA, unsigned int));
 

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -8353,7 +8353,9 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 		**  missing KeyTable entries.
 		*/
 
-		if (conf->conf_signtabledb != NULL && conf->conf_checksigningtable != FALSE)
+		if (conf->conf_signtabledb != NULL &&
+		    conf->conf_checksigningtable != FALSE &&
+		    dkimf_db_can_walk(conf->conf_signtabledb))
 		{
 			_Bool first = TRUE;
 			_Bool found;


### PR DESCRIPTION
Fixes #218. Based on futatuki's PR #219.

`dkimf_db_walk()` had no case for `DKIMF_DB_TYPE_MEMCACHE`, so using a memcache dataset for `SigningTable` or `KeyTable` hit `assert(0)` on startup.

## Changes

- Add `dkimf_db_can_walk()` to test whether a DB type supports walking (memcache, refile, socket, lua, and unknown all return FALSE)
- Replace the ad-hoc `if` guard in `dkimf_db_walk()` with proper switch cases that return `-1` cleanly, including `DKIMF_DB_TYPE_MEMCACHE`
- Guard the `SigningTable` walk in `dkimf_config_load()` with `dkimf_db_can_walk()`, alongside the existing `CheckSigningTable` check

## Using memcache as a SigningTable

With this fix, memcache-backed `SigningTable` and `KeyTable` datasets work without needing to set `CheckSigningTable no`. The walk is skipped automatically for DB types that don't support it. Previously the workaround suggested in #218 was to use the `CheckSigningTable no` option (merged in #281), but `dkimf_db_can_walk()` makes that unnecessary for memcache users specifically.

Note: walking a memcache dataset is not supported by design — this fix ensures that limitation is handled cleanly rather than with an assertion failure.