### PR TITLE
opendkim: remove smfi_insheader() stub (sendmail 8.13.0 is 20 years old)

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -785,32 +785,6 @@ pthread_mutex_t pwdb_lock;			/* passwd/group lock */
 **  BEGIN private section
 */
 
-#ifndef HAVE_SMFI_INSHEADER
-/*
-**  SMFI_INSHEADER -- stub for smfi_insheader() which didn't exist before
-**                    sendmail 8.13.0
-**
-**  Parameters:
-**  	ctx -- milter context
-**  	idx -- insertion index
-**  	hname -- header name
-**  	hvalue -- header value
-**
-**  Return value:
-**  	An sfsistat.
-*/
-
-sfsistat 
-smfi_insheader(SMFICTX *ctx, int idx, char *hname, char *hvalue)
-{
-	assert(ctx != NULL);
-	assert(hname != NULL);
-	assert(hvalue != NULL);
-
-	return smfi_addheader(ctx, hname, hvalue);
-}
-#endif /* ! HAVE_SMFI_INSHEADER */
-
 /*
 **  DKIMF_GETPRIV -- wrapper for smfi_getpriv()
 **
@@ -876,11 +850,7 @@ dkimf_insheader(SMFICTX *ctx, int idx, char *hname, char *hvalue)
 	if (testmode)
 		return dkimf_test_insheader(ctx, idx, hname, hvalue);
 	else
-#ifdef HAVE_SMFI_INSHEADER
 		return smfi_insheader(ctx, idx, hname, hvalue);
-#else /* HAVE_SMFI_INSHEADER */
-		return smfi_addheader(ctx, hname, hvalue);
-#endif /* HAVE_SMFI_INSHEADER */
 }
 
 /*


### PR DESCRIPTION
Removes the compatibility stub for `smfi_insheader()` and the associated `HAVE_SMFI_INSHEADER` preprocessor guards.

`smfi_insheader()` has been present in libmilter since sendmail 8.13.0, released in 2004. Keeping the stub risks duplicate symbol errors when linking against any modern libmilter that doesn't set `HAVE_SMFI_INSHEADER` correctly.

Closes #89