### PR TITLE
libopendkim, librbl: fix syntax errors in res_nslist functions

### DIFF
--- a/libopendkim/dkim-dns.c
+++ b/libopendkim/dkim-dns.c
@@ -273,7 +273,7 @@ dkim_res_nslist(void *srv, const char *nslist)
 	struct sockaddr_in6 in6;
 # endif /* AF_INET6 */
 	struct __res_state *res;
-	res_sockaddr_union nses[MAXNS];
+	union res_sockaddr_union nses[MAXNS];
 
 	assert(srv != NULL);
 	assert(nslist != NULL);
@@ -286,7 +286,7 @@ dkim_res_nslist(void *srv, const char *nslist)
 
 	for (ns = strtok_r(tmp, ",", &last);
 	     ns != NULL && nscount < MAXNS;
-	     ns = strtok_r(NULL, ",", &last)
+	     ns = strtok_r(NULL, ",", &last))
 	{
 		memset(&in, '\0', sizeof in);
 # ifdef AF_INET6

--- a/librbl/rbl.c
+++ b/librbl/rbl.c
@@ -259,7 +259,7 @@ rbl_res_nslist(void *srv, const char *nslist)
 	struct sockaddr_in6 in6;
 # endif /* AF_INET6 */
 	struct __res_state *res;
-	res_sockaddr_union nses[MAXNS];
+	union res_sockaddr_union nses[MAXNS];
 
 	assert(srv != NULL);
 	assert(nslist != NULL);
@@ -272,7 +272,7 @@ rbl_res_nslist(void *srv, const char *nslist)
 
 	for (ns = strtok_r(tmp, ",", &last);
 	     ns != NULL && nscount < MAXNS;
-	     ns = strtok_r(NULL, ",", &last)
+	     ns = strtok_r(NULL, ",", &last))
 	{
 		memset(&in, '\0', sizeof in);
 # ifdef AF_INET6


### PR DESCRIPTION
Fixes #199.

Two bugs in both `dkim-dns.c` (`dkim_res_nslist`) and `rbl.c` (`rbl_res_nslist`), both inside `#ifdef HAVE_RES_SETSERVERS`:

1. `res_sockaddr_union nses[MAXNS]` -> `union res_sockaddr_union nses[MAXNS]` — missing `union` keyword, rejected by strict C compilers
2. `ns = strtok_r(NULL, ",", &last)` -> `ns = strtok_r(NULL, ",", &last))` — missing closing `)` on the for-loop increment, a syntax error that prevented compilation whenever `HAVE_RES_SETSERVERS` was defined