### PR TITLE
libopendkim: fix assert in dkim_canon_selecthdrs when all headers are skipped

### DIFF
--- a/libopendkim/dkim-canon.c
+++ b/libopendkim/dkim-canon.c
@@ -971,7 +971,8 @@ dkim_canon_selecthdrs(DKIM *dkim, u_char *hdrlist, struct dkim_header **ptrs,
 
 	assert(dkim != NULL);
 	assert(ptrs != NULL);
-	assert(nptrs != 0);
+	if (nptrs == 0)
+		return 0;
 
 	/* if there are no headers named, use them all */
 	if (hdrlist == NULL)
@@ -1145,7 +1146,7 @@ dkim_canon_runheaders(DKIM *dkim)
 	end = tmpbuf + sizeof tmpbuf - 1;
 
 	n = dkim->dkim_hdrcnt * sizeof(struct dkim_header *);
-	hdrset = DKIM_MALLOC(dkim, n);
+	hdrset = DKIM_MALLOC(dkim, n > 0 ? n : 1);
 	if (hdrset == NULL)
 		return DKIM_STAT_NORESOURCE;
 


### PR DESCRIPTION
Fixes #174.

## Root cause

When signing with `DKIM_OPTS_SKIPHDRS` matching all headers in a message,
`dkim_header()` returns early (without incrementing `dkim_hdrcnt`) for each
skipped header. After processing, `dkim_hdrcnt` remains 0.

`dkim_canon_runheaders()` then calls `DKIM_MALLOC(dkim, 0)` (undefined
behavior on some platforms, returns NULL on others), and passes `nptrs=0`
to `dkim_canon_selecthdrs()`, which hits `assert(nptrs != 0)`.

The test case in the issue uses a message with only a `Return-Path` header,
which is in `dkim_should_not_signhdrs`, so all headers are skipped.

## Fix

Two minimal changes in `libopendkim/dkim-canon.c`:

1. In `dkim_canon_runheaders()`: allocate at least 1 byte to avoid `malloc(0)`.
2. In `dkim_canon_selecthdrs()`: replace `assert(nptrs != 0)` with a graceful
   return of 0 (zero headers selected), which the callers already handle correctly.