### PR TITLE
issue #40: preserve user's primary group when explicit group given in UserID

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -16728,7 +16728,7 @@ main(int argc, char **argv)
 			/* make all the process changes */
 			if (getuid() != pw->pw_uid)
 			{
-				if (initgroups(pw->pw_name, gid) != 0)
+				if (initgroups(pw->pw_name, pw->pw_gid) != 0)
 				{
 					if (curconf->conf_dolog)
 						syslog(LOG_ERR, "initgroups(): %s", strerror(errno));
@@ -16988,7 +16988,7 @@ main(int argc, char **argv)
 		/* make all the process changes */
 		if (getuid() != pw->pw_uid)
 		{
-			if (initgroups(pw->pw_name, gid) != 0)
+			if (initgroups(pw->pw_name, pw->pw_gid) != 0)
 			{
 				if (curconf->conf_dolog)
 					syslog(LOG_ERR, "initgroups(): %s", strerror(errno));


### PR DESCRIPTION
## Summary

When `UserID` is configured as `user:group` (e.g. `opendkim:dkimsocket`), `initgroups()` was being called with the explicit group GID as its second argument. The second argument to `initgroups()` is an "additional" group added to the supplemental list — but it does not guarantee the user's primary group from `/etc/passwd` is included unless that group also appears in `/etc/group` as an explicit membership.

This meant that on systems where the user's primary group only exists as the `/etc/passwd` entry (not as a supplemental `/etc/group` entry), the process would lose access to resources owned by that primary group — e.g. private key files owned by the `opendkim` group when `UserID opendkim:dkimsocket` was set.

**Fix:** Pass `pw->pw_gid` (the user's primary group) to `initgroups()` in both privilege-drop paths. `setgid()` still sets the process's primary GID to the explicitly requested group, so socket ownership behaviour is unchanged.

Fixes #40