### PR TITLE
libopendkim/tests: fix make -j check failures due to parallel test ordering

### DIFF
--- a/libopendkim/tests/Makefile.am
+++ b/libopendkim/tests/Makefile.am
@@ -17,7 +17,7 @@ endif
 
 PROF_SRCS = base64.c dkim-cache.c dkim-canon.c dkim-keys.c dkim-mailparse.c dkim-policy.c dkim-rep.c dkim-strl.c dkim-tables.c dkim-test.c dkim-ub.c dkim-util.c dkim.c util.c
 
-check_PROGRAMS = t-setup t-test00 t-test01 t-test02 t-test03 t-test04 \
+check_PROGRAMS = t-test00 t-test01 t-test02 t-test03 t-test04 \
 	t-test05 t-test06 t-test07 t-test08 t-test09 t-test10 t-test11 \
 	t-test12 t-test13 t-test14 t-test15 t-test16 t-test17 t-test18 \
 	t-test19 t-test20 t-test21 t-test22 t-test23 t-test24 t-test25 \
@@ -48,8 +48,14 @@ check_SCRIPTS = t-signperf-sha1 t-signperf-relaxed-relaxed \
 if ALL_SYMBOLS
 check_PROGRAMS += t-test49 t-test113 t-test118
 endif
-check_PROGRAMS += t-cleanup
+noinst_PROGRAMS = t-setup t-cleanup
 TESTS = $(check_PROGRAMS) $(check_SCRIPTS)
+
+testkeys: t-setup$(EXEEXT)
+	./t-setup$(EXEEXT)
+
+check_DATA = testkeys
+CLEANFILES += testkeys
 
 EXTRA_DIST = $(check_SCRIPTS)
 


### PR DESCRIPTION
Fixes #110. Also relates to #113.

`t-setup` and `t-cleanup` were listed in `TESTS`, meaning under `make -j<N> check` they could run in any order — other tests would race ahead before `t-setup` had written `./testkeys`, causing them to fail with missing key material.

**Changes:**
- Move `t-setup` and `t-cleanup` to `noinst_PROGRAMS` so they still build but are no longer executed as tests
- Add a `testkeys` Make target that runs `./t-setup` to generate the key file
- Add `testkeys` to `check_DATA` so automake ensures it exists as a prerequisite of `check-am`, before any tests run in parallel
- Add `testkeys` to `CLEANFILES` so `make clean` handles removal (replacing what `t-cleanup` used to do)

This follows the approach suggested by @orlitzky in the issue.