### PR TITLE
issue #108: fix always-false header character validity check

### DIFF
--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -6498,9 +6498,9 @@ dkim_header(DKIM *dkim, u_char *hdr, size_t len)
 		else
 		{
 			/* field bodies are printable ASCII, SP, HT, CR, LF */
-			if (!(hdr[c] != 9 ||  /* HT */
-			      hdr[c] != 10 || /* LF */
-			      hdr[c] != 13 || /* CR */
+			if (!(hdr[c] == 9 ||  /* HT */
+			      hdr[c] == 10 || /* LF */
+			      hdr[c] == 13 || /* CR */
 			      (hdr[c] >= 32 && hdr[c] <= 126) /* SP, print */ ))
 				return DKIM_STAT_SYNTAX;
 		}


### PR DESCRIPTION
## Summary

The header field body character validity check in `libopendkim/dkim.c` used `!=` with OR, which is a tautology — no single byte value can simultaneously differ from 9, 10, and 13, so the entire condition is always true and `!(always true)` is always false. The `return DKIM_STAT_SYNTAX` was dead code and invalid bytes in header field bodies were silently accepted.

Fix: change `!=` to `==` so the expression correctly returns `DKIM_STAT_SYNTAX` for any byte that is not HT (9), LF (10), CR (13), or printable ASCII (32–126).

Thanks to @hdatma for the diagnosis and proposed fix.

Fixes #108