### PR TITLE
Fix SigningTable consistency check db handling (issue #229)

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -8385,20 +8385,23 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 			char keydata[BUFRSZ + 1];
 			char signalgstr[BUFRSZ + 1];
 			char signer[BUFRSZ + 1];
+			int db_stat;
 
-			dbd[0].dbdata_flags = 0;
-			
 			memset(keyname, '\0', sizeof keyname);
+			/*
+			** As we don't care signer values here,
+			** we don't need to clear it.
+			*/
 
 			dbd[0].dbdata_buffer = keyname;
 			dbd[0].dbdata_buflen = sizeof keyname - 1;
 			dbd[0].dbdata_flags = 0;
 			dbd[1].dbdata_buffer = signer;
 			dbd[1].dbdata_buflen = sizeof signer - 1;
-			dbd[1].dbdata_flags = 0;
+			dbd[1].dbdata_flags = DKIMF_DB_DATA_OPTIONAL;
 
-			while (dkimf_db_walk(conf->conf_signtabledb, first,
-			                     NULL, NULL, dbd, 2) == 0)
+			while ((db_stat = dkimf_db_walk(conf->conf_signtabledb,
+			                                first, NULL, NULL, dbd, 2)) == 0)
 			{
 				first = FALSE;
 				found = FALSE;
@@ -8448,6 +8451,16 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 				dbd[0].dbdata_buffer = keyname;
 				dbd[0].dbdata_buflen = sizeof keyname - 1;
 				dbd[0].dbdata_flags = 0;
+				dbd[1].dbdata_buffer = signer;
+				dbd[1].dbdata_buflen = sizeof signer - 1;
+				dbd[1].dbdata_flags = DKIMF_DB_DATA_OPTIONAL;
+			}
+			if (db_stat == -1)
+			{
+				snprintf(err, errlen,
+				         "error on retrieving an entry from \"%s\"",
+				         conf->conf_signtable);
+				return -1;
 			}
 		}
 	}

--- a/opendkim/tests/t-sign-rs-tables-bad.conf
+++ b/opendkim/tests/t-sign-rs-tables-bad.conf
@@ -5,4 +5,4 @@ Background		No
 Canonicalization	relaxed/simple
 RequireSafeKeys		No
 KeyTable		file:t-sign-rs-tables-bad.keys
-SigningTable		file:t-sign-rs-tables.sign
+SigningTable		refile:t-sign-rs-tables.sign


### PR DESCRIPTION
Fixes #229. Supersedes #230.

Rebase of @futatuki's PR #230 onto current develop. One conflict resolved: develop had already added `dbd[3]`/`signalgstr` for algorithm validation in this same block, which futatuki's PR predated.

Three fixes from the original PR are preserved:

- `dkimf_db_walk()` return value is now captured in `db_stat`; if it returns `-1` (error) after the loop, an error message is emitted and config load fails rather than silently passing incomplete checks.
- The `signer` field in SigningTable entries is now correctly marked `DKIMF_DB_DATA_OPTIONAL`, so entries without a signer value (the common case) are not skipped during the consistency check.
- `dbd[1]` is now reset on each loop iteration alongside `dbd[0]`, ensuring the signer buffer is fresh for each entry.

Also includes the test config fix from the first commit in #230 (SigningTable changed to `refile:` type so the walk operation is supported during testing).

All credit for the fix goes to @futatuki.