### PR TITLE
issue #178: relax OpenSSL version check to ignore patch letter and status

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -15969,7 +15969,7 @@ main(int argc, char **argv)
 #ifdef USE_GNUTLS
 	if (dkim_ssl_version() != GNUTLS_VERSION_NUMBER * 256)
 #else /* USE_GNUTLS */
-	if (dkim_ssl_version() != OPENSSL_VERSION_NUMBER)
+	if ((dkim_ssl_version() >> 8) != (OPENSSL_VERSION_NUMBER >> 8))
 #endif /* USE_GNUTLS */
 	{
 		fprintf(stderr,


### PR DESCRIPTION
## Summary

The runtime OpenSSL version check compared the full `OPENSSL_VERSION_NUMBER`, which encodes major, minor, fix, patch letter, and release status. Patch releases within the same major.minor.fix series (e.g. 1.1.1a through 1.1.1n, or 3.0.0 through 3.0.x) are ABI-stable, so rejecting them as "incompatible" was incorrect.

The fix shifts both the library version and the compiled-in version right by 8 bits before comparing, stripping the patch letter and release status nibbles. A mismatch in major, minor, or fix version still triggers the error.

Fixes #178