### PR TITLE
issue #240: warn when KeyFile is set alongside KeyTable

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -7494,6 +7494,15 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 		{
 			int status;
 			char *dberr = NULL;
+			char *ignored_keyfile = NULL;
+
+			(void) config_get(data, "KeyFile", &ignored_keyfile,
+			                  sizeof ignored_keyfile);
+			if (ignored_keyfile != NULL)
+			{
+				syslog(LOG_WARNING,
+				       "KeyFile is ignored when KeyTable is set");
+			}
 
 			status = dkimf_db_open(&conf->conf_keytabledb,
 			                       conf->conf_keytable,


### PR DESCRIPTION
## Summary

When `KeyTable` is present in the config, `KeyFile` is silently ignored. If the user also has `Selector` set (or it is provided on the command line, as NixOS does unconditionally), they get the confusing error `KeyFile and Selector must both be defined or both be undefined` — because the actual condition being enforced is that neither may be present when `KeyTable` is used.

This emits a `LOG_WARNING` to syslog when `KeyFile` is set alongside `KeyTable`, making the misconfiguration immediately visible rather than silently swallowed.

Fixes #240