### PR TITLE
contrib/systemd: use network-online.target for reliable startup

### DIFF
--- a/contrib/systemd/opendkim.service.in
+++ b/contrib/systemd/opendkim.service.in
@@ -1,11 +1,19 @@
-# If you are using OpenDKIM with SQL datasets it might be necessary to start OpenDKIM after the database servers.
-# For example, if using both MariaDB and PostgreSQL, change "After=" in the "[Unit]" section to:
-# After=network.target nss-lookup.target syslog.target mariadb.service postgresql.service
+# network-online.target is used (rather than network.target) because OpenDKIM
+# may bind to specific IP addresses and may connect to remote backends (LDAP,
+# SQL) at startup.  network-online.target ensures interfaces have addresses
+# before the service starts.  If boot latency is a concern and your setup only
+# uses local sockets, you can relax this to network.target.
+#
+# If you are using OpenDKIM with SQL datasets it might be necessary to start
+# OpenDKIM after the database servers.  For example, if using both MariaDB and
+# PostgreSQL, change "After=" in the "[Unit]" section to:
+# After=network-online.target nss-lookup.target syslog.target mariadb.service postgresql.service
 
 [Unit]
 Description=DomainKeys Identified Mail (DKIM) Milter
 Documentation=man:opendkim(8) man:opendkim.conf(5) man:opendkim-genkey(8) man:opendkim-genzone(8) man:opendkim-testadsp(8) man:opendkim-testkey http://www.opendkim.org/docs.html
-After=network.target nss-lookup.target syslog.target
+After=network-online.target nss-lookup.target syslog.target
+Wants=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
Fixes #141.

Changes `network.target` to `network-online.target` in
`contrib/systemd/opendkim.service.in`, and adds `Wants=network-online.target`
(required because the target is passive and won't activate on `After=` alone).

Also adds comments at the top of the file explaining why `network-online.target`
is used, and how to relax it for setups that only use local sockets — since
this is contrib it should be self-documenting.

Note: PR #146 also modifies this file (`[Service]` section). Both can coexist;
a trivial conflict on the `After=` line will need resolving at merge time.