### PR TITLE
libopendkim/tests: fix t-test205 expected return value

### DIFF
--- a/libopendkim/tests/t-test205.c
+++ b/libopendkim/tests/t-test205.c
@@ -237,9 +237,9 @@ main(int argc, char **argv)
 	status = dkim_body(dkim, BODY01, strlen(BODY01));
 	assert(status == DKIM_STAT_OK);
 
-	/* dkim_eom() returns DKIM_STAT_BADSIG when any signature fails */
+	/* dkim_eom() returns the status of the best signature; Ed25519 passes */
 	status = dkim_eom(dkim, NULL);
-	assert(status == DKIM_STAT_BADSIG);
+	assert(status == DKIM_STAT_OK);
 
 	nsigs = 0;
 	assert(dkim_getsiglist(dkim, &sigs, &nsigs) == DKIM_STAT_OK);


### PR DESCRIPTION
## Summary

- Fixes a wrong assertion in t-test205 introduced in PR #326
- `dkim_eom()` returns the status of the **best** (first passing) signature, not the worst — when Ed25519 passes and RSA is corrupted, the return is `DKIM_STAT_OK`
- The per-signature checks via `dkim_getsiglist()` / `DKIM_SIG_CHECK()` below that assertion are the correct way to confirm RSA failed and Ed25519 passed independently

The PR description for #326 incorrectly stated that `dkim_eom()` returns `DKIM_STAT_BADSIG` when any signature fails; this corrects both the code and that misunderstanding.

## Test plan

- [x] t-test205 passes on FreeBSD 14.4 with OpenSSL 3.x
- [x] Full `gmake check` suite passes (all 160+ unit tests + miltertest integration suite)