### PR TITLE
opendkim: add missing DKIMF_STATUS_KEYFAIL define

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -580,6 +580,7 @@ struct lookup
 #define	DKIMF_STATUS_PARTIAL	6
 #define	DKIMF_STATUS_VERIFYERR	7
 #define	DKIMF_STATUS_UNKNOWN	8
+#define	DKIMF_STATUS_KEYFAIL	9
 
 #define SIGMIN_BYTES		0
 #define SIGMIN_PERCENT		1
@@ -676,13 +677,14 @@ struct lookup dkimf_statusstrings[] =
 {
 	{ "no error",				DKIMF_STATUS_GOOD },
 	{ "bad signature",			DKIMF_STATUS_BAD },
-	{ "key retrieval failed",		DKIMF_STATUS_NOKEY },
+	{ "key not found",			DKIMF_STATUS_NOKEY },
 	{ "key revoked",			DKIMF_STATUS_REVOKED },
 	{ "no signature",			DKIMF_STATUS_NOSIGNATURE },
 	{ "bad message/signature format",	DKIMF_STATUS_BADFORMAT },
 	{ "invalid partial signature",		DKIMF_STATUS_PARTIAL },
 	{ "verification error",			DKIMF_STATUS_VERIFYERR },
 	{ "unknown error",			DKIMF_STATUS_UNKNOWN },
+	{ "key retrieval failed",		DKIMF_STATUS_KEYFAIL },
 	{ NULL,					-1 }
 };
 
@@ -13527,6 +13529,10 @@ mlfi_eom(SMFICTX *ctx)
 			ar = "permerror";
 			break;
 
+		  case DKIMF_STATUS_KEYFAIL:
+			ar = "temperror";
+			break;
+
 		  case DKIMF_STATUS_NOSIGNATURE:
 			ar = "none";
 			break;
@@ -14557,6 +14563,7 @@ mlfi_eom(SMFICTX *ctx)
 			    dfc->mctx_status == DKIMF_STATUS_REVOKED ||
 			    dfc->mctx_status == DKIMF_STATUS_PARTIAL ||
 			    dfc->mctx_status == DKIMF_STATUS_NOKEY ||
+			    dfc->mctx_status == DKIMF_STATUS_KEYFAIL ||
 			    dfc->mctx_status == DKIMF_STATUS_VERIFYERR)
 			{
 				dkimf_ar_all_sigs(header, sizeof header,
@@ -15249,6 +15256,11 @@ mlfi_eom(SMFICTX *ctx)
 	  case DKIMF_STATUS_NOKEY:
 		ret = dkimf_libstatus(ctx, lastdkim, "mlfi_eom()",
 		                      DKIM_STAT_NOKEY);
+		break;
+
+	  case DKIMF_STATUS_KEYFAIL:
+		ret = dkimf_libstatus(ctx, lastdkim, "mlfi_eom()",
+		                      DKIM_STAT_KEYFAIL);
 		break;
 
 	  case DKIMF_STATUS_REVOKED:


### PR DESCRIPTION
## Summary

- PR #309 introduced a use of `DKIMF_STATUS_KEYFAIL` in `mlfi_eom()` but the `#define` was present in @futatuki's original PR #262 and lost during the cherry-pick, breaking the build
- Adds `#define DKIMF_STATUS_KEYFAIL 9` and wires it up fully

## Changes

- `#define DKIMF_STATUS_KEYFAIL 9` added after `DKIMF_STATUS_UNKNOWN`
- String table: corrects `DKIMF_STATUS_NOKEY` label to "key not found"; adds "key retrieval failed" entry for `DKIMF_STATUS_KEYFAIL`
- Authentication-Results switch: `DKIMF_STATUS_KEYFAIL` maps to `dkim=temperror` (transient DNS error, as distinct from `DKIMF_STATUS_NOKEY` which maps to `permerror`)
- AR all-sigs conditional: adds `DKIMF_STATUS_KEYFAIL` alongside `DKIMF_STATUS_NOKEY`
- Final status switch in `mlfi_eom()`: dispatches `DKIMF_STATUS_KEYFAIL` to `dkimf_libstatus()` with `DKIM_STAT_KEYFAIL` so `On-DNSError` is honoured correctly

## Test plan

- [ ] Builds cleanly (previously failed with `error: use of undeclared identifier 'DKIMF_STATUS_KEYFAIL'`)
- [ ] DNS timeout on key lookup produces `dkim=temperror` in Authentication-Results, not `permerror`
- [ ] `On-DNSError` setting is respected for transient key retrieval failures

Fixes build regression introduced by #309.