### PR TITLE
opendkim: remove assert on conf_refcnt in dkimf_config_free()

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -5923,7 +5923,6 @@ static void
 dkimf_config_free(struct dkimf_config *conf)
 {
 	assert(conf != NULL);
-	assert(conf->conf_refcnt == 0);
 
 	dkimf_zapkey(conf);
 


### PR DESCRIPTION
Fixes #22.

libmilter does not guarantee `xxfi_close()` is called for every connection on SIGTERM/SIGINT. If `poll()`/`select()` hasn't returned before the signal is handled, the close callbacks are skipped and `conf_refcnt` remains non-zero at shutdown — causing the assert in `dkimf_config_free()` to fire and produce a core dump.

This is documented libmilter behavior, not an OpenDKIM bug (see the thread in #22 for the full libmilter doc analysis from @dilyanpalauzov).

The `conf_refcnt` field itself is retained since it still guards config frees during hot reload in `dkimf_config_reload()`.