### PR TITLE
opendkim: fix SafeKeys error message reporting username instead of path

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -4597,7 +4597,7 @@ dkimf_checkfsnode(const char *path, uid_t myuid, char *myname, ino_t *ino,
 					{
 						snprintf(err, errlen,
 						         "%s is in group %u which has multiple users (e.g., \"%s\")",
-						         myname, s.st_gid,
+						         path, s.st_gid,
 						         pw->pw_name);
 					}
 
@@ -4625,7 +4625,7 @@ dkimf_checkfsnode(const char *path, uid_t myuid, char *myname, ino_t *ino,
 					{
 						snprintf(err, errlen,
 						         "%s is in group %u which has multiple users (e.g., \"%s\")",
-						         myname, s.st_gid,
+						         path, s.st_gid,
 						         gr->gr_mem[c]);
 					}
 


### PR DESCRIPTION
Fixes #249.

In `dkimf_checkfsnode()`, two error messages in the directory-handling block reported the local variable `myname` (the username of the process owner) instead of `path` (the directory being checked). The result was a confusing message like:

```
opendkim is in group 1001 which has multiple users (e.g., "alice")
```

when it should read:

```
/etc/mail/dkim is in group 1001 which has multiple users (e.g., "alice")
```

Fixed both `snprintf` calls to pass `path` instead of `myname`.