### PR TITLE
issue #233: use dkim=policy for ignored signatures in AR header

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -10698,6 +10698,7 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, struct dkimf_dstring *tmpstr,
 
 		for (c = 0; c < nsigs; c++)
 		{
+			unsigned int sigflag;
 			dnssec = NULL;
 
 			memset(comment, '\0', sizeof comment);
@@ -10719,7 +10720,12 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, struct dkimf_dstring *tmpstr,
 				                           &ssl);
 			}
 
-			if ((dkim_sig_getflags(sigs[c]) & DKIM_SIGFLAG_PASSED) != 0 &&
+			sigflag = dkim_sig_getflags(sigs[c]);
+			if (sigflag & DKIM_SIGFLAG_IGNORE)
+			{
+				result = "policy";
+			}
+			else if ((sigflag & DKIM_SIGFLAG_PASSED) != 0 &&
 			    dkim_sig_getbh(sigs[c]) == DKIM_SIGBH_MATCH)
 			{
 				result = "pass";
@@ -10743,8 +10749,8 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, struct dkimf_dstring *tmpstr,
 					         " reason=\"%s\"", err);
 				}
 			}
-			else if ((dkim_sig_getflags(sigs[c]) & DKIM_SIGFLAG_PROCESSED) != 0 &&
-			         ((dkim_sig_getflags(sigs[c]) & DKIM_SIGFLAG_PASSED) == 0 ||
+			else if ((sigflag & DKIM_SIGFLAG_PROCESSED) != 0 &&
+			         ((sigflag & DKIM_SIGFLAG_PASSED) == 0 ||
 			          dkim_sig_getbh(sigs[c]) != DKIM_SIGBH_MATCH))
 			{
 				const char *err;


### PR DESCRIPTION
## Summary

When a DKIM signature is marked as ignored via `dkim_sig_ignore()`, the milter was still emitting `dkim=fail` in the `Authentication-Results` header. Per RFC 8601 §2.7.1, the correct result for a signature not evaluated due to a policy decision is `dkim=policy`.

Also caches the `dkim_sig_getflags()` result to avoid redundant calls.

Cherry-picked from @futatuki's PR #234.

Fixes #233