### PR TITLE
tests: use ./testkeys instead of /tmp/testkeys (CVE-2020-35766)

### DIFF
--- a/libopendkim/tests/t-testdata.h
+++ b/libopendkim/tests/t-testdata.h
@@ -12,7 +12,7 @@
 #define	LARGEBODYSIZE	65536
 #define	LARGELINESIZE	4100
 
-#define	KEYFILE		"/tmp/testkeys"
+#define	KEYFILE		"./testkeys"
 
 #define	JOBID		"testing"
 #define	SELECTOR	"test"


### PR DESCRIPTION
Fixes #113. This is CVE-2020-35766.

The hardcoded `/tmp/testkeys` path is predictable and world-writable, allowing a local user to pre-create a symlink at that path and have it overwritten when the test suite runs. Changing to `./testkeys` confines the file to the build directory, which is under the control of the user running the tests.

This is a one-line change. A more configurable approach (using an `--with-test-keys` configure option) was discussed in #113 but the simple relative path is sufficient to address the CVE.