### PR TITLE
libopendkim: fix sig_signalg left as rsa-sha1 when unsupported algorithm skipped

### DIFF
--- a/libopendkim/dkim-tables.c
+++ b/libopendkim/dkim-tables.c
@@ -194,6 +194,7 @@ static struct dkim_nametable prv_sigerrors[] =	/* signature parsing errors */
 	{ "conditional signature not satisfied", DKIM_SIGERROR_CONDITIONAL },
 	{ "too many signature indirections",	DKIM_SIGERROR_CONDLOOP },
 #endif /* _FFR_CONDITIONAL */
+	{ "algorithm not supported in this build", DKIM_SIGERROR_UNSUPPORTED_A },
 	{ NULL,					-1 },
 };
 DKIM_NAMETABLE *dkim_table_sigerrors = prv_sigerrors;

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -2144,7 +2144,7 @@ dkim_siglist_setup(DKIM *dkim)
 				}
 				else
 				{
-					dkim->dkim_siglist[c]->sig_error = DKIM_SIGERROR_INVALID_A;
+					dkim->dkim_siglist[c]->sig_error = DKIM_SIGERROR_UNSUPPORTED_A;
 					continue;
 				}
 				break;
@@ -2156,7 +2156,7 @@ dkim_siglist_setup(DKIM *dkim)
 				}
 				else
 				{
-					dkim->dkim_siglist[c]->sig_error = DKIM_SIGERROR_INVALID_A;
+					dkim->dkim_siglist[c]->sig_error = DKIM_SIGERROR_UNSUPPORTED_A;
 					continue;
 				}
 				break;

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -2121,8 +2121,9 @@ dkim_siglist_setup(DKIM *dkim)
 		}
 		else
 		{
-			signalg = dkim_name_to_code(dkim_table_algorithms,
-			                            (char *) param);
+			dkim->dkim_siglist[c]->sig_signalg = signalg =
+				dkim_name_to_code(dkim_table_algorithms,
+				                  (char *) param);
 
 			if (signalg == -1)
 			{
@@ -2165,7 +2166,6 @@ dkim_siglist_setup(DKIM *dkim)
 				/* NOTREACHED */
 			}
 
-			dkim->dkim_siglist[c]->sig_signalg = signalg;
 			dkim->dkim_siglist[c]->sig_hashtype = hashtype;
 		}
 

--- a/libopendkim/dkim.h
+++ b/libopendkim/dkim.h
@@ -168,6 +168,7 @@ typedef int DKIM_SIGERROR;
 #define	DKIM_SIGERROR_KEYTOOSMALL	46	/* too few key bits */
 #define DKIM_SIGERROR_CONDITIONAL	47	/* conditional sig error */
 #define DKIM_SIGERROR_CONDLOOP		48	/* conditional sig loop */
+#define DKIM_SIGERROR_UNSUPPORTED_A	49	/* a= algorithm not supported in this build */
 
 extern DKIM_NAMETABLE *dkim_table_sigerrors;
 

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -5503,6 +5503,7 @@ dkimf_arfdkim(msgctx dfc)
 	  case DKIM_SIGERROR_INVALID_BC:
 	  case DKIM_SIGERROR_MISSING_A:
 	  case DKIM_SIGERROR_INVALID_A:
+	  case DKIM_SIGERROR_UNSUPPORTED_A:
 	  case DKIM_SIGERROR_MISSING_H:
 	  case DKIM_SIGERROR_INVALID_L:
 	  case DKIM_SIGERROR_INVALID_Q:
@@ -10731,6 +10732,20 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, struct dkimf_dstring *tmpstr,
 			memset(comment, '\0', sizeof comment);
 
 			sigerror = dkim_sig_geterror(sigs[c]);
+
+			if (sigerror == DKIM_SIGERROR_UNSUPPORTED_A)
+			{
+				dkim_alg_t unsup_alg;
+				if (dkim_sig_getsignalg(sigs[c],
+				                        &unsup_alg) == DKIM_STAT_OK)
+				{
+					dkimf_log(conf, LOG_WARNING,
+					          "%s: signature ignored: algorithm '%s' not supported in this build",
+					          JOBID(dfc->mctx_jobid),
+					          dkim_code_to_name(dkim_table_algorithms,
+					                            unsup_alg));
+				}
+			}
 
 			if (dkim_sig_getkeysize(sigs[c],
 			                        &keybits) != DKIM_STAT_OK)

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -10740,8 +10740,7 @@ dkimf_ar_all_sigs(char *hdr, size_t hdrlen, struct dkimf_dstring *tmpstr,
 				                        &unsup_alg) == DKIM_STAT_OK)
 				{
 					dkimf_log(conf, LOG_WARNING,
-					          "%s: signature ignored: algorithm '%s' not supported in this build",
-					          JOBID(dfc->mctx_jobid),
+					          "signature ignored: algorithm '%s' not supported in this build",
 					          dkim_code_to_name(dkim_table_algorithms,
 					                            unsup_alg));
 				}


### PR DESCRIPTION
When opendkim is compiled without Ed25519 support and receives a message signed with `ed25519-sha256`, `sig_signalg` was left at its `memset` default of 0 (`DKIM_SIGN_RSASHA1`). The `continue` in the `DKIM_FEATURE_ED25519` check jumped past the `sig_signalg = signalg` assignment, so the Authentication-Results header would incorrectly report `header.a=rsa-sha1` instead of `header.a=ed25519-sha256`.

Fix: assign `sig_signalg` immediately when `signalg` is decoded from the `a=` tag, before any `continue` that might skip the signature.

Closes #27