### PR TITLE
Fix CVE-2022-48521: delete Authentication-Results headers in reverse

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -13653,8 +13653,15 @@ mlfi_eom(SMFICTX *ctx)
 			return SMFIS_TEMPFAIL;
 		}
 
-		c = 0;
+		c = 1;
+
 		for (hdr = dfc->mctx_hqhead; hdr != NULL; hdr = hdr->hdr_next)
+		{
+			if (strcasecmp(hdr->hdr_hdr, AUTHRESULTSHDR) == 0)
+				c++;
+		}
+
+		for (hdr = dfc->mctx_hqtail; hdr != NULL; hdr = hdr->hdr_prev)
 		{
 			memset(ares, '\0', sizeof(struct authres));
 
@@ -13666,7 +13673,7 @@ mlfi_eom(SMFICTX *ctx)
 				char *slash;
 
 				/* remember index */
-				c++;
+				c--;
 
 				/* parse the header */
 				arstat = ares_parse((u_char *) hdr->hdr_val,


### PR DESCRIPTION
Fixes #148. Closes #260 (partially — see CVE-2020-35766 / #113 which is tracked separately).

Incorporates glts's PR #189.

## The bug

`KeepAuthResults = no` (the default) removes incoming `Authentication-Results` headers by iterating forward through the header list and calling `smfi_chgheader()` with an incrementing index. However, each deletion shifts the indices of all subsequent headers, so the second and later deletions hit the wrong headers.

## The fix

- Count the total number of `Authentication-Results` headers first
- Iterate **backwards** through the header list, decrementing the index as we go

Deleting from the tail forward means each deletion only affects headers already processed, so indices remain correct throughout.

This is CVE-2022-48521.