### PR TITLE
libopendkim: fix strlcpy destination size in dkim_diffheaders()

### DIFF
--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -6117,13 +6117,13 @@ dkim_ohdrs(DKIM *dkim, DKIM_SIGINFO *sig, u_char **ptrs, int *pcnt)
 		if (dkim->dkim_zdecode == NULL)
 		{
 			dkim_error(dkim, "unable to allocate %d byte(s)",
-			           strlen(z));
+			           MAXHEADERS);
 			return DKIM_STAT_NORESOURCE;
 		}
 	}
 
 	/* copy it */
-	strlcpy((char *) dkim->dkim_zdecode, z, strlen(z));
+	strlcpy((char *) dkim->dkim_zdecode, z, MAXHEADERS);
 
 	/* decode */
 	for (ch = (u_char *) strtok_r(z, "|", &last);


### PR DESCRIPTION
Fixes #86.

The `strlcpy` call in `dkim_diffheaders()` was passing `strlen(z)` (the source length) as the size argument instead of the destination buffer size. `strlcpy` expects the size of the destination, so using the source length would silently truncate the copy by one character and is what triggers the compiler warning.

The buffer is allocated with `MAXHEADERS` (32768 bytes), so the correct size argument is `MAXHEADERS`.

Also fixed the adjacent allocation error message which was reporting `strlen(z)` bytes when `MAXHEADERS` bytes are actually being allocated.

Neither the original code nor the proposed patch in the issue was correct:
- Original (`strlen(z)`): copies at most `strlen(z) - 1` characters, truncating by one
- Proposed (`strlen(dkim->dkim_zdecode)`): on freshly-allocated memory this is `strlen("") = 0`, copying nothing
- Correct: `MAXHEADERS`, matching the `DKIM_MALLOC(dkim, MAXHEADERS)` on the line above