### PR TITLE
issue #177: relax minimum autoconf version from 2.71 to 2.69

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@
 #
 # Setup
 #
-AC_PREREQ([2.71])
+AC_PREREQ([2.69])
 
 #
 # Package version


### PR DESCRIPTION
## Summary

Relaxes `AC_PREREQ` from 2.71 to 2.69. Autoconf 2.69 ships with Debian 11, Ubuntu 20.04 LTS, RHEL 9, SUSE 15, and many other current distributions. Requiring 2.71 unnecessarily prevents development on these platforms. The rest of `configure.ac` is compatible with 2.69.

Cherry-picked from @futatuki's PR #263.

Fixes #177