### PR TITLE
opendkim: improve error messages for KeyTable/SafeKeys failures

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -4510,9 +4510,12 @@ dkimf_checkfsnode(const char *path, uid_t myuid, char *myname, ino_t *ino,
 				{
 					if (err != NULL)
 					{
+						gr = getgrgid(s.st_gid);
 						snprintf(err, errlen,
-						         "%s is in group %u which has multiple users (e.g. \"%s\")",
-						         path, s.st_gid,
+						         "%s is in group \"%s\" (gid %u) which has multiple users (e.g., \"%s\")",
+						         path,
+						         gr != NULL ? gr->gr_name : "unknown",
+						         (unsigned int) s.st_gid,
 						         pw->pw_name);
 					}
 					endpwent();
@@ -4538,8 +4541,9 @@ dkimf_checkfsnode(const char *path, uid_t myuid, char *myname, ino_t *ino,
 					if (err != NULL)
 					{
 						snprintf(err, errlen,
-						         "%s is in group %u which has multiple users (e.g., \"%s\")",
-						         path, s.st_gid,
+						         "%s is in group \"%s\" (gid %u) which has multiple users (e.g., \"%s\")",
+						         path, gr->gr_name,
+						         (unsigned int) s.st_gid,
 						         gr->gr_mem[c]);
 					}
 					pthread_mutex_unlock(&pwdb_lock);
@@ -4595,9 +4599,12 @@ dkimf_checkfsnode(const char *path, uid_t myuid, char *myname, ino_t *ino,
 				{
 					if (err != NULL)
 					{
+						gr = getgrgid(s.st_gid);
 						snprintf(err, errlen,
-						         "%s is in group %u which has multiple users (e.g., \"%s\")",
-						         path, s.st_gid,
+						         "%s is in group \"%s\" (gid %u) which has multiple users (e.g., \"%s\")",
+						         path,
+						         gr != NULL ? gr->gr_name : "unknown",
+						         (unsigned int) s.st_gid,
 						         pw->pw_name);
 					}
 
@@ -4624,8 +4631,9 @@ dkimf_checkfsnode(const char *path, uid_t myuid, char *myname, ino_t *ino,
 					if (err != NULL)
 					{
 						snprintf(err, errlen,
-						         "%s is in group %u which has multiple users (e.g., \"%s\")",
-						         path, s.st_gid,
+						         "%s is in group \"%s\" (gid %u) which has multiple users (e.g., \"%s\")",
+						         path, gr->gr_name,
+						         (unsigned int) s.st_gid,
 						         gr->gr_mem[c]);
 					}
 
@@ -5010,8 +5018,11 @@ dkimf_add_signrequest(struct msgctx *dfc, DKIMF_DB keytable, char *keyname,
 			if (dolog)
 			{
 				syslog(LOG_ERR,
-				       "KeyTable entry for '%s' corrupt",
-				       keyname);
+				       "KeyTable entry for '%s' corrupt: %s field is empty or missing",
+				       keyname,
+				       (dbd[0].dbdata_buflen == 0 || dbd[0].dbdata_buflen == (size_t) -1) ? "domain" :
+				       (dbd[1].dbdata_buflen == 0 || dbd[1].dbdata_buflen == (size_t) -1) ? "selector" :
+				       "key");
 			}
 
 			return 2;
@@ -8414,7 +8425,7 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 				    dbd[2].dbdata_buflen == 0)
 				{
 					snprintf(err, errlen,
-					         "could not find valid key record \"%s\" in KeyTable",
+					         "no KeyTable entry found for signing key \"%s\" (from SigningTable)",
 					         keyname);
 					return -1;
 				}


### PR DESCRIPTION
Fixes #164

Three targeted improvements to diagnostic messages in `opendkim.c`:

**1. KeyTable lookup failure (`dkimf_add_signrequest`, line ~8428)**

Before: `could not find valid key record "1" in KeyTable`
After: `no KeyTable entry found for signing key "1" (from SigningTable)`

Admins are often confused that the identifier in this message comes from their SigningTable configuration, not an internal row ID. The new wording makes the data flow explicit.

**2. KeyTable corrupt entry (line ~5021)**

Before: `KeyTable entry for 'mykey' corrupt`
After: `KeyTable entry for 'mykey' corrupt: domain field is empty or missing`
(or `selector` or `key` depending on which field is the problem)

The original message tells you a record is broken but not which of the three required fields (domain, selector, key path) is missing, requiring a manual database inspection to proceed.

**3. SafeKeys group-membership check (`dkimf_checkfsnode`, four sites)**

Before: `/etc/mail/dkim.key is in group 8 which has multiple users (e.g., "postfix")`
After: `/etc/mail/dkim.key is in group "mail" (gid 8) which has multiple users (e.g., "postfix")`

Numeric GIDs are not meaningful without a lookup. Including the group name makes the message immediately actionable. The two `getpwent()`-loop sites call `getgrgid()` early (already within `pwdb_lock`); the two `gr_mem` sites already have `gr` in scope.