### PR TITLE
INSTALL: remove reference to unimplemented --with-libxml2 option

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -85,14 +85,11 @@ doesn't find it, you will need to specify the location with
 
 --with-libjansson
 		Location of the jansson JSON library.  Required for reputation
-		query support, unless "--with-libxml2" is also specified.
+		query support.
 
 --with-libmemcached
 		Location of the memcache library.  Enables the "memcache"
 		data set type.
-
---with-libxml2	Location of the XML parser library.  Optional for use
-		with reputation query support.
 
 --with-lua	Lua interpreter library.  Enables fine-grained policy control
 		via Lua script hooks, and also enables building of the


### PR DESCRIPTION
Removes the misleading `--with-libxml2` option from INSTALL. The option was never implemented in configure.ac and passing it generates an "unrecognized option" warning.

Also removes the "unless --with-libxml2 is also specified" clause from the `--with-libjansson` description so it accurately reflects that jansson is simply required for reputation query support.

Closes #91