### PR TITLE
ci: add GitHub Actions workflow for Linux build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build-test-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y \
+            autoconf automake libtool pkg-config \
+            libssl-dev libmilter-dev \
+            lua5.4 liblua5.4-dev
+
+      - name: Bootstrap build system
+        run: autoreconf -fvi
+
+      - name: Configure
+        run: |
+          ./configure --enable-lua \
+            CFLAGS='-g -O2 -Wno-pointer-sign'
+
+      - name: Build
+        run: make -j$(nproc)
+
+      - name: Test
+        run: make check


### PR DESCRIPTION
Adds a CI workflow that builds and tests OpenDKIM on Ubuntu using GitHub-hosted runners.

Triggers on push and pull_request to `develop`. Uses GitHub-hosted `ubuntu-latest` runners only (no self-hosted infrastructure required).

**What it does:**
- Installs dependencies (autoconf, automake, libtool, OpenSSL, libmilter, Lua 5.4)
- Bootstraps the build system with `autoreconf -fvi`
- Configures with Lua support enabled
- Builds with `make -j$(nproc)`
- Runs the full test suite with `make check`