### PR TITLE
issue #49: distinguish NXDOMAIN from DNS error in stub resolver

### DIFF
--- a/libopendkim/dkim-dns.c
+++ b/libopendkim/dkim-dns.c
@@ -183,7 +183,30 @@ dkim_res_query(void *srv, int type, unsigned char *query, unsigned char *buf,
 	ret = res_query((char *) query, C_IN, type, buf, buflen);
 #endif /* HAVE_RES_NINIT */
 	if (ret == -1)
-		return DKIM_DNS_ERROR;
+	{
+		/* NXDOMAIN/NODATA: synthesize a minimal NXDOMAIN response so
+		   dkim-keys.c can distinguish "key doesn't exist" (NOKEY)
+		   from a DNS error (KEYFAIL/tempfail) */
+		if (h_errno == HOST_NOT_FOUND || h_errno == NO_DATA)
+		{
+			if (buflen >= HFIXEDSZ)
+			{
+				memset(buf, '\0', HFIXEDSZ);
+				hdr = (HEADER *) buf;
+				hdr->qr = 1;
+				hdr->rcode = NXDOMAIN;
+				ret = HFIXEDSZ;
+			}
+			else
+			{
+				return DKIM_DNS_ERROR;
+			}
+		}
+		else
+		{
+			return DKIM_DNS_ERROR;
+		}
+	}
 
 	rq = (struct dkim_res_qh *) malloc(sizeof *rq);
 	if (rq == NULL)
@@ -194,16 +217,8 @@ dkim_res_query(void *srv, int type, unsigned char *query, unsigned char *buf,
 		rq->rq_dnssec = DKIM_DNSSEC_SECURE;
 	else
 		rq->rq_dnssec = DKIM_DNSSEC_INSECURE;
-	if (ret == -1)
-	{
-		rq->rq_error = errno;
-		rq->rq_buflen = 0;
-	}
-	else
-	{
-		rq->rq_error = 0;
-		rq->rq_buflen = (size_t) ret;
-	}
+	rq->rq_error = 0;
+	rq->rq_buflen = (size_t) ret;
 
 	*qh = (void *) rq;
 

--- a/libopendkim/dkim-keys.c
+++ b/libopendkim/dkim-keys.c
@@ -232,6 +232,15 @@ dkim_get_key_dns(DKIM *dkim, DKIM_SIGINFO *sig, u_char *buf, size_t buflen)
 	cp = (u_char *) &ansbuf + HFIXEDSZ;
 	eom = (u_char *) &ansbuf + anslen;
 
+	/* if NXDOMAIN, return DKIM_STAT_NOKEY immediately (before parsing
+	   the question section, so a minimal NXDOMAIN response with
+	   qdcount=0 is handled correctly) */
+	if (hdr.rcode == NXDOMAIN)
+	{
+		dkim_error(dkim, "'%s' record not found", qname);
+		return DKIM_STAT_NOKEY;
+	}
+
 	/* skip over the name at the front of the answer */
 	for (qdcount = ntohs((unsigned short) hdr.qdcount);
 	     qdcount > 0;
@@ -240,7 +249,7 @@ dkim_get_key_dns(DKIM *dkim, DKIM_SIGINFO *sig, u_char *buf, size_t buflen)
 		/* copy it first */
 		(void) dn_expand((unsigned char *) &ansbuf, eom, cp,
 		                 (char *) qname, sizeof qname);
- 
+
 		if ((n = dn_skipname(cp, eom)) < 0)
 		{
 			dkim_error(dkim, "'%s' reply corrupt", qname);
@@ -263,13 +272,6 @@ dkim_get_key_dns(DKIM *dkim, DKIM_SIGINFO *sig, u_char *buf, size_t buflen)
 		dkim_error(dkim, "'%s' unexpected reply class/type (%d/%d)",
 		           qname, class, type);
 		return DKIM_STAT_KEYFAIL;
-	}
-
-	/* if NXDOMAIN, return DKIM_STAT_NOKEY */
-	if (hdr.rcode == NXDOMAIN)
-	{
-		dkim_error(dkim, "'%s' record not found", qname);
-		return DKIM_STAT_NOKEY;
 	}
 
 	/* if truncated, we can't do it */


### PR DESCRIPTION
## Summary

When the stock resolver (`res_query`/`res_nquery`) returns -1, it could indicate either a transport error (SERVFAIL, timeout) or an authoritative NXDOMAIN. Both were being treated as `DKIM_DNS_ERROR`, which maps to `DKIM_STAT_KEYFAIL` (tempfail) in `dkim-keys.c`. Per RFC 6376, NXDOMAIN means the key genuinely doesn't exist and should produce `DKIM_STAT_NOKEY` (permfail).

**Fix (two parts):**

1. **`dkim-dns.c`**: After a `-1` return from `res_query`, check `h_errno`. For `HOST_NOT_FOUND` or `NO_DATA` (authoritative negative responses), synthesize a minimal NXDOMAIN DNS response header and return `DKIM_DNS_SUCCESS`, so the normal parsing path in `dkim-keys.c` sees the NXDOMAIN rcode. All other errors continue to return `DKIM_DNS_ERROR`.

2. **`dkim-keys.c`**: Move the `hdr.rcode == NXDOMAIN` check to before the question section parsing loop. This allows the minimal synthesized response (with `qdcount=0`) to be handled correctly without reading uninitialized `type`/`class` variables.

This is specific to the stub resolver path. The libunbound path handles NXDOMAIN correctly via the response packet's rcode already.

Fixes #49