### PR TITLE
configure.ac: include prerequisite headers before checking for res_ninit()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ build-config.h.in
 compile
 config.guess
 config.sub
+configure
 configure.scan
 configure.lineno
 aclocal.m4

--- a/configure.ac
+++ b/configure.ac
@@ -116,10 +116,26 @@ AC_SEARCH_LIBS(getaddrinfo, resolv,
 # it, it conflicts with AC_LANG_CALL's redeclaration. Hmm. I guess the
 # only thing for it is to include resolv.h, don't redeclare res_ninit(),
 # and use the proper type signature when calling it.
+
+# Before using resolv.h, we need to check headers required for it.
+AC_HEADER_RESOLV
+
 m4_rename([AC_LANG_CALL], [saved_AC_LANG_CALL])
-m4_define([AC_LANG_CALL], [AC_LANG_PROGRAM([#include <resolv.h>],
+m4_define([AC_LANG_CALL], [AC_LANG_PROGRAM([#ifdef HAVE_SYS_TYPES_H
+#  include <sys/types.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#  include <netinet/in.h>
+#endif
+#ifdef HAVE_ARPA_NAMESER_H
+#  include <arpa/nameser.h>
+#endif
+#ifdef HAVE_NETDB_H
+#  include <netdb.h>
+#endif
+#include <resolv.h>],
                                            [return res_ninit(NULL);])])
-AC_SEARCH_LIBS(res_ninit, resolv,
+AC_SEARCH_LIBS(res_ninit, resolv bind,
                AC_DEFINE(HAVE_RES_NINIT, 1,
                          [Define to 1 if you have the `res_ninit()' function.]))
 m4_rename_force([saved_AC_LANG_CALL], [AC_LANG_CALL])
@@ -129,8 +145,6 @@ AC_SEARCH_LIBS(res_setservers, resolv bind,
 AC_SEARCH_LIBS(getopt_long, iberty,
                AC_DEFINE(HAVE_GETOPT_LONG, 1,
                          [Define to 1 if you have the `getopt_long()' function.]))
-
-AC_HEADER_RESOLV
 
 #
 # Check for types


### PR DESCRIPTION
Fixes #203. Based on PR #204 by @futatuki.

On FreeBSD 14 (and other non-glibc platforms), `resolv.h` requires `sys/types.h`, `netinet/in.h`, `arpa/nameser.h`, and `netdb.h` to be included first. The configure check for `res_ninit()` was including only `resolv.h`, so the compile test failed and `res_ninit()` went undetected on these platforms.

Changes:
- Move `AC_HEADER_RESOLV` to before the `res_ninit` check (it was previously called after)
- Add the prerequisite headers to the test program, guarded by their `HAVE_*` defines
- Add `bind` as a fallback library in `AC_SEARCH_LIBS` (needed on some BSDs where resolver functions live in `-lbind`)
- Add `configure` to `.gitignore` — it is a generated file and should not be tracked
