### PR TITLE
opendkim-db: fix ldapi:// URI reconstruction dropping socket path

### DIFF
--- a/opendkim/opendkim-db.c
+++ b/opendkim/opendkim-db.c
@@ -2898,10 +2898,15 @@ dkimf_db_open(DKIMF_DB *db, char *name, u_int flags, pthread_mutex_t *lock,
 				rem--;
 			}
 
-			plen = snprintf(q, rem, "%s://%s:%d",
-			                descr->lud_scheme,
-			                descr->lud_host,
-			                descr->lud_port);
+			if (strcmp(descr->lud_scheme, "ldapi") == 0)
+				plen = snprintf(q, rem, "%s://%s",
+				                descr->lud_scheme,
+				                descr->lud_host ? descr->lud_host : "");
+			else
+				plen = snprintf(q, rem, "%s://%s:%d",
+				                descr->lud_scheme,
+				                descr->lud_host,
+				                descr->lud_port);
 
 			if (plen >= rem)
 			{


### PR DESCRIPTION
Fixes #167.

## Root cause

When building the URI list passed to `ldap_initialize()`, `opendkim-db.c`
reconstructs each URI from the parsed `LDAPURLDesc` as `scheme://host:port`.

For `ldapi://` (Unix domain socket) URIs, the socket path is encoded as the
host component (e.g. `%2Fpath%2Fto%2Fldapi`), and there is no port. Appending
`:port` (`:0` or `:389`) to an ldapi URI causes libldap to discard the socket
path and fall back to its compiled-in default (typically
`/usr/local/var/run/ldapi`).

## Fix

When the scheme is `ldapi`, omit the port from the reconstructed URI, and
guard against a `NULL` `lud_host`. All other schemes continue to use the
existing `scheme://host:port` format.