### PR TITLE
issue #176: fix DKIM_STAT_KEYFAIL handling — DNS errors now honour On-DNSError

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -9610,12 +9610,14 @@ dkimf_libstatus(SMFICTX *ctx, DKIM *dkim, char *where, int status)
 			retcode = dkimf_miltercode(ctx,
 			                           conf->conf_handling.hndl_dnserr,
 			                           NULL);
+			replytxt = "DKIM key retrieval timeout";
 		}
 		else
 		{
 			retcode = dkimf_miltercode(ctx,
 			                           conf->conf_handling.hndl_nokey,
 			                           NULL);
+			replytxt = "DKIM key retrieval failed";
 		}
 
 		if (conf->conf_dolog)
@@ -9653,7 +9655,6 @@ dkimf_libstatus(SMFICTX *ctx, DKIM *dkim, char *where, int status)
 				       err == NULL ? "" : err);
 			}
 		}
-		replytxt = "DKIM key retrieval failed";
 		break;
 
 	  case DKIM_STAT_SYNTAX:

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -9637,16 +9637,18 @@ dkimf_libstatus(SMFICTX *ctx, DKIM *dkim, char *where, int status)
 			if (selector != NULL && domain != NULL)
 			{
 				syslog(LOG_ERR,
-				       "%s: key retrieval failed (s=%s, d=%s)%s%s",
+				       "%s: %s (s=%s, d=%s)%s%s",
 				       JOBID(dfc->mctx_jobid), selector,
+				       dkimf_lookup_inttostr(status, dkimf_statusstrings),
 				       domain,
 				       err == NULL ? "" : ": ",
 				       err == NULL ? "" : err);
 			}
 			else
 			{
-				syslog(LOG_ERR, "%s: key retrieval failed%s%s",
+				syslog(LOG_ERR, "%s: key %s%s%s",
 				       JOBID(dfc->mctx_jobid),
+				       dkimf_lookup_inttostr(status, dkimf_statusstrings),
 				       err == NULL ? "" : ": ",
 				       err == NULL ? "" : err);
 			}

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -13307,17 +13307,18 @@ mlfi_eoh(SMFICTX *ctx)
 #ifdef USE_LUA
 	if (conf->conf_screenscript != NULL)
 	{
+		int hkstat;
 		_Bool dofree = TRUE;
 		struct dkimf_lua_script_result lres;
 
 		memset(&lres, '\0', sizeof lres);
 
-		status = dkimf_lua_screen_hook(ctx, conf->conf_screenfunc,
+		hkstat = dkimf_lua_screen_hook(ctx, conf->conf_screenfunc,
 		                               conf->conf_screenfuncsz,
 		                               "screen script", &lres,
 		                               NULL, NULL);
 
-		if (status != 0)
+		if (hkstat != 0)
 		{
 			if (conf->conf_dolog)
 			{
@@ -13325,7 +13326,7 @@ mlfi_eoh(SMFICTX *ctx)
 				{
 					dofree = FALSE;
 
-					switch (status)
+					switch (hkstat)
 					{
 					  case 2:
 						lres.lrs_error = "processing error";

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -13513,7 +13513,7 @@ mlfi_eom(SMFICTX *ctx)
 	_Bool authorsig;
 	int status = DKIM_STAT_OK;
 	int c;
-	sfsistat ret;
+	sfsistat ret = SMFIS_ACCEPT;
 	connctx cc;
 	msgctx dfc;
 	DKIM *lastdkim = NULL;
@@ -13985,8 +13985,8 @@ mlfi_eom(SMFICTX *ctx)
 				                     (char *) dfc->mctx_jobid);
 			}
 
-			status = dkimf_libstatus(ctx, dfc->mctx_dkimv,
-			                         "dkim_eom()", status);
+			ret = dkimf_libstatus(ctx, dfc->mctx_dkimv,
+			                      "dkim_eom()", status);
 
 #ifdef SMFIF_QUARANTINE
 			if (dfc->mctx_capture)
@@ -14002,7 +14002,7 @@ mlfi_eom(SMFICTX *ctx)
 					}
 				}
 
-				status = SMFIS_ACCEPT;
+				ret = SMFIS_ACCEPT;
 			}
 #endif /* ! SMFIF_QUARANTINE */
 			break;
@@ -15368,8 +15368,6 @@ mlfi_eom(SMFICTX *ctx)
 	/*
 	**  If we got this far, we're ready to complete.
 	*/
-
-	ret = SMFIS_ACCEPT;
 
 	/* translate the stored status */
 	switch (dfc->mctx_status)

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -13382,6 +13382,11 @@ mlfi_eoh(SMFICTX *ctx)
 		dfc->mctx_addheader = TRUE;
 		return SMFIS_CONTINUE;
 
+	  case DKIM_STAT_KEYFAIL:
+		dfc->mctx_addheader = TRUE;
+		dfc->mctx_status = DKIMF_STATUS_KEYFAIL;
+		return SMFIS_CONTINUE;
+
 	  case DKIM_STAT_SYNTAX:
 		dfc->mctx_status = DKIMF_STATUS_BADFORMAT;
 		dfc->mctx_addheader = TRUE;


### PR DESCRIPTION
## Summary

When DKIM key retrieval failed due to a DNS error/timeout, opendkim was calling `smfi_setreply()` with a 451 code but then returning `SMFIS_ACCEPT`, so the MTA ignored the reply code and accepted the message.

The root cause was a confusion between `ret` (the milter return value) and `status` (the DKIM status code) in the default case of the `dkim_eom()` result switch in `mlfi_eom()`. The result of `dkimf_libstatus()` was stored back into `status` (an `int`) rather than `ret` (an `sfsistat`), so it was immediately overwritten by `ret = SMFIS_ACCEPT` at the end of the function.

This is a cherry-pick of @futatuki's PR #262, preferred over PR #254 because:
- PR #254 conflates `DKIM_STAT_KEYFAIL` (DNS error) with `DKIM_STAT_NOKEY` (key not found), causing `On-DNSError` to behave like `On-KeyNotFound`
- This fix adds a proper `DKIMF_STATUS_KEYFAIL` status so the two conditions are handled and reported distinctly

**Changes (5 commits):**
- Distinguish error log messages between no-key and DNS timeout
- Distinguish reply text between no-key and DNS timeout  
- Fix Lua screen hook variable shadowing in `mlfi_eoh()`
- Fix `ret` vs `status` confusion in `mlfi_eom()` (root cause)
- Postpone `DKIM_STAT_KEYFAIL` handling in `mlfi_eoh()` so `mlfi_eom()` can apply the correct `On-DNSError` policy

Fixes #176