### PR TITLE
libopendkim/util.c,libvbr/vbr.c: include stdio.h

### DIFF
--- a/libopendkim/util.c
+++ b/libopendkim/util.c
@@ -23,6 +23,7 @@
 #include <netdb.h>
 #include <resolv.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 /* libopendkim includes */
 #include "dkim-internal.h"

--- a/libvbr/vbr.c
+++ b/libvbr/vbr.c
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <resolv.h>
+#include <stdio.h>
 
 #ifdef __STDC__
 # include <stdarg.h>


### PR DESCRIPTION
We need stdio.h for the `snprintf()` family of functions, otherwise on musl systems we'll get build failures.

(We've had this in Gentoo since ~ August 2024)
