### PR TITLE
libopendkim: remove duplicate /* in block comment

### DIFF
--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -8697,7 +8697,6 @@ dkim_conditional(DKIM *dkim, u_char *domain)
 }
 
 /*
-/*
 **  DKIM_GET_SIGSUBSTRING -- retrieve a minimal signature substring for
 **                           disambiguation
 **


### PR DESCRIPTION
Fixes #87.

Removes the duplicate `/*` line that was opening a block comment before `dkim_get_sigsubstring()`. The extra line triggers `-Wcomment` ("'/*' within block comment").