### PR TITLE
issue #181: make libunbound honor /etc/resolv.conf nameservers by default

### DIFF
--- a/opendkim/opendkim-dns.c
+++ b/opendkim/opendkim-dns.c
@@ -602,6 +602,10 @@ dkimf_ub_init(void **ub)
 		return DKIM_DNS_ERROR;
 	}
 
+	/* use system nameservers from /etc/resolv.conf if available;
+	   ignore errors and fall back to full resolver mode */
+	(void) ub_ctx_resolvconf(out->ub_ub, "/etc/resolv.conf");
+
 	/* suppress debug output */
 	(void) ub_ctx_debugout(out->ub_ub, NULL);
 


### PR DESCRIPTION
## Summary

When opendkim is built with libunbound and `Nameservers` is not set in the config, libunbound was acting as a full recursive resolver — querying root servers directly rather than using the system's configured nameservers from `/etc/resolv.conf`. This caused:

- Failures for large DNS responses (UDP truncation, no TCP fallback via the local resolver)
- Breakage on systems with split-horizon or forwarding-only DNS setups
- The confusing "unexpected reply class/type (-1/-1)" error on records that work fine with other tools

**Fix:** Call `ub_ctx_resolvconf()` during `dkimf_ub_init()` to load `/etc/resolv.conf`. Errors are silently ignored so behavior gracefully falls back to full resolver mode when `resolv.conf` is absent. An explicit `Nameservers` config option continues to override this, as before (that path calls `ub_ctx_set_fwd()` which overrides the resolv.conf settings).

Thanks to @futatuki for the diagnosis and patch in the issue thread.

Fixes #181