### PR TITLE
issue #107: document that SignatureAlgorithm must be set for Ed25519 keys

### DIFF
--- a/opendkim/opendkim.conf.5.in
+++ b/opendkim/opendkim.conf.5.in
@@ -346,6 +346,11 @@ Gives the location of a PEM-formatted private key to be used for signing
 all messages.  Ignored if a
 .I KeyTable
 is defined.
+If the key is an Ed25519 key, you must also set
+.I SignatureAlgorithm
+to
+.I ed25519-sha256;
+the algorithm is not auto-detected from the key type.
 
 .TP
 .I KeyTable (dataset)
@@ -1007,6 +1012,13 @@ The default is
 .I rsa-sha256
 if it is available, otherwise it will be
 .I rsa-sha1.
+This setting must match the type of key specified by
+.I KeyFile
+or the key's entry in
+.I KeyTable.
+In particular, Ed25519 keys require this to be set to
+.I ed25519-sha256
+explicitly, as the algorithm is not auto-detected from the key type.
 
 .TP
 .I SignatureTTL (integer)


### PR DESCRIPTION
## Summary

- Adds a note to the `KeyFile` entry that Ed25519 keys require `SignatureAlgorithm ed25519-sha256` to be set explicitly
- Adds a note to the `SignatureAlgorithm` entry that the setting must match the key type, and that Ed25519 keys are not auto-detected

This is a documentation-only stopgap until auto-detection from key type is implemented (tracked in #107).

Related: #107