### PR TITLE
configure.ac: respect variable for LUA_CFLAGS and LUA_LIBS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1472,8 +1472,6 @@ AC_ARG_ENABLE([lua],
                              [enable Lua scripting support]),
               [enable_lua="$enableval"], [enable_lua="no"])
 
-LUA_CFLAGS=""
-LUA_LIBS=""
 lua_found="no"
 
 AS_IF([test x"$enable_lua" = x"yes"], [


### PR DESCRIPTION
With PR #266, it removes the way to tell the configure script the place where the user installed Lua include files and library file(s) if the user uses custom INSTALL_TOP value in Makefile for Lua source package. With this commit, the configure script respect LUA_CFLAGS and LUA_LIBS set by environment variable or configure script command line, as a last resort of such case.