### PR TITLE
Lua 5.5 support: better seed for lua_newstate

### DIFF
--- a/miltertest/miltertest.c
+++ b/miltertest/miltertest.c
@@ -3884,7 +3884,7 @@ main(int argc, char **argv)
 	nowait = FALSE;
 
 #if LUA_VERSION_NUM >= 505
-	l = lua_newstate(mt_lua_alloc, NULL, 0);
+	l = lua_newstate(mt_lua_alloc, NULL, luaL_makeseed(NULL));
 #else
 	l = lua_newstate(mt_lua_alloc, NULL);
 #endif

--- a/opendkim/opendkim-lua.c
+++ b/opendkim/opendkim-lua.c
@@ -481,7 +481,7 @@ dkimf_lua_setup_hook(void *ctx, const char *script, size_t scriptlen,
 	gc.gc_tail = NULL;
 
 #if LUA_VERSION_NUM >= 505
-	l = lua_newstate(dkimf_lua_alloc, NULL, 0);
+	l = lua_newstate(dkimf_lua_alloc, NULL, luaL_makeseed(NULL));
 #else
 	l = lua_newstate(dkimf_lua_alloc, NULL);
 #endif
@@ -644,7 +644,7 @@ dkimf_lua_screen_hook(void *ctx, const char *script, size_t scriptlen,
 	gc.gc_tail = NULL;
 
 #if LUA_VERSION_NUM >= 505
-	l = lua_newstate(dkimf_lua_alloc, NULL, 0);
+	l = lua_newstate(dkimf_lua_alloc, NULL, luaL_makeseed(NULL));
 #else
 	l = lua_newstate(dkimf_lua_alloc, NULL);
 #endif
@@ -797,7 +797,7 @@ dkimf_lua_stats_hook(void *ctx, const char *script, size_t scriptlen,
 	gc.gc_tail = NULL;
 
 #if LUA_VERSION_NUM >= 505
-	l = lua_newstate(dkimf_lua_alloc, NULL, 0);
+	l = lua_newstate(dkimf_lua_alloc, NULL, luaL_makeseed(NULL));
 #else
 	l = lua_newstate(dkimf_lua_alloc, NULL);
 #endif
@@ -1042,7 +1042,7 @@ dkimf_lua_final_hook(void *ctx, const char *script, size_t scriptlen,
 	gc.gc_tail = NULL;
 
 #if LUA_VERSION_NUM >= 505
-	l = lua_newstate(dkimf_lua_alloc, NULL, 0);
+	l = lua_newstate(dkimf_lua_alloc, NULL, luaL_makeseed(NULL));
 #else
 	l = lua_newstate(dkimf_lua_alloc, NULL);
 #endif
@@ -1277,7 +1277,7 @@ dkimf_lua_db_hook(const char *script, size_t scriptlen, const char *query,
 		io.lua_io_len = scriptlen;
 
 #if LUA_VERSION_NUM >= 505
-	l = lua_newstate(dkimf_lua_alloc, NULL, 0);
+	l = lua_newstate(dkimf_lua_alloc, NULL, luaL_makeseed(NULL));
 #else
 	l = lua_newstate(dkimf_lua_alloc, NULL);
 #endif


### PR DESCRIPTION
In Lua 5.5.0, it introduce 3rd parameter `seed` for `lua_newstate()`[1]. It is used for the seed of randomness for the hashing of strings in new lua state returned by `lua_newstate()`.  Lua 5.5.0 also provides a wrapper function 'luaL_newstate()`[2] to use `lua_newstate()` easly and it uses `luaL_makeseed(NULL)` for calling 'lua_newstate()`. So we also use it for seeds instead of `0`.

[1] https://www.lua.org/manual/5.5/manual.html#lua_newstate
[2] https://www.lua.org/manual/5.5/manual.html#luaL_newstate