### PR TITLE
configure.ac: fix libssl detection for OpenSSL 1.1.0+

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -888,9 +888,12 @@ then
 	               AC_MSG_ERROR([libcrypto not found]))
 
 
+	# SSL_library_init() was removed in OpenSSL 1.1.0 (it became a no-op
+	# macro).  Use SSL_CTX_new(), which is a real function in all supported
+	# OpenSSL versions (1.0.x, 1.1.x, 3.x).
 	AC_LINK_IFELSE(
 		       [AC_LANG_PROGRAM([[#include <openssl/ssl.h>]],
-					[[SSL_library_init();]])],
+					[[SSL_CTX_free(NULL);]])],
 					[od_have_ossl="yes";],
 					[od_have_ossl="no";])
 	if test x"$od_have_ossl" = x"no"
@@ -906,7 +909,7 @@ then
 		fi
 
 		LIBCRYPTO_LIBS="$LIBCRYPTO_LIBS -ldl"
-		AC_SEARCH_LIBS([SSL_library_init], [ssl], ,
+		AC_SEARCH_LIBS([SSL_CTX_new], [ssl], ,
 		               AC_MSG_ERROR([libssl not found]), [-ldl])
 	fi
 


### PR DESCRIPTION
Fixes #138.

## Root cause

`configure.ac` probes for libssl using `SSL_library_init()`. In OpenSSL 1.1.0
this function was deprecated and became a no-op macro; it no longer exists as
a linkable symbol. `AC_LINK_IFELSE` therefore fails even when a shared libssl
is present, producing the misleading error:

> Cannot build shared opendkim against static openssl libraries.

CentOS 8/9 Stream ships OpenSSL 1.1.1, which triggers this.

## Fix

Replace both the `AC_LINK_IFELSE` probe and the `AC_SEARCH_LIBS` fallback
with `SSL_CTX_free`/`SSL_CTX_new`, which are real functions in all supported
OpenSSL versions (1.0.x, 1.1.x, 3.x).

Note: PR #162 (OpenSSL 3 upgrade) does not touch `configure.ac` for this
issue, so this fix is independent and can land first.