### PR TITLE
libopendkim: use first TXT record when multiple DKIM key records found

### DIFF
--- a/libopendkim/dkim-keys.c
+++ b/libopendkim/dkim-keys.c
@@ -284,6 +284,10 @@ dkim_get_key_dns(DKIM *dkim, DKIM_SIGINFO *sig, u_char *buf, size_t buflen)
 	if (ancount == 0)
 		return DKIM_STAT_NOKEY;
 
+	if (ancount > 1)
+		dkim_error(dkim, "multiple DNS replies for '%s', using first",
+		           qname);
+
 	/*
 	**  Extract the data from the first TXT answer.
 	*/
@@ -338,9 +342,8 @@ dkim_get_key_dns(DKIM *dkim, DKIM_SIGINFO *sig, u_char *buf, size_t buflen)
 
 		if (txtfound != NULL)
 		{
-			dkim_error(dkim, "multiple DNS replies for '%s'",
-			           qname);
-			return DKIM_STAT_MULTIDNSREPLY;
+			cp += n;
+			continue;
 		}
 
 		/* remember where this one started */


### PR DESCRIPTION
Fixes #123.

Previously `dkim_get_key_dns()` returned `DKIM_STAT_MULTIDNSREPLY` when a second TXT record was encountered, causing verification to fail hard for any domain with duplicate key records in DNS.

Changed behavior: log a warning at the point where `ancount > 1` is detected, then skip any subsequent TXT records and proceed with the first one returned by DNS.

RFC 6376 Section 6.1.2 explicitly leaves multi-record handling to implementer discretion. Using the first record and warning is consistent with the intent discussed in the issue.