### PR TITLE
remove __P() macro for C89/musl portability

### DIFF
--- a/libopendkim/dkim-atps.c
+++ b/libopendkim/dkim-atps.c
@@ -39,7 +39,7 @@
 #endif /* USE_GNUTLS */
 
 /* prototypes */
-extern void dkim_error __P((DKIM *, const char *, ...));
+extern void dkim_error (DKIM *, const char *, ...);
 
 /* local definitions needed for DNS queries */
 #define MAXPACKET		8192

--- a/libopendkim/dkim-cache.h
+++ b/libopendkim/dkim-cache.h
@@ -19,13 +19,13 @@
 #include <db.h>
 
 /* prototypes */
-extern void dkim_cache_close __P((DB *));
-extern int dkim_cache_expire __P((DB *, int, int *));
-extern DB *dkim_cache_init __P((int *, char *));
-extern int dkim_cache_insert __P((DB *, char *, char *, int, int *));
-extern int dkim_cache_query __P((DB *, char *, int, char *, size_t *, int *));
-extern void dkim_cache_stats __P((DB *, u_int *, u_int *, u_int *, u_int *,
-                                  _Bool));
+extern void dkim_cache_close (DB *);
+extern int dkim_cache_expire (DB *, int, int *);
+extern DB *dkim_cache_init (int *, char *);
+extern int dkim_cache_insert (DB *, char *, char *, int, int *);
+extern int dkim_cache_query (DB *, char *, int, char *, size_t *, int *);
+extern void dkim_cache_stats (DB *, u_int *, u_int *, u_int *, u_int *,
+                                  _Bool);
 
 #endif /* QUERY_CACHE */
 

--- a/libopendkim/dkim-canon.c
+++ b/libopendkim/dkim-canon.c
@@ -64,7 +64,7 @@
 #define	DKIM_ISLWSP(x)	((x) == 011 || (x) == 012 || (x) == 015 || (x) == 040)
 
 /* prototypes */
-extern void dkim_error __P((DKIM *, const char *, ...));
+extern void dkim_error (DKIM *, const char *, ...);
 
 /* ========================= PRIVATE SECTION ========================= */
 

--- a/libopendkim/dkim-canon.h
+++ b/libopendkim/dkim-canon.h
@@ -23,23 +23,23 @@
 #define	DKIM_HASHBUFSIZE	4096
 
 /* prototypes */
-extern DKIM_STAT dkim_add_canon __P((DKIM *, _Bool, dkim_canon_t, int,
+extern DKIM_STAT dkim_add_canon (DKIM *, _Bool, dkim_canon_t, int,
                                      u_char *, struct dkim_header *,
-                                     ssize_t length, DKIM_CANON **));
-extern DKIM_STAT dkim_canon_bodychunk __P((DKIM *, u_char *, size_t));
-extern void dkim_canon_cleanup __P((DKIM *));
-extern DKIM_STAT dkim_canon_closebody __P((DKIM *));
-extern DKIM_STAT dkim_canon_getfinal __P((DKIM_CANON *, u_char **, size_t *));
-extern DKIM_STAT dkim_canon_gethashes __P((DKIM_SIGINFO *, void **, size_t *,
-                                           void **, size_t *));
-extern DKIM_STAT dkim_canon_header_string __P((struct dkim_dstring *,
+                                     ssize_t length, DKIM_CANON **);
+extern DKIM_STAT dkim_canon_bodychunk (DKIM *, u_char *, size_t);
+extern void dkim_canon_cleanup (DKIM *);
+extern DKIM_STAT dkim_canon_closebody (DKIM *);
+extern DKIM_STAT dkim_canon_getfinal (DKIM_CANON *, u_char **, size_t *);
+extern DKIM_STAT dkim_canon_gethashes (DKIM_SIGINFO *, void **, size_t *,
+                                           void **, size_t *);
+extern DKIM_STAT dkim_canon_header_string (struct dkim_dstring *,
                                                dkim_canon_t, unsigned char *,
-                                               size_t, _Bool));
-extern DKIM_STAT dkim_canon_init __P((DKIM *, _Bool, _Bool));
-extern u_long dkim_canon_minbody __P((DKIM *));
-extern DKIM_STAT dkim_canon_runheaders __P((DKIM *));
-extern int dkim_canon_selecthdrs __P((DKIM *, u_char *, struct dkim_header **,
-                                      int));
-extern DKIM_STAT dkim_canon_signature __P((DKIM *, struct dkim_header *));
+                                               size_t, _Bool);
+extern DKIM_STAT dkim_canon_init (DKIM *, _Bool, _Bool);
+extern u_long dkim_canon_minbody (DKIM *);
+extern DKIM_STAT dkim_canon_runheaders (DKIM *);
+extern int dkim_canon_selecthdrs (DKIM *, u_char *, struct dkim_header **,
+                                      int);
+extern DKIM_STAT dkim_canon_signature (DKIM *, struct dkim_header *);
 
 #endif /* ! _DKIM_CANON_H_ */

--- a/libopendkim/dkim-dns.h
+++ b/libopendkim/dkim-dns.h
@@ -10,13 +10,13 @@
 #include "dkim.h"
 
 /* prototypes */
-extern int dkim_res_cancel __P((void *, void *));
-extern void dkim_res_close __P((void *));
-extern int dkim_res_init __P((void **));
-extern int dkim_res_nslist __P((void *, const char *));
-extern int dkim_res_query __P((void *, int, unsigned char *, unsigned char *,
-                               size_t, void **));
-extern int dkim_res_waitreply __P((void *, void *, struct timeval *,
-                                   size_t *, int *, int *));
+extern int dkim_res_cancel (void *, void *);
+extern void dkim_res_close (void *);
+extern int dkim_res_init (void **);
+extern int dkim_res_nslist (void *, const char *);
+extern int dkim_res_query (void *, int, unsigned char *, unsigned char *,
+                               size_t, void **);
+extern int dkim_res_waitreply (void *, void *, struct timeval *,
+                                   size_t *, int *, int *);
 
 #endif /* ! _DKIM_DNS_H_ */

--- a/libopendkim/dkim-internal.h
+++ b/libopendkim/dkim-internal.h
@@ -37,15 +37,6 @@
 # define MAX(x,y)		((x) > (y) ? (x) : (y))
 #endif /* ! MAX */
 
-#ifdef __STDC__
-# ifndef __P
-#  define __P(x)  x
-# endif /* ! __P */
-#else /* __STDC__ */
-# ifndef __P
-#  define __P(x)  ()
-# endif /* ! __P */
-#endif /* __STDC__ */
 
 /* limits, macros, etc. */
 #define	BUFRSZ			1024	/* base temp buffer size */
@@ -170,8 +161,8 @@ extern DKIM_NAMETABLE *dkim_table_mandatory;
 #endif /* _FFR_CONDITIONAL */
 
 /* prototypes */
-extern DKIM_STAT dkim_process_set __P((DKIM *, dkim_set_t, u_char *, size_t,
-                                       void *, _Bool, const char *));
-extern DKIM_STAT dkim_siglist_setup __P((DKIM *));
+extern DKIM_STAT dkim_process_set (DKIM *, dkim_set_t, u_char *, size_t,
+                                       void *, _Bool, const char *);
+extern DKIM_STAT dkim_siglist_setup (DKIM *);
 
 #endif /* ! _DKIM_INTERNAL_H_ */

--- a/libopendkim/dkim-keys.c
+++ b/libopendkim/dkim-keys.c
@@ -40,7 +40,7 @@
 #endif /* USE_STRL_H */
 
 /* prototypes */
-extern void dkim_error __P((DKIM *, const char *, ...));
+extern void dkim_error (DKIM *, const char *, ...);
 
 /* local definitions needed for DNS queries */
 #define MAXPACKET		8192

--- a/libopendkim/dkim-keys.h
+++ b/libopendkim/dkim-keys.h
@@ -12,9 +12,9 @@
 #include "dkim.h"
 
 /* prototypes */
-extern DKIM_STAT dkim_get_key_dns __P((DKIM *, DKIM_SIGINFO *, u_char *,
-                                       size_t));
-extern DKIM_STAT dkim_get_key_file __P((DKIM *, DKIM_SIGINFO *, u_char *,
-                                        size_t));
+extern DKIM_STAT dkim_get_key_dns (DKIM *, DKIM_SIGINFO *, u_char *,
+                                       size_t);
+extern DKIM_STAT dkim_get_key_file (DKIM *, DKIM_SIGINFO *, u_char *,
+                                        size_t);
 
 #endif /* ! _DKIM_KEYS_H_ */

--- a/libopendkim/dkim-mailparse.h
+++ b/libopendkim/dkim-mailparse.h
@@ -9,20 +9,11 @@
 #ifndef _DKIM_MAILPARSE_H_
 #define _DKIM_MAILPARSE_H_
 
-#ifdef __STDC__
-# ifndef __P
-#  define __P(x)  x
-# endif /* ! __P */
-#else /* __STDC__ */
-# ifndef __P
-#  define __P(x)  ()
-# endif /* ! __P */
-#endif /* __STDC__ */
 
 /* prototypes */
-extern int dkim_mail_parse __P((unsigned char *line, unsigned char **user_out,
-                                unsigned char **domain_out));
-extern int dkim_mail_parse_multi __P((unsigned char *line,
+extern int dkim_mail_parse (unsigned char *line, unsigned char **user_out,
+                                unsigned char **domain_out);
+extern int dkim_mail_parse_multi (unsigned char *line,
                                       unsigned char ***users_out,
-                                      unsigned char ***domains_out));
+                                      unsigned char ***domains_out);
 #endif /* ! _DKIM_MAILPARSE_H_ */

--- a/libopendkim/dkim-report.c
+++ b/libopendkim/dkim-report.c
@@ -25,7 +25,7 @@
 #include "util.h"
 
 /* prototypes */
-extern void dkim_error __P((DKIM *, const char *, ...));
+extern void dkim_error (DKIM *, const char *, ...);
 
 /* local definitions needed for DNS queries */
 #define MAXPACKET		8192

--- a/libopendkim/dkim-report.h
+++ b/libopendkim/dkim-report.h
@@ -16,7 +16,7 @@
 #define	DKIM_REPORT_PREFIX	"_report._domainkey"
 
 /* prototypes */
-extern DKIM_STAT dkim_repinfo __P((DKIM *, DKIM_SIGINFO *,
-                                   struct timeval *, unsigned char *, size_t));
+extern DKIM_STAT dkim_repinfo (DKIM *, DKIM_SIGINFO *,
+                                   struct timeval *, unsigned char *, size_t);
 
 #endif /* ! _DKIM_REPORT_H_ */

--- a/libopendkim/dkim-test.c
+++ b/libopendkim/dkim-test.c
@@ -51,7 +51,7 @@
 #define MAXPACKET		8192
 
 /* prototypes from elsewhere */
-extern DKIM_STAT dkim_get_key __P((DKIM *, DKIM_SIGINFO *, _Bool));
+extern DKIM_STAT dkim_get_key (DKIM *, DKIM_SIGINFO *, _Bool);
 
 /*
 **  DKIM_TEST_DNS_PUT -- enqueue a DNS reply for automated testing

--- a/libopendkim/dkim-test.h
+++ b/libopendkim/dkim-test.h
@@ -12,7 +12,7 @@
 #include "dkim.h"
 
 /* prototypes */
-extern size_t dkim_test_dns_get __P((DKIM *, u_char *, size_t));
-extern int dkim_test_dns_put __P((DKIM *, int, int, int, u_char *, u_char *));
+extern size_t dkim_test_dns_get (DKIM *, u_char *, size_t);
+extern int dkim_test_dns_put (DKIM *, int, int, int, u_char *, u_char *);
 
 #endif /* ! _DKIM_TEST_H_ */

--- a/libopendkim/dkim-util.c
+++ b/libopendkim/dkim-util.c
@@ -29,7 +29,7 @@
 #include "dkim-util.h"
 
 /* prototypes */
-extern void dkim_error __P((DKIM *, const char *, ...));
+extern void dkim_error (DKIM *, const char *, ...);
 
 /*
 **  DKIM_MALLOC -- allocate memory

--- a/libopendkim/dkim-util.h
+++ b/libopendkim/dkim-util.h
@@ -26,21 +26,21 @@
 #define	DKIM_FREE(x,y)		dkim_mfree((x)->dkim_libhandle, \
 				           (x)->dkim_closure, y)
 
-extern void *dkim_malloc __P((DKIM_LIB *, void *, size_t));
-extern void dkim_mfree __P((DKIM_LIB *, void *, void *));
-extern unsigned char *dkim_strdup __P((DKIM *, const unsigned char *, size_t));
-extern DKIM_STAT dkim_tmpfile __P((DKIM *, int *, _Bool));
+extern void *dkim_malloc (DKIM_LIB *, void *, size_t);
+extern void dkim_mfree (DKIM_LIB *, void *, void *);
+extern unsigned char *dkim_strdup (DKIM *, const unsigned char *, size_t);
+extern DKIM_STAT dkim_tmpfile (DKIM *, int *, _Bool);
 
-extern void dkim_dstring_blank __P((struct dkim_dstring *));
-extern _Bool dkim_dstring_cat __P((struct dkim_dstring *, u_char *));
-extern _Bool dkim_dstring_cat1 __P((struct dkim_dstring *, int));
-extern _Bool dkim_dstring_catn __P((struct dkim_dstring *, u_char *, size_t));
-extern _Bool dkim_dstring_copy __P((struct dkim_dstring *, u_char *));
-extern void dkim_dstring_free __P((struct dkim_dstring *));
-extern u_char *dkim_dstring_get __P((struct dkim_dstring *));
-extern int dkim_dstring_len __P((struct dkim_dstring *));
-extern struct dkim_dstring *dkim_dstring_new __P((DKIM *, int, int));
-extern size_t dkim_dstring_printf __P((struct dkim_dstring *dstr, char *fmt,
-                                       ...));
+extern void dkim_dstring_blank (struct dkim_dstring *);
+extern _Bool dkim_dstring_cat (struct dkim_dstring *, u_char *);
+extern _Bool dkim_dstring_cat1 (struct dkim_dstring *, int);
+extern _Bool dkim_dstring_catn (struct dkim_dstring *, u_char *, size_t);
+extern _Bool dkim_dstring_copy (struct dkim_dstring *, u_char *);
+extern void dkim_dstring_free (struct dkim_dstring *);
+extern u_char *dkim_dstring_get (struct dkim_dstring *);
+extern int dkim_dstring_len (struct dkim_dstring *);
+extern struct dkim_dstring *dkim_dstring_new (DKIM *, int, int);
+extern size_t dkim_dstring_printf (struct dkim_dstring *dstr, char *fmt,
+                                       ...);
 
 #endif /* _DKIM_UTIL_H_ */

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -102,7 +102,7 @@
 #endif /* USE_STRL_H */
 
 /* prototypes */
-void dkim_error __P((DKIM *, const char *, ...));
+void dkim_error (DKIM *, const char *, ...);
 
 /* macros */
 #define	DKIM_STATE_INIT		0

--- a/libopendkim/dkim.h
+++ b/libopendkim/dkim.h
@@ -36,15 +36,6 @@ extern "C" {
 
 #define	OPENDKIM_LIB_VERSION	0x020B0000
 
-#ifdef __STDC__
-# ifndef __P
-#  define __P(x)  x
-# endif /* ! __P */
-#else /* __STDC__ */
-# ifndef __P
-#  define __P(x)  ()
-# endif /* ! __P */
-#endif /* __STDC__ */
 
 /* definitions */
 #define	DKIM_ATPSTAG		"atps"	/* ATPS tag name */
@@ -399,8 +390,8 @@ typedef struct dkim_iter_ctx DKIM_ITER_CTX;
 **  	A new DKIM library instance handle, or NULL on failure.
 */
 
-extern DKIM_LIB *dkim_init __P((void *(*mallocf)(void *closure, size_t nbytes),
-                                void (*freef)(void *closure, void *p)));
+extern DKIM_LIB *dkim_init (void *(*mallocf)(void *closure, size_t nbytes),
+                                void (*freef)(void *closure, void *p));
 
 /*
 **  DKIM_CLOSE -- shut down the DKIM package
@@ -412,7 +403,7 @@ extern DKIM_LIB *dkim_init __P((void *(*mallocf)(void *closure, size_t nbytes),
 **  	None.
 */
 
-extern void dkim_close __P((DKIM_LIB *lib));
+extern void dkim_close (DKIM_LIB *lib);
 
 /*
 **  DKIM_SIGN -- make a new DKIM context for signing
@@ -440,14 +431,14 @@ extern void dkim_close __P((DKIM_LIB *lib));
 **  	updated.
 */
 
-extern DKIM *dkim_sign __P((DKIM_LIB *libhandle, const unsigned char *id,
+extern DKIM *dkim_sign (DKIM_LIB *libhandle, const unsigned char *id,
                             void *memclosure, const dkim_sigkey_t secretkey,
                             const unsigned char *selector,
                             const unsigned char *domain,
                             dkim_canon_t hdr_canon_alg,
                             dkim_canon_t body_canon_alg,
                             dkim_alg_t sign_alg,
-                            ssize_t length, DKIM_STAT *statp));
+                            ssize_t length, DKIM_STAT *statp);
 
 /*
 **  DKIM_VERIFY -- make a new DKIM context for verifying
@@ -464,8 +455,8 @@ extern DKIM *dkim_sign __P((DKIM_LIB *libhandle, const unsigned char *id,
 **  	updated.
 */
 
-extern DKIM *dkim_verify __P((DKIM_LIB *libhandle, const unsigned char *id,
-                              void *memclosure, DKIM_STAT *statp));
+extern DKIM *dkim_verify (DKIM_LIB *libhandle, const unsigned char *id,
+                              void *memclosure, DKIM_STAT *statp);
 
 /*
 **  DKIM_RESIGN -- bind a new signing handle to a verifying handle
@@ -486,7 +477,7 @@ extern DKIM *dkim_verify __P((DKIM_LIB *libhandle, const unsigned char *id,
 **  	its reference count reaches zero.  See documentation for details.
 */
 
-extern DKIM_STAT dkim_resign __P((DKIM *news, DKIM *olds, _Bool hdrbind));
+extern DKIM_STAT dkim_resign (DKIM *news, DKIM *olds, _Bool hdrbind);
 
 /*
 **  DKIM_HEADER -- process a header
@@ -501,7 +492,7 @@ extern DKIM_STAT dkim_resign __P((DKIM *news, DKIM *olds, _Bool hdrbind));
 **  	A DKIM_STAT value.
 */
 
-extern DKIM_STAT dkim_header __P((DKIM *dkim, u_char *hdr, size_t len));
+extern DKIM_STAT dkim_header (DKIM *dkim, u_char *hdr, size_t len);
 
 /*
 **  DKIM_EOH -- identify end of headers
@@ -515,7 +506,7 @@ extern DKIM_STAT dkim_header __P((DKIM *dkim, u_char *hdr, size_t len));
 **  	validating a signature but no DKIM signature was found in the headers.
 */
 
-extern DKIM_STAT dkim_eoh __P((DKIM *dkim));
+extern DKIM_STAT dkim_eoh (DKIM *dkim);
 
 /*
 **  DKIM_BODY -- process a body chunk
@@ -530,7 +521,7 @@ extern DKIM_STAT dkim_eoh __P((DKIM *dkim));
 **  	A DKIM_STAT value.
 */
 
-extern DKIM_STAT dkim_body __P((DKIM *dkim, u_char *buf, size_t len));
+extern DKIM_STAT dkim_body (DKIM *dkim, u_char *buf, size_t len);
 
 /*
 **  DKIM_CHUNK -- process a message chunk
@@ -544,7 +535,7 @@ extern DKIM_STAT dkim_body __P((DKIM *dkim, u_char *buf, size_t len));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_chunk __P((DKIM *dkim, u_char *buf, size_t buflen));
+extern DKIM_STAT dkim_chunk (DKIM *dkim, u_char *buf, size_t buflen);
 
 /*
 **  DKIM_EOM -- identify end of body
@@ -559,7 +550,7 @@ extern DKIM_STAT dkim_chunk __P((DKIM *dkim, u_char *buf, size_t buflen));
 **  	A DKIM_STAT value.
 */
 
-extern DKIM_STAT dkim_eom __P((DKIM *dkim, _Bool *testkey));
+extern DKIM_STAT dkim_eom (DKIM *dkim, _Bool *testkey);
 
 /*
 **  DKIM_KEY_SYNTAX -- process a key record parameter set for valid syntax
@@ -573,7 +564,7 @@ extern DKIM_STAT dkim_eom __P((DKIM *dkim, _Bool *testkey));
 **  	A DKIM_STAT constant.
 */
 
-extern DKIM_STAT dkim_key_syntax __P((DKIM *dkim, u_char *str, size_t len));
+extern DKIM_STAT dkim_key_syntax (DKIM *dkim, u_char *str, size_t len);
 
 /*
 **  DKIM_SIG_SYNTAX -- process a signature parameter set for valid syntax
@@ -587,7 +578,7 @@ extern DKIM_STAT dkim_key_syntax __P((DKIM *dkim, u_char *str, size_t len));
 **  	A DKIM_STAT constant.
 */
 
-extern DKIM_STAT dkim_sig_syntax __P((DKIM *dkim, u_char *str, size_t len));
+extern DKIM_STAT dkim_sig_syntax (DKIM *dkim, u_char *str, size_t len);
 
 /*
 **  DKIM_GETID -- retrieve "id" pointer from a handle
@@ -599,7 +590,7 @@ extern DKIM_STAT dkim_sig_syntax __P((DKIM *dkim, u_char *str, size_t len));
 **  	The "id" pointer from inside the handle, stored when it was created.
 */
 
-extern const char *dkim_getid __P((DKIM *dkim));
+extern const char *dkim_getid (DKIM *dkim);
 
 /*
 **  DKIM_GETCACHESTATS -- retrieve cache statistics
@@ -621,9 +612,9 @@ extern const char *dkim_getid __P((DKIM *dkim));
 **  	is not of interest.
 */
 
-extern DKIM_STAT dkim_getcachestats __P((DKIM_LIB *, u_int *queries, u_int *hits,
+extern DKIM_STAT dkim_getcachestats (DKIM_LIB *, u_int *queries, u_int *hits,
                                          u_int *expired, u_int *keys,
-                                         _Bool reset));
+                                         _Bool reset);
 
 /*
 **  DKIM_FLUSH_CACHE -- purge expired records from the database, reclaiming
@@ -637,7 +628,7 @@ extern DKIM_STAT dkim_getcachestats __P((DKIM_LIB *, u_int *queries, u_int *hits
 **  	>= 0 -- number of flushed records
 */
 
-extern int dkim_flush_cache __P((DKIM_LIB *lib));
+extern int dkim_flush_cache (DKIM_LIB *lib);
 
 /*
 **  DKIM_MINBODY -- return number of bytes still expected
@@ -651,7 +642,7 @@ extern int dkim_flush_cache __P((DKIM_LIB *lib));
 **  	other -- bytes required to satisfy all canonicalizations
 */
 
-extern u_long dkim_minbody __P((DKIM *dkim));
+extern u_long dkim_minbody (DKIM *dkim);
 
 /*
 **  DKIM_GETSIGLIST -- retrieve the list of signatures
@@ -665,8 +656,8 @@ extern u_long dkim_minbody __P((DKIM *dkim));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_getsiglist __P((DKIM *dkim, DKIM_SIGINFO ***sigs,
-                                      int *nsigs));
+extern DKIM_STAT dkim_getsiglist (DKIM *dkim, DKIM_SIGINFO ***sigs,
+                                      int *nsigs);
 
 /*
 **  DKIM_GETSIGNATURE -- retrieve the "final" signature
@@ -679,7 +670,7 @@ extern DKIM_STAT dkim_getsiglist __P((DKIM *dkim, DKIM_SIGINFO ***sigs,
 **  	use to return a "final" result; NULL if none could be determined.
 */
 
-extern DKIM_SIGINFO *dkim_getsignature __P((DKIM *dkim));
+extern DKIM_SIGINFO *dkim_getsignature (DKIM *dkim);
 
 /*
 **  DKIM_GETSIGHDR -- compute and return a signature header for a message
@@ -694,8 +685,8 @@ extern DKIM_SIGINFO *dkim_getsignature __P((DKIM *dkim));
 **  	A DKIM_STAT value.
 */
 
-extern DKIM_STAT dkim_getsighdr __P((DKIM *dkim, u_char *buf, size_t len,
-                                     size_t initial));
+extern DKIM_STAT dkim_getsighdr (DKIM *dkim, u_char *buf, size_t len,
+                                     size_t initial);
 
 /*
 **  DKIM_GETSIGHDR_D -- compute and return a signature header for a message,
@@ -711,8 +702,8 @@ extern DKIM_STAT dkim_getsighdr __P((DKIM *dkim, u_char *buf, size_t len,
 **  	A DKIM_STAT value.
 */
 
-extern DKIM_STAT dkim_getsighdr_d __P((DKIM *dkim, size_t initial,
-                                       u_char **buf, size_t *len));
+extern DKIM_STAT dkim_getsighdr_d (DKIM *dkim, size_t initial,
+                                       u_char **buf, size_t *len);
 
 /*
 **  DKIM_SIG_HDRSIGNED -- retrieve the header list from a signature
@@ -726,7 +717,7 @@ extern DKIM_STAT dkim_getsighdr_d __P((DKIM *dkim, size_t initial,
 **  	appeared in that list.
 */
 
-extern _Bool dkim_sig_hdrsigned __P((DKIM_SIGINFO *sig, u_char *hdr));
+extern _Bool dkim_sig_hdrsigned (DKIM_SIGINFO *sig, u_char *hdr);
 
 /*
 **  DKIM_SIG_GETQUERIES -- retrieve the queries needed to validate a signature
@@ -741,9 +732,9 @@ extern _Bool dkim_sig_hdrsigned __P((DKIM_SIGINFO *sig, u_char *hdr));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_sig_getqueries __P((DKIM *dkim, DKIM_SIGINFO *sig,
+extern DKIM_STAT dkim_sig_getqueries (DKIM *dkim, DKIM_SIGINFO *sig,
                                           DKIM_QUERYINFO ***qi,
-                                          unsigned int *nqi));
+                                          unsigned int *nqi);
 
 /*
 **  DKIM_SIG_GETDNSSEC -- retrieve DNSSEC results for a signature
@@ -755,7 +746,7 @@ extern DKIM_STAT dkim_sig_getqueries __P((DKIM *dkim, DKIM_SIGINFO *sig,
 **  	A DKIM_DNSSEC_* constant.
 */
 
-extern int dkim_sig_getdnssec __P((DKIM_SIGINFO *sig));
+extern int dkim_sig_getdnssec (DKIM_SIGINFO *sig);
 
 /*
 **  DKIM_SIG_SETDNSSEC -- set DNSSEC results for a signature
@@ -765,7 +756,7 @@ extern int dkim_sig_getdnssec __P((DKIM_SIGINFO *sig));
 **      dnssec_status -- A DKIM_DNSSEC_* constant
 */
 
-extern void dkim_sig_setdnssec __P((DKIM_SIGINFO *sig, int dnssec_status));
+extern void dkim_sig_setdnssec (DKIM_SIGINFO *sig, int dnssec_status);
 
 /*
 **  DKIM_SIG_GETREPORTINFO -- retrieve reporting information from a key
@@ -787,12 +778,12 @@ extern void dkim_sig_setdnssec __P((DKIM_SIGINFO *sig, int dnssec_status));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_sig_getreportinfo __P((DKIM *dkim, DKIM_SIGINFO *sig,
+extern DKIM_STAT dkim_sig_getreportinfo (DKIM *dkim, DKIM_SIGINFO *sig,
                                              int *hfd, int *bfd,
                                              u_char *addr, size_t addrlen,
                                              u_char *opts, size_t optslen,
                                              u_char *smtp, size_t smtplen,
-                                             u_int *interval));
+                                             u_int *interval);
 
 /*
 **  DKIM_SIG_GETIDENTITY -- retrieve identity of the signer
@@ -807,8 +798,8 @@ extern DKIM_STAT dkim_sig_getreportinfo __P((DKIM *dkim, DKIM_SIGINFO *sig,
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_sig_getidentity __P((DKIM *dkim, DKIM_SIGINFO *sig,
-                                           u_char *val, size_t vallen));
+extern DKIM_STAT dkim_sig_getidentity (DKIM *dkim, DKIM_SIGINFO *sig,
+                                           u_char *val, size_t vallen);
 
 /*
 **  DKIM_SIG_GETCANONLEN -- report number of (canonicalized) body bytes that
@@ -830,9 +821,9 @@ extern DKIM_STAT dkim_sig_getidentity __P((DKIM *dkim, DKIM_SIGINFO *sig,
 **  	to the caller.
 */
 
-extern DKIM_STAT dkim_sig_getcanonlen __P((DKIM *dkim, DKIM_SIGINFO *sig,
+extern DKIM_STAT dkim_sig_getcanonlen (DKIM *dkim, DKIM_SIGINFO *sig,
                                            ssize_t *msglen, ssize_t *canonlen,
-                                           ssize_t *signlen));
+                                           ssize_t *signlen);
 
 /*
 **  DKIM_OPTIONS -- set/get options
@@ -848,8 +839,8 @@ extern DKIM_STAT dkim_sig_getcanonlen __P((DKIM *dkim, DKIM_SIGINFO *sig,
 **  	A DKIM_STAT value.
 */
 
-extern DKIM_STAT dkim_options __P((DKIM_LIB *dkimlib, int op, dkim_opts_t opt,
-                                   void *ptr, size_t len));
+extern DKIM_STAT dkim_options (DKIM_LIB *dkimlib, int op, dkim_opts_t opt,
+                                   void *ptr, size_t len);
 
 /*
 **  DKIM_SIG_GETFLAGS -- retreive signature handle flags
@@ -862,7 +853,7 @@ extern DKIM_STAT dkim_options __P((DKIM_LIB *dkimlib, int op, dkim_opts_t opt,
 **  	constants currently set in the provided handle.
 */
 
-extern unsigned int dkim_sig_getflags __P((DKIM_SIGINFO *sig));
+extern unsigned int dkim_sig_getflags (DKIM_SIGINFO *sig);
 
 /*
 **  DKIM_SIG_GETBH -- retreive signature handle "bh" test state
@@ -875,7 +866,7 @@ extern unsigned int dkim_sig_getflags __P((DKIM_SIGINFO *sig));
 **  	indicating the current state of "bh" evaluation of the signature.
 */
 
-extern int dkim_sig_getbh __P((DKIM_SIGINFO *sig));
+extern int dkim_sig_getbh (DKIM_SIGINFO *sig);
 
 /*
 **  DKIM_SIG_GETKEYSIZE -- retreive key size after verifying
@@ -888,8 +879,8 @@ extern int dkim_sig_getbh __P((DKIM_SIGINFO *sig));
 **  	A DKIM_STAT value.
 */
 
-extern DKIM_STAT dkim_sig_getkeysize __P((DKIM_SIGINFO *sig,
-                                          unsigned int *bits));
+extern DKIM_STAT dkim_sig_getkeysize (DKIM_SIGINFO *sig,
+                                          unsigned int *bits);
 
 /*
 **  DKIM_SIG_GETSIGNALG -- retreive signature algorithm after verifying
@@ -902,7 +893,7 @@ extern DKIM_STAT dkim_sig_getkeysize __P((DKIM_SIGINFO *sig,
 **  	A DKIM_STAT value.
 */
 
-extern DKIM_STAT dkim_sig_getsignalg __P((DKIM_SIGINFO *sig, dkim_alg_t *alg));
+extern DKIM_STAT dkim_sig_getsignalg (DKIM_SIGINFO *sig, dkim_alg_t *alg);
 
 /*
 **  DKIM_SIG_GETSIGNTIME -- retreive signature timestamp after verifying
@@ -915,7 +906,7 @@ extern DKIM_STAT dkim_sig_getsignalg __P((DKIM_SIGINFO *sig, dkim_alg_t *alg));
 **  	A DKIM_STAT value.
 */
 
-extern DKIM_STAT dkim_sig_getsigntime __P((DKIM_SIGINFO *sig, uint64_t *when));
+extern DKIM_STAT dkim_sig_getsigntime (DKIM_SIGINFO *sig, uint64_t *when);
 
 /*
 **  DKIM_SIG_GETSELECTOR -- retrieve selector used to generate the signature
@@ -927,7 +918,7 @@ extern DKIM_STAT dkim_sig_getsigntime __P((DKIM_SIGINFO *sig, uint64_t *when));
 **  	Selector found in the signature.
 */
 
-extern unsigned char *dkim_sig_getselector __P((DKIM_SIGINFO *sig));
+extern unsigned char *dkim_sig_getselector (DKIM_SIGINFO *sig);
 
 /*
 **  DKIM_SIG_GETDOMAIN -- retrieve signing domain after verifying
@@ -939,7 +930,7 @@ extern unsigned char *dkim_sig_getselector __P((DKIM_SIGINFO *sig));
 **  	Pointer to the signing domain.
 */
 
-extern unsigned char *dkim_sig_getdomain __P((DKIM_SIGINFO *sig));
+extern unsigned char *dkim_sig_getdomain (DKIM_SIGINFO *sig);
 
 /*
 **  DKIM_SIG_GETALGORITHM -- retrieve algorithm from a DKIM_SIGINFO
@@ -952,7 +943,7 @@ extern unsigned char *dkim_sig_getdomain __P((DKIM_SIGINFO *sig));
 **  	Pointer to the algorithm associated with the DKIM_SIGINFO.
 */
 
-extern unsigned char *dkim_sig_getalgorithm __P((DKIM_SIGINFO *sig));
+extern unsigned char *dkim_sig_getalgorithm (DKIM_SIGINFO *sig);
 
 /*
 **  DKIM_SIG_GETCANONS -- retrieve canonicaliztions after verifying
@@ -964,8 +955,8 @@ extern unsigned char *dkim_sig_getalgorithm __P((DKIM_SIGINFO *sig));
 **  	DKIM_STAT_OK -- success
 */
 
-extern DKIM_STAT dkim_sig_getcanons __P((DKIM_SIGINFO *sig, dkim_canon_t *hdr,
-                                         dkim_canon_t *body));
+extern DKIM_STAT dkim_sig_getcanons (DKIM_SIGINFO *sig, dkim_canon_t *hdr,
+                                         dkim_canon_t *body);
 
 /*
 **  DKIM_SET_USER_CONTEXT -- set DKIM handle user context
@@ -978,7 +969,7 @@ extern DKIM_STAT dkim_sig_getcanons __P((DKIM_SIGINFO *sig, dkim_canon_t *hdr,
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_set_user_context __P((DKIM *dkim, void *ctx));
+extern DKIM_STAT dkim_set_user_context (DKIM *dkim, void *ctx);
 
 /*
 **  DKIM_GET_USER_CONTEXT -- retrieve DKIM handle user context
@@ -990,7 +981,7 @@ extern DKIM_STAT dkim_set_user_context __P((DKIM *dkim, void *ctx));
 **  	User context pointer.
 */
 
-extern void *dkim_get_user_context __P((DKIM *dkim));
+extern void *dkim_get_user_context (DKIM *dkim);
 
 /*
 **  DKIM_GETMODE -- return the mode (signing, verifying, etc.) of a handle
@@ -1002,7 +993,7 @@ extern void *dkim_get_user_context __P((DKIM *dkim));
 **  	A DKIM_MODE_* constant.
 */
 
-extern int dkim_getmode __P((DKIM *dkim));
+extern int dkim_getmode (DKIM *dkim);
 
 /*
 **  DKIM_GETDOMAIN -- retrieve policy domain from a DKIM context
@@ -1015,7 +1006,7 @@ extern int dkim_getmode __P((DKIM *dkim));
 **  	no domain could be determined.
 */
 
-extern u_char *dkim_getdomain __P((DKIM *dkim));
+extern u_char *dkim_getdomain (DKIM *dkim);
 
 /*
 **  DKIM_GETUSER -- retrieve sending user (local-part) from a DKIM context
@@ -1027,7 +1018,7 @@ extern u_char *dkim_getdomain __P((DKIM *dkim));
 **  	Pointer to the apparent sending user (local-part) or NULL if not known.
 */
 
-extern u_char *dkim_getuser __P((DKIM *dkim));
+extern u_char *dkim_getuser (DKIM *dkim);
 
 /*
 **  DKIM_GET_SIGNER -- get DKIM signature's signer
@@ -1040,7 +1031,7 @@ extern u_char *dkim_getuser __P((DKIM *dkim));
 **  	or NULL if none.
 */
 
-extern const unsigned char *dkim_get_signer __P((DKIM *dkim));
+extern const unsigned char *dkim_get_signer (DKIM *dkim);
 
 /*
 **  DKIM_SET_SIGNER -- set DKIM signature's signer
@@ -1053,7 +1044,7 @@ extern const unsigned char *dkim_get_signer __P((DKIM *dkim));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_set_signer __P((DKIM *dkim, const u_char *signer));
+extern DKIM_STAT dkim_set_signer (DKIM *dkim, const u_char *signer);
 
 /*
 **  DKIM_SET_DNS_CALLBACK -- set the DNS wait callback
@@ -1069,9 +1060,9 @@ extern DKIM_STAT dkim_set_signer __P((DKIM *dkim, const u_char *signer));
 **  	DKIM_STAT_NOTIMPLEMENT -- underlying resolver doesn't support callbacks
 */
 
-extern DKIM_STAT dkim_set_dns_callback __P((DKIM_LIB *libopendkim,
+extern DKIM_STAT dkim_set_dns_callback (DKIM_LIB *libopendkim,
                                             void (*func)(const void *context),
-                                            unsigned int interval));
+                                            unsigned int interval);
 
 /*
 **  DKIM_SET_KEY_LOOKUP -- set the key lookup function
@@ -1084,11 +1075,11 @@ extern DKIM_STAT dkim_set_dns_callback __P((DKIM_LIB *libopendkim,
 **  	DKIM_STAT_OK
 */
 
-extern DKIM_STAT dkim_set_key_lookup __P((DKIM_LIB *libopendkim,
+extern DKIM_STAT dkim_set_key_lookup (DKIM_LIB *libopendkim,
                                           DKIM_CBSTAT (*func)(DKIM *dkim,
                                                               DKIM_SIGINFO *sig,
                                                               u_char *buf,
-                                                              size_t buflen)));
+                                                              size_t buflen));
 
 /*
 **  DKIM_SET_SIGNATURE_HANDLE -- set the signature handle creator function
@@ -1101,8 +1092,8 @@ extern DKIM_STAT dkim_set_key_lookup __P((DKIM_LIB *libopendkim,
 **  	Pointer to the user-side handle thus created, or NULL.
 */
 
-extern DKIM_STAT dkim_set_signature_handle __P((DKIM_LIB *libopendkim,
-                                                void * (*func)(void *closure)));
+extern DKIM_STAT dkim_set_signature_handle (DKIM_LIB *libopendkim,
+                                                void * (*func)(void *closure));
 
 /*
 **  DKIM_SET_SIGNATURE_HANDLE_FREE -- set the signature handle destroyer
@@ -1116,9 +1107,9 @@ extern DKIM_STAT dkim_set_signature_handle __P((DKIM_LIB *libopendkim,
 **  	None.
 */
 
-extern DKIM_STAT dkim_set_signature_handle_free __P((DKIM_LIB *libopendkim,
+extern DKIM_STAT dkim_set_signature_handle_free (DKIM_LIB *libopendkim,
                                                      void (*func)(void *closure,
-                                                                  void *user)));
+                                                                  void *user));
 
 /*
 **  DKIM_SET_SIGNATURE_TAGVALUES -- set the signature handle populator function
@@ -1131,11 +1122,11 @@ extern DKIM_STAT dkim_set_signature_handle_free __P((DKIM_LIB *libopendkim,
 **  	DKIM_STAT_OK
 */
 
-extern DKIM_STAT dkim_set_signature_tagvalues __P((DKIM_LIB *libopendkim,
+extern DKIM_STAT dkim_set_signature_tagvalues (DKIM_LIB *libopendkim,
                                                    void (*func)(void *user,
                                                                 dkim_param_t pcode,
                                                                 const u_char *param,
-                                                                const u_char *value)));
+                                                                const u_char *value));
 
 /*
 **  DKIM_SET_PRESCREEN -- set the prescreen function
@@ -1148,10 +1139,10 @@ extern DKIM_STAT dkim_set_signature_tagvalues __P((DKIM_LIB *libopendkim,
 **  	DKIM_STAT_OK
 */
 
-extern DKIM_STAT dkim_set_prescreen __P((DKIM_LIB *libopendkim,
+extern DKIM_STAT dkim_set_prescreen (DKIM_LIB *libopendkim,
                                          DKIM_CBSTAT (*func)(DKIM *dkim,
                                                              DKIM_SIGINFO **sigs,
-                                                             int nsigs)));
+                                                             int nsigs));
 
 /*
 **  DKIM_SET_FINAL -- set the final processing function
@@ -1164,10 +1155,10 @@ extern DKIM_STAT dkim_set_prescreen __P((DKIM_LIB *libopendkim,
 **  	DKIM_STAT_OK
 */
 
-extern DKIM_STAT dkim_set_final __P((DKIM_LIB *libopendkim,
+extern DKIM_STAT dkim_set_final (DKIM_LIB *libopendkim,
                                      DKIM_CBSTAT (*func)(DKIM *dkim,
                                                          DKIM_SIGINFO **sigs,
-                                                         int nsigs)));
+                                                         int nsigs));
 
 /*
 **  DKIM_SIG_GETCONTEXT -- get user-specific context from a DKIM_SIGINFO
@@ -1180,7 +1171,7 @@ extern DKIM_STAT dkim_set_final __P((DKIM_LIB *libopendkim,
 **  	if none was ever set.
 */
 
-extern void *dkim_sig_getcontext __P((DKIM_SIGINFO *siginfo));
+extern void *dkim_sig_getcontext (DKIM_SIGINFO *siginfo);
 
 /*
 **  DKIM_SIG_GETERROR -- get error code from a DKIM_SIGINFO
@@ -1192,7 +1183,7 @@ extern void *dkim_sig_getcontext __P((DKIM_SIGINFO *siginfo));
 **  	A DKIM_SIGERROR_* constant.
 */
 
-extern int dkim_sig_geterror __P((DKIM_SIGINFO *siginfo));
+extern int dkim_sig_geterror (DKIM_SIGINFO *siginfo);
 
 /*
 **  DKIM_SIG_SETERROR -- set error code in a DKIM_SIGINFO
@@ -1205,7 +1196,7 @@ extern int dkim_sig_geterror __P((DKIM_SIGINFO *siginfo));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_sig_seterror __P((DKIM_SIGINFO *siginfo, int err));
+extern DKIM_STAT dkim_sig_seterror (DKIM_SIGINFO *siginfo, int err);
 
 /*
 **  DKIM_SIG_GETERRORSTR -- translate a DKIM_SIGERROR into a string
@@ -1218,7 +1209,7 @@ extern DKIM_STAT dkim_sig_seterror __P((DKIM_SIGINFO *siginfo, int err));
 **  	if no such translation exists.
 */
 
-extern const char *dkim_sig_geterrorstr __P((DKIM_SIGERROR sigerr));
+extern const char *dkim_sig_geterrorstr (DKIM_SIGERROR sigerr);
 
 /*
 **  DKIM_SIG_IGNORE -- mark a signature referenced by a DKIM_SIGINFO with
@@ -1231,7 +1222,7 @@ extern const char *dkim_sig_geterrorstr __P((DKIM_SIGERROR sigerr));
 **  	None.
 */
 
-extern void dkim_sig_ignore __P((DKIM_SIGINFO *siginfo));
+extern void dkim_sig_ignore (DKIM_SIGINFO *siginfo);
 
 /*
 **  DKIM_SIG_PROCESS -- process a signature
@@ -1244,7 +1235,7 @@ extern void dkim_sig_ignore __P((DKIM_SIGINFO *siginfo));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_sig_process __P((DKIM *dkim, DKIM_SIGINFO *sig));
+extern DKIM_STAT dkim_sig_process (DKIM *dkim, DKIM_SIGINFO *sig);
 
 /*
 **  DKIM_FREE -- release resources associated with a DKIM handle
@@ -1257,7 +1248,7 @@ extern DKIM_STAT dkim_sig_process __P((DKIM *dkim, DKIM_SIGINFO *sig));
 **  	A DKIM_STAT value.
 */
 
-extern DKIM_STAT dkim_free __P((DKIM *dkim));
+extern DKIM_STAT dkim_free (DKIM *dkim);
 
 /*
 **  DKIM_GETERROR -- return any stored error string from within the DKIM
@@ -1270,7 +1261,7 @@ extern DKIM_STAT dkim_free __P((DKIM *dkim));
 **  	A pointer to the stored string, or NULL if none was stored.
 */
 
-extern const char *dkim_geterror __P((DKIM *dkim));
+extern const char *dkim_geterror (DKIM *dkim);
 
 /*
 **  DKIM_GETRESULTSTR -- translate a DKIM_STAT_* constant to a string
@@ -1282,7 +1273,7 @@ extern const char *dkim_geterror __P((DKIM *dkim));
 **      Pointer to a text describing "result", or NULL if none exists
 */
 
-extern const char *dkim_getresultstr __P((DKIM_STAT result));
+extern const char *dkim_getresultstr (DKIM_STAT result);
 
 /*
 **  DKIM_OHDRS -- extract and decode original headers
@@ -1297,8 +1288,8 @@ extern const char *dkim_getresultstr __P((DKIM_STAT result));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_ohdrs __P((DKIM *dkim, DKIM_SIGINFO *sig, u_char **ptrs,
-                                 int *pcnt));
+extern DKIM_STAT dkim_ohdrs (DKIM *dkim, DKIM_SIGINFO *sig, u_char **ptrs,
+                                 int *pcnt);
 
 /*
 **  DKIM_DIFFHEADERS -- compare original headers with received headers
@@ -1320,10 +1311,10 @@ extern DKIM_STAT dkim_ohdrs __P((DKIM *dkim, DKIM_SIGINFO *sig, u_char **ptrs,
 **  	destroyed.
 */
 
-extern DKIM_STAT dkim_diffheaders __P((DKIM *dkim, dkim_canon_t canon,
+extern DKIM_STAT dkim_diffheaders (DKIM *dkim, dkim_canon_t canon,
                                        int maxcost,
                                        char **ohdrs, int nohdrs,
-                                       struct dkim_hdrdiff **out, int *nout));
+                                       struct dkim_hdrdiff **out, int *nout);
 
 /*
 **  DKIM_GETPARTIAL -- return a DKIM handle's "body length tag" flag
@@ -1335,7 +1326,7 @@ extern DKIM_STAT dkim_diffheaders __P((DKIM *dkim, dkim_canon_t canon,
 **  	True iff the signature is to include a body length tag
 */
 
-extern _Bool dkim_getpartial __P((DKIM *dkim));
+extern _Bool dkim_getpartial (DKIM *dkim);
 
 /*
 **  DKIM_SETPARTIAL -- set the DKIM handle to sign using the DKIM body length
@@ -1349,7 +1340,7 @@ extern _Bool dkim_getpartial __P((DKIM *dkim));
 **  	DKIM_STAT_OK
 */
 
-extern DKIM_STAT dkim_setpartial __P((DKIM *dkim, _Bool value));
+extern DKIM_STAT dkim_setpartial (DKIM *dkim, _Bool value);
 
 /*
 **  DKIM_SET_MARGIN -- set the margin to use when generating signatures
@@ -1364,7 +1355,7 @@ extern DKIM_STAT dkim_setpartial __P((DKIM *dkim, _Bool value));
 **      DKIM_STAT_OK -- otherwise
 */
 
-extern DKIM_STAT dkim_set_margin __P((DKIM *dkim, int value));
+extern DKIM_STAT dkim_set_margin (DKIM *dkim, int value);
 
 /*
 **  DKIM_MAIL_PARSE -- extract the local-part and domain-name from a structured
@@ -1379,7 +1370,7 @@ extern DKIM_STAT dkim_set_margin __P((DKIM *dkim, int value));
 **  	0 on success; other on error (see source)
 */
 
-extern int dkim_mail_parse __P((u_char *addr, u_char **user, u_char **domain));
+extern int dkim_mail_parse (u_char *addr, u_char **user, u_char **domain);
 
 /*
 **  DKIM_SSL_VERSION -- return the version of the OpenSSL library against
@@ -1392,7 +1383,7 @@ extern int dkim_mail_parse __P((u_char *addr, u_char **user, u_char **domain));
 **  	The OPENSSL_VERSION_NUMBER constant as defined by OpenSSL.
 */
 
-extern unsigned long dkim_ssl_version __P((void));
+extern unsigned long dkim_ssl_version (void);
 
 /*
 **  DKIM_LIBFEATURE -- check for a library feature
@@ -1420,7 +1411,7 @@ extern unsigned long dkim_ssl_version __P((void));
 
 #define	DKIM_FEATURE_MAX		11
 
-extern _Bool dkim_libfeature __P((DKIM_LIB *lib, u_int fc));
+extern _Bool dkim_libfeature (DKIM_LIB *lib, u_int fc);
 
 
 /*
@@ -1433,7 +1424,7 @@ extern _Bool dkim_libfeature __P((DKIM_LIB *lib, u_int fc));
 **  	Library version, i.e. value of the OPENDKIM_LIB_VERSION macro.
 */
 
-extern uint32_t dkim_libversion __P((void));
+extern uint32_t dkim_libversion (void);
 
 /*
 **  DKIM_GET_SIGSUBSTRING -- retrieve a minimal signature substring for
@@ -1449,8 +1440,8 @@ extern uint32_t dkim_libversion __P((void));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_get_sigsubstring __P((DKIM *, DKIM_SIGINFO *,
-                                            char *, size_t *));
+extern DKIM_STAT dkim_get_sigsubstring (DKIM *, DKIM_SIGINFO *,
+                                            char *, size_t *);
 
 /*
 **  DKIM_TEST_KEY2 -- retrieve a public key and verify it against a provided
@@ -1473,8 +1464,8 @@ extern DKIM_STAT dkim_get_sigsubstring __P((DKIM *, DKIM_SIGINFO *,
 **  	-1 -- error
 */
 
-extern int dkim_test_key2 __P((DKIM_LIB *, char *, char *, char *, size_t,
-                               dkim_alg_t, int *, char *, size_t));
+extern int dkim_test_key2 (DKIM_LIB *, char *, char *, char *, size_t,
+                               dkim_alg_t, int *, char *, size_t);
 
 /*
 **  DKIM_TEST_KEY -- retrieve a public key and verify it against a provided
@@ -1496,8 +1487,8 @@ extern int dkim_test_key2 __P((DKIM_LIB *, char *, char *, char *, size_t,
 **  	-1 -- error
 */
 
-extern int dkim_test_key __P((DKIM_LIB *, char *, char *, char *, size_t,
-                              int *, char *, size_t));
+extern int dkim_test_key (DKIM_LIB *, char *, char *, char *, size_t,
+                              int *, char *, size_t);
 
 /*
 **  DKIM_SIG_GETTAGVALUE -- retrieve a tag's value from a signature or its key
@@ -1519,7 +1510,7 @@ extern int dkim_test_key __P((DKIM_LIB *, char *, char *, char *, size_t,
 **  	necessarily been vetted in any way.  Caveat emptor.
 */
 
-extern u_char *dkim_sig_gettagvalue __P((DKIM_SIGINFO *, _Bool, u_char *));
+extern u_char *dkim_sig_gettagvalue (DKIM_SIGINFO *, _Bool, u_char *);
 
 /*
 **  DKIM_SIG_GETSIGNEDHDRS -- retrieve the signed header fields covered by
@@ -1536,8 +1527,8 @@ extern u_char *dkim_sig_gettagvalue __P((DKIM_SIGINFO *, _Bool, u_char *));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_sig_getsignedhdrs __P((DKIM *, DKIM_SIGINFO *,
-                                             u_char *, size_t, u_int *));
+extern DKIM_STAT dkim_sig_getsignedhdrs (DKIM *, DKIM_SIGINFO *,
+                                             u_char *, size_t, u_int *);
 
 /*
 **  DKIM_QP_DECODE -- decode a quoted-printable string
@@ -1552,7 +1543,7 @@ extern DKIM_STAT dkim_sig_getsignedhdrs __P((DKIM *, DKIM_SIGINFO *,
 **  	-1 -- parse error
 */
 
-extern int dkim_qp_decode __P((unsigned char *, unsigned char *, int));
+extern int dkim_qp_decode (unsigned char *, unsigned char *, int);
 
 /*
 **  DKIM_DNS_SET_QUERY_SERVICE -- stores a handle representing the DNS
@@ -1567,7 +1558,7 @@ extern int dkim_qp_decode __P((unsigned char *, unsigned char *, int));
 **  	Previously stored handle, or NULL if none.
 */
 
-extern void *dkim_dns_set_query_service __P((DKIM_LIB *, void *));
+extern void *dkim_dns_set_query_service (DKIM_LIB *, void *);
 
 /*
 **  DKIM_DNS_SET_QUERY_START -- stores a pointer to a query start function
@@ -1591,11 +1582,11 @@ extern void *dkim_dns_set_query_service __P((DKIM_LIB *, void *));
 **  		void **qh -- returned query handle
 */
 
-extern void dkim_dns_set_query_start __P((DKIM_LIB *,
+extern void dkim_dns_set_query_start (DKIM_LIB *,
                                           int (*)(void *, int,
                                                   unsigned char *,
                                                   unsigned char *,
-                                                  size_t, void **)));
+                                                  size_t, void **));
 
 /*
 **  DKIM_DNS_SET_QUERY_CANCEL -- stores a pointer to a query cancel function
@@ -1614,8 +1605,8 @@ extern void dkim_dns_set_query_start __P((DKIM_LIB *,
 **  		void *qh -- query handle to be canceled
 */
 
-extern void dkim_dns_set_query_cancel __P((DKIM_LIB *,
-                                           int (*)(void *, void *)));
+extern void dkim_dns_set_query_cancel (DKIM_LIB *,
+                                           int (*)(void *, void *));
 
 /*
 **  DKIM_DNS_SET_QUERY_WAITREPLY -- stores a pointer to wait for a DNS reply
@@ -1638,11 +1629,11 @@ extern void dkim_dns_set_query_cancel __P((DKIM_LIB *,
 **  		int *dnssec -- DNSSEC status returned
 */
 
-extern void dkim_dns_set_query_waitreply __P((DKIM_LIB *,
+extern void dkim_dns_set_query_waitreply (DKIM_LIB *,
                                               int (*)(void *, void *,
                                                       struct timeval *,
                                                       size_t *, int *,
-                                                      int *)));
+                                                      int *));
 
 /*
 **  DKIM_DNS_SET_INIT -- initializes the resolver
@@ -1660,8 +1651,8 @@ extern void dkim_dns_set_query_waitreply __P((DKIM_LIB *,
 **  		void **srv -- DNS service handle (updated)
 */
 
-extern void dkim_dns_set_init __P((DKIM_LIB *,
-                                   int (*)(void **)));
+extern void dkim_dns_set_init (DKIM_LIB *,
+                                   int (*)(void **));
 
 /*
 **  DKIM_DNS_SET_CLOSE -- shuts down the resolver
@@ -1679,8 +1670,8 @@ extern void dkim_dns_set_init __P((DKIM_LIB *,
 **  		void *srv -- DNS service handle
 */
 
-extern void dkim_dns_set_close __P((DKIM_LIB *,
-                                    void (*)(void *)));
+extern void dkim_dns_set_close (DKIM_LIB *,
+                                    void (*)(void *));
 
 /*
 **  DKIM_DNS_SET_NSLIST -- set function that updates resolver nameserver list
@@ -1700,8 +1691,8 @@ extern void dkim_dns_set_close __P((DKIM_LIB *,
 **  			string
 */
 
-extern void dkim_dns_set_nslist __P((DKIM_LIB *,
-                                     int (*)(void *, const char *)));
+extern void dkim_dns_set_nslist (DKIM_LIB *,
+                                     int (*)(void *, const char *));
 
 /*
 **  DKIM_DNS_SET_CONFIG -- set function that passes configuration data to
@@ -1721,8 +1712,8 @@ extern void dkim_dns_set_nslist __P((DKIM_LIB *,
 **  		const char *config -- arbitrary configuration data
 */
 
-extern void dkim_dns_set_config __P((DKIM_LIB *,
-                                     int (*)(void *, const char *)));
+extern void dkim_dns_set_config (DKIM_LIB *,
+                                     int (*)(void *, const char *));
 
 /*
 **  DKIM_DNS_SET_TRUSTANCHOR -- set function that passes trust anchor data to
@@ -1742,8 +1733,8 @@ extern void dkim_dns_set_config __P((DKIM_LIB *,
 **  		const char *trustanchor -- arbitrary trust anchor data
 */
 
-extern void dkim_dns_set_trustanchor __P((DKIM_LIB *,
-                                          int (*)(void *, const char *)));
+extern void dkim_dns_set_trustanchor (DKIM_LIB *,
+                                          int (*)(void *, const char *));
 
 /*
 **  DKIM_DNS_NSLIST -- update resolver nameserver list
@@ -1761,7 +1752,7 @@ extern void dkim_dns_set_trustanchor __P((DKIM_LIB *,
 **  	not use all of the nameservers provided.
 */
 
-extern int dkim_dns_nslist __P((DKIM_LIB *, const char *));
+extern int dkim_dns_nslist (DKIM_LIB *, const char *);
 
 /*
 **  DKIM_DNS_INIT -- force resolver (re)initialization
@@ -1773,7 +1764,7 @@ extern int dkim_dns_nslist __P((DKIM_LIB *, const char *));
 **  	A DKIM_DNS_* constant.
 */
 
-extern int dkim_dns_init __P((DKIM_LIB *));
+extern int dkim_dns_init (DKIM_LIB *);
 
 /*
 **  DKIM_DNS_CLOSE -- force resolver shutdown
@@ -1785,7 +1776,7 @@ extern int dkim_dns_init __P((DKIM_LIB *));
 **  	A DKIM_DNS_* constant.
 */
 
-extern int dkim_dns_close __P((DKIM_LIB *));
+extern int dkim_dns_close (DKIM_LIB *);
 
 /*
 **  DKIM_DNS_CONFIG -- requests a change to resolver configuration
@@ -1798,7 +1789,7 @@ extern int dkim_dns_close __P((DKIM_LIB *));
 **  	A DKIM_DNS_* constant.
 */
 
-extern int dkim_dns_config __P((DKIM_LIB *, const char *));
+extern int dkim_dns_config (DKIM_LIB *, const char *);
 
 /*
 **  DKIM_DNS_TRUSTANCHOR -- requests a change to trust anchor configuration
@@ -1811,7 +1802,7 @@ extern int dkim_dns_config __P((DKIM_LIB *, const char *));
 **  	A DKIM_DNS_* constant.
 */
 
-extern int dkim_dns_trustanchor __P((DKIM_LIB *, const char *));
+extern int dkim_dns_trustanchor (DKIM_LIB *, const char *);
 
 /*
 **  DKIM_ADD_QUERYMETHOD -- add a query method
@@ -1825,8 +1816,8 @@ extern int dkim_dns_trustanchor __P((DKIM_LIB *, const char *));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_add_querymethod __P((DKIM *, const char *,
-                                           const char *));
+extern DKIM_STAT dkim_add_querymethod (DKIM *, const char *,
+                                           const char *);
 
 /*
 **  DKIM_ADD_XTAG -- add an extension tag/value
@@ -1840,7 +1831,7 @@ extern DKIM_STAT dkim_add_querymethod __P((DKIM *, const char *,
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_add_xtag __P((DKIM *, const char *, const char *));
+extern DKIM_STAT dkim_add_xtag (DKIM *, const char *, const char *);
 
 /*
 **  DKIM_PRIVKEY_LOAD -- explicitly try to load the private key
@@ -1852,7 +1843,7 @@ extern DKIM_STAT dkim_add_xtag __P((DKIM *, const char *, const char *));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_privkey_load __P((DKIM *));
+extern DKIM_STAT dkim_privkey_load (DKIM *);
 
 /*
 **  DKIM_ATPS_CHECK -- check for Authorized Third Party Signing
@@ -1867,8 +1858,8 @@ extern DKIM_STAT dkim_privkey_load __P((DKIM *));
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_atps_check __P((DKIM *, DKIM_SIGINFO *,
-                                      struct timeval *, dkim_atps_t *res));
+extern DKIM_STAT dkim_atps_check (DKIM *, DKIM_SIGINFO *,
+                                      struct timeval *, dkim_atps_t *res);
 
 /*
 **  DKIM_CONDITIONAL -- set conditional domain for a signature
@@ -1881,7 +1872,7 @@ extern DKIM_STAT dkim_atps_check __P((DKIM *, DKIM_SIGINFO *,
 **  	A DKIM_STAT_* constant.
 */
 
-extern DKIM_STAT dkim_conditional __P((DKIM *, u_char *));
+extern DKIM_STAT dkim_conditional (DKIM *, u_char *);
 
 /*
 **  DKIM_QI_GETNAME -- retrieve the DNS name from a DKIM_QUERYINFO object
@@ -1894,7 +1885,7 @@ extern DKIM_STAT dkim_conditional __P((DKIM *, u_char *));
 **  	queried, or NULL on error.
 */
 
-extern const char *dkim_qi_getname __P((DKIM_QUERYINFO *));
+extern const char *dkim_qi_getname (DKIM_QUERYINFO *);
 
 /*
 **  DKIM_QI_GETTYPE -- retrieve the DNS RR type from a DKIM_QUERYINFO object
@@ -1906,7 +1897,7 @@ extern const char *dkim_qi_getname __P((DKIM_QUERYINFO *));
 **  	The DNS RR type to be queried, or -1 on error.
 */
 
-extern int dkim_qi_gettype __P((DKIM_QUERYINFO *));
+extern int dkim_qi_gettype (DKIM_QUERYINFO *);
 
 /*
 **  DKIM_BASE32_ENCODE -- encode a string using base32
@@ -1927,7 +1918,7 @@ extern int dkim_qi_gettype __P((DKIM_QUERYINFO *));
 **  	*buflen is updated to count the number of bytes read from "data".
 */
 
-extern int dkim_base32_encode __P((char *, size_t *, const void *, size_t));
+extern int dkim_base32_encode (char *, size_t *, const void *, size_t);
 
 /*
 **  DKIM_SIG_GETHASHES -- retrieve hashes
@@ -1944,8 +1935,8 @@ extern int dkim_base32_encode __P((char *, size_t *, const void *, size_t));
 **  	DKIM_STAT_INVALID -- hashing hasn't been completed
 */
 
-extern DKIM_STAT dkim_sig_gethashes __P((DKIM_SIGINFO *, void **, size_t *,
-                                         void **, size_t *));
+extern DKIM_STAT dkim_sig_gethashes (DKIM_SIGINFO *, void **, size_t *,
+                                         void **, size_t *);
 
 /*
 **  DKIM_SIGNHDRS -- set the list of header fields to sign for a signature,
@@ -1962,7 +1953,7 @@ extern DKIM_STAT dkim_sig_gethashes __P((DKIM_SIGINFO *, void **, size_t *,
 **  	"hdrlist" can be NULL if the library's default is to be used.
 */
 
-extern DKIM_STAT dkim_signhdrs __P((DKIM *, const char **));
+extern DKIM_STAT dkim_signhdrs (DKIM *, const char **);
 
 /*
 **  DKIM_GETSSLBUF -- get the SSL error buffer, if any, from a DKIM handle
@@ -1974,7 +1965,7 @@ extern DKIM_STAT dkim_signhdrs __P((DKIM *, const char **));
 **  	Pointer to the string, if defined, or NULL otherwise.
 */
 
-extern const char *dkim_getsslbuf __P((DKIM *dkim));
+extern const char *dkim_getsslbuf (DKIM *dkim);
 
 /*
 **  DKIM_SIG_GETSSLBUF -- get the SSL error buffer, if any, from a signature
@@ -1986,7 +1977,7 @@ extern const char *dkim_getsslbuf __P((DKIM *dkim));
 **  	Pointer to the string, if defined, or NULL otherwise.
 */
 
-extern const char *dkim_sig_getsslbuf __P((DKIM_SIGINFO *sig));
+extern const char *dkim_sig_getsslbuf (DKIM_SIGINFO *sig);
 
 /* list of headers that should be signed, per RFC6376 Section 5.4 */
 extern const u_char *dkim_should_signhdrs[]; 
@@ -2005,8 +1996,8 @@ extern const u_char *dkim_should_not_signhdrs[];
 **  	Pointer to the name matching the provided code, or NULL if not found.
 */
 
-extern const char *dkim_code_to_name __P((DKIM_NAMETABLE *tbl,
-                                          const int code));
+extern const char *dkim_code_to_name (DKIM_NAMETABLE *tbl,
+                                          const int code);
 
 /*
 **  DKIM_NAME_TO_CODE -- translate a name to a mnemonic code
@@ -2019,8 +2010,8 @@ extern const char *dkim_code_to_name __P((DKIM_NAMETABLE *tbl,
 **  	A mnemonic code matching the provided name, or -1 if not found.
 */
 
-extern const int dkim_name_to_code __P((DKIM_NAMETABLE *tbl,
-                                        const char *name));
+extern const int dkim_name_to_code (DKIM_NAMETABLE *tbl,
+                                        const char *name);
 
 /*
 **  DKIM_NAMETABLE_FIRST -- get the first entry of the table and start iteration
@@ -2038,9 +2029,9 @@ extern const int dkim_name_to_code __P((DKIM_NAMETABLE *tbl,
 ** 	                          iteration context
 **
 */
-extern DKIM_STAT dkim_nametable_first __P((DKIM_NAMETABLE *tbl,
+extern DKIM_STAT dkim_nametable_first (DKIM_NAMETABLE *tbl,
                                            DKIM_ITER_CTX **ctx,
-                                           const char **name, int *code));
+                                           const char **name, int *code);
 
 /*
 **  DKIM_NAMETABLE_NEXT -- get the next entry on the iteration the table
@@ -2055,9 +2046,9 @@ extern DKIM_STAT dkim_nametable_first __P((DKIM_NAMETABLE *tbl,
 **  	A DKIM_STAT_ITER_EOT   -- the table has no item.
 **
 */
-extern DKIM_STAT dkim_nametable_next __P((DKIM_ITER_CTX *ctx,
+extern DKIM_STAT dkim_nametable_next (DKIM_ITER_CTX *ctx,
                                           const char **name,
-                                          int *code));
+                                          int *code);
 
 /*
 **  DKIM_ITER_CTX_FREE -- release resources associated with
@@ -2070,7 +2061,7 @@ extern DKIM_STAT dkim_nametable_next __P((DKIM_ITER_CTX *ctx,
 **  	None.
 **
 */
-extern DKIM_STAT dkim_iter_ctx_free __P((DKIM_ITER_CTX *ctx));
+extern DKIM_STAT dkim_iter_ctx_free (DKIM_ITER_CTX *ctx);
 
 
 #ifdef __cplusplus

--- a/libopendkim/util.h
+++ b/libopendkim/util.h
@@ -22,26 +22,26 @@
 #endif /* HAVE_STDBOOL_H */
 
 /* prototypes */
-extern int dkim_addrcmp __P((u_char *, u_char *));
-extern int dkim_check_dns_reply __P((unsigned char *ansbuf, size_t anslen,
-                                     int xclass, int xtype));
-extern void dkim_clobber_array __P((char **));
-extern void dkim_collapse __P((u_char *));
-extern const char **dkim_copy_array __P((char **));
-extern _Bool dkim_hdrlist __P((u_char *, size_t, u_char **, _Bool));
-extern int dkim_hexchar __P((int c));
-extern void dkim_lowerhdr __P((u_char *));
-extern void dkim_min_timeval __P((struct timeval *, struct timeval *,
-                                  struct timeval *, struct timeval **));
-extern int dkim_qp_decode __P((u_char *, u_char *, int));
-extern int dkim_qp_encode __P((u_char *, u_char *, int));
-extern _Bool dkim_strisprint __P((u_char *));
+extern int dkim_addrcmp (u_char *, u_char *);
+extern int dkim_check_dns_reply (unsigned char *ansbuf, size_t anslen,
+                                     int xclass, int xtype);
+extern void dkim_clobber_array (char **);
+extern void dkim_collapse (u_char *);
+extern const char **dkim_copy_array (char **);
+extern _Bool dkim_hdrlist (u_char *, size_t, u_char **, _Bool);
+extern int dkim_hexchar (int c);
+extern void dkim_lowerhdr (u_char *);
+extern void dkim_min_timeval (struct timeval *, struct timeval *,
+                                  struct timeval *, struct timeval **);
+extern int dkim_qp_decode (u_char *, u_char *, int);
+extern int dkim_qp_encode (u_char *, u_char *, int);
+extern _Bool dkim_strisprint (u_char *);
 
 #ifdef NEED_FAST_STRTOUL
-extern unsigned long dkim_strtoul __P((const char *str, char **endptr,
-                                       int base));
-extern unsigned long long dkim_strtoull __P((const char *str, char **endptr,
-                                             int base));
+extern unsigned long dkim_strtoul (const char *str, char **endptr,
+                                       int base);
+extern unsigned long long dkim_strtoull (const char *str, char **endptr,
+                                             int base);
 #endif /* NEED_FAST_STRTOUL */
 
 #endif /* ! _UTIL_H_ */

--- a/librbl/rbl.h
+++ b/librbl/rbl.h
@@ -59,10 +59,10 @@ typedef struct rbl_handle RBL;
 **  	Strange radar returns at Indianapolis ARTCC.
 */
 
-extern RBL * rbl_init __P((void *(*caller_mallocf)(void *closure,
+extern RBL * rbl_init (void *(*caller_mallocf)(void *closure,
                                                    size_t nbytes),
                            void (*caller_freef)(void *closure, void *p),
-                           void *closure));
+                           void *closure);
 
 /*
 **  RBL_CLOSE -- shut down a RBL instance
@@ -74,7 +74,7 @@ extern RBL * rbl_init __P((void *(*caller_mallocf)(void *closure,
 **  	None.
 */
 
-extern void rbl_close __P((RBL *));
+extern void rbl_close (RBL *);
 
 /*
 **  RBL_GETERROR -- return any stored error string from within the RBL
@@ -87,7 +87,7 @@ extern void rbl_close __P((RBL *));
 **  	A pointer to the stored string, or NULL if none was stored.
 */
 
-extern const u_char *rbl_geterror __P((RBL *));
+extern const u_char *rbl_geterror (RBL *);
 
 /*
 **  RBL_SETDOMAIN -- declare the RBL's domain (the query root)
@@ -100,7 +100,7 @@ extern const u_char *rbl_geterror __P((RBL *));
 **  	None (yet).
 */
 
-extern void rbl_setdomain __P((RBL *, u_char *));
+extern void rbl_setdomain (RBL *, u_char *);
 
 /*
 **  RBL_QUERY_START -- initiate a query to the RBL for entries
@@ -115,7 +115,7 @@ extern void rbl_setdomain __P((RBL *, u_char *));
 ** 	RBL_STAT_* -- as defined
 */
 
-extern RBL_STAT rbl_query_start __P((RBL *, u_char *, void **));
+extern RBL_STAT rbl_query_start (RBL *, u_char *, void **);
 
 /*
 **  RBL_QUERY_CHECK -- check for a reply from an active query
@@ -130,8 +130,8 @@ extern RBL_STAT rbl_query_start __P((RBL *, u_char *, void **));
 ** 	RBL_STAT_* -- as defined
 */
 
-extern RBL_STAT rbl_query_check __P((RBL *, void *, struct timeval *,
-                                     uint32_t *));
+extern RBL_STAT rbl_query_check (RBL *, void *, struct timeval *,
+                                     uint32_t *);
 
 /*
 **  RBL_QUERY_CANCEL -- cancel an open query to the RBL
@@ -144,7 +144,7 @@ extern RBL_STAT rbl_query_check __P((RBL *, void *, struct timeval *,
 ** 	RBL_STAT_* -- as defined
 */
 
-extern RBL_STAT rbl_query_cancel __P((RBL *, void *));
+extern RBL_STAT rbl_query_cancel (RBL *, void *);
 
 /*
 **  RBL_SETTIMEOUT -- set the DNS timeout
@@ -157,7 +157,7 @@ extern RBL_STAT rbl_query_cancel __P((RBL *, void *));
 **  	None.
 */
 
-extern void rbl_settimeout __P((RBL *, u_int));
+extern void rbl_settimeout (RBL *, u_int);
 
 /*
 **  RBL_SETCALLBACKINT -- set the DNS callback interval
@@ -170,7 +170,7 @@ extern void rbl_settimeout __P((RBL *, u_int));
 **  	None.
 */
 
-extern void rbl_setcallbackint __P((RBL *, u_int));
+extern void rbl_setcallbackint (RBL *, u_int);
 
 /*
 **  RBL_SETCALLBACKCTX -- set the DNS callback context
@@ -183,7 +183,7 @@ extern void rbl_setcallbackint __P((RBL *, u_int));
 **  	None.
 */
 
-extern void rbl_setcallbackctx __P((RBL *, void *));
+extern void rbl_setcallbackctx (RBL *, void *);
 
 /*
 **  RBL_SETDNSCALLBACK -- set the DNS wait callback
@@ -196,8 +196,8 @@ extern void rbl_setcallbackctx __P((RBL *, void *));
 **  	None.
 */
 
-extern void rbl_setdnscallback __P((RBL *rbl,
-                                    void (*func)(const void *context)));
+extern void rbl_setdnscallback (RBL *rbl,
+                                    void (*func)(const void *context));
 
 /*
 **  RBL_DNS_SET_QUERY_SERVICE -- stores a handle representing the DNS
@@ -212,7 +212,7 @@ extern void rbl_setdnscallback __P((RBL *rbl,
 **  	Previously stored handle, or NULL if none.
 */
 
-extern void *rbl_dns_set_query_service __P((RBL *, void *));
+extern void *rbl_dns_set_query_service (RBL *, void *);
 
 /*
 **  RBL_DNS_SET_QUERY_START -- stores a pointer to a query start function
@@ -236,11 +236,11 @@ extern void *rbl_dns_set_query_service __P((RBL *, void *));
 **  		void **qh -- returned query handle
 */
 
-extern void rbl_dns_set_query_start __P((RBL *,
+extern void rbl_dns_set_query_start (RBL *,
                                          int (*)(void *, int,
                                                  unsigned char *,
                                                  unsigned char *,
-                                                 size_t, void **)));
+                                                 size_t, void **));
 
 /*
 **  RBL_DNS_SET_QUERY_CANCEL -- stores a pointer to a query cancel function
@@ -259,8 +259,8 @@ extern void rbl_dns_set_query_start __P((RBL *,
 **  		void *qh -- query handle to be canceled
 */
 
-extern void rbl_dns_set_query_cancel __P((RBL *,
-                                          int (*)(void *, void *)));
+extern void rbl_dns_set_query_cancel (RBL *,
+                                          int (*)(void *, void *));
 
 /*
 **  RBL_DNS_SET_QUERY_WAITREPLY -- stores a pointer to wait for a DNS reply
@@ -283,11 +283,11 @@ extern void rbl_dns_set_query_cancel __P((RBL *,
 **  		int *dnssec -- DNSSEC status returned
 */
 
-extern void rbl_dns_set_query_waitreply __P((RBL *,
+extern void rbl_dns_set_query_waitreply (RBL *,
                                              int (*)(void *, void *,
                                                      struct timeval *,
                                                      size_t *, int *,
-                                                     int *)));
+                                                     int *));
 
 /*
 **  RBL_DNS_SET_NSLIST -- set function that updates resolver nameserver list
@@ -307,8 +307,8 @@ extern void rbl_dns_set_query_waitreply __P((RBL *,
 **  			string
 */
 
-extern void rbl_dns_set_nslist __P((RBL *,
-                                    int (*)(void *, const char *)));
+extern void rbl_dns_set_nslist (RBL *,
+                                    int (*)(void *, const char *));
 
 /*
 **  RBL_DNS_SET_CLOSE -- shuts down the resolver
@@ -326,8 +326,8 @@ extern void rbl_dns_set_nslist __P((RBL *,
 **  		void *srv -- DNS service handle
 */
 
-extern void rbl_dns_set_close __P((RBL *,
-                                   void (*)(void *)));
+extern void rbl_dns_set_close (RBL *,
+                                   void (*)(void *));
 
 /*
 **  RBL_DNS_SET_INIT -- initializes the resolver
@@ -345,8 +345,8 @@ extern void rbl_dns_set_close __P((RBL *,
 **  		void **srv -- DNS service handle (updated)
 */
 
-extern void rbl_dns_set_init __P((RBL *,
-                                  int (*)(void **)));
+extern void rbl_dns_set_init (RBL *,
+                                  int (*)(void **));
 
 /*
 **  RBL_DNS_SET_CONFIG -- configures the resolver
@@ -365,8 +365,8 @@ extern void rbl_dns_set_init __P((RBL *,
 **  		const char *config -- arbitrary resolver configuration data
 */
 
-extern void rbl_dns_set_config __P((RBL *,
-                                    int (*)(void *, const char *)));
+extern void rbl_dns_set_config (RBL *,
+                                    int (*)(void *, const char *));
 
 /*
 **  RBL_DNS_SET_TRUSTANCHOR -- provides trust anchor data to the resolver
@@ -385,8 +385,8 @@ extern void rbl_dns_set_config __P((RBL *,
 **  		const char *trust -- arbitrary trust anchor data
 */
 
-extern void rbl_dns_set_trustanchor __P((RBL *,
-                                         int (*)(void *, const char *)));
+extern void rbl_dns_set_trustanchor (RBL *,
+                                         int (*)(void *, const char *));
 
 /*
 **  RBL_DNS_NSLIST -- requests update to a nameserver list
@@ -399,7 +399,7 @@ extern void rbl_dns_set_trustanchor __P((RBL *,
 **  	An RBL_STAT_* constant.
 */
 
-extern RBL_STAT rbl_dns_nslist __P((RBL *, const char *));
+extern RBL_STAT rbl_dns_nslist (RBL *, const char *);
 
 /*
 **  RBL_DNS_CONFIG -- requests a change to resolver configuration
@@ -412,7 +412,7 @@ extern RBL_STAT rbl_dns_nslist __P((RBL *, const char *));
 **  	An RBL_STAT_* constant.
 */
 
-extern RBL_STAT rbl_dns_config __P((RBL *, const char *));
+extern RBL_STAT rbl_dns_config (RBL *, const char *);
 
 /*
 **  RBL_DNS_TRUSTANCHOR -- requests a change to resolver trust anchor data
@@ -425,7 +425,7 @@ extern RBL_STAT rbl_dns_config __P((RBL *, const char *));
 **  	An RBL_STAT_* constant.
 */
 
-extern RBL_STAT rbl_dns_trustanchor __P((RBL *, const char *));
+extern RBL_STAT rbl_dns_trustanchor (RBL *, const char *);
 
 /*
 **  RBL_DNS_INIT -- force nameserver (re)initialization
@@ -437,6 +437,6 @@ extern RBL_STAT rbl_dns_trustanchor __P((RBL *, const char *));
 **  	An RBL_STAT_* constant.
 */
 
-extern RBL_STAT rbl_dns_init __P((RBL *));
+extern RBL_STAT rbl_dns_init (RBL *);
 
 #endif /* _RBL_H_ */

--- a/libvbr/vbr.c
+++ b/libvbr/vbr.c
@@ -109,7 +109,7 @@ struct vbr_handle
 };
 
 /* prototypes */
-static void vbr_error __P((VBR *, const char *, ...));
+static void vbr_error (VBR *, const char *, ...);
 
 /* ========================= PRIVATE SECTION ========================= */
 

--- a/libvbr/vbr.h
+++ b/libvbr/vbr.h
@@ -12,15 +12,6 @@
 /* system includes */
 #include <sys/types.h>
 
-#ifdef __STDC__
-# ifndef __P
-#  define __P(x)  x
-# endif /* ! __P */
-#else /* __STDC__ */
-# ifndef __P
-#  define __P(x)  ()
-# endif /* ! __P */
-#endif /* __STDC__ */
 
 /* strings */
 #define	VBR_ALL			"all"
@@ -64,10 +55,10 @@ typedef struct vbr_handle VBR;
 **  	Strange radar returns at Indianapolis ARTCC.
 */
 
-extern VBR * vbr_init __P((void *(*caller_mallocf)(void *closure,
+extern VBR * vbr_init (void *(*caller_mallocf)(void *closure,
                                                    size_t nbytes),
                            void (*caller_freef)(void *closure, void *p),
-                           void *closure));
+                           void *closure);
 
 /*
 **  VBR_OPTIONS -- set VBR options
@@ -80,7 +71,7 @@ extern VBR * vbr_init __P((void *(*caller_mallocf)(void *closure,
 **  	None.
 */
 
-extern void vbr_options __P((VBR *, unsigned int));
+extern void vbr_options (VBR *, unsigned int);
 
 /*
 **  VBR_CLOSE -- shut down a VBR instance
@@ -92,7 +83,7 @@ extern void vbr_options __P((VBR *, unsigned int));
 **  	None.
 */
 
-extern void vbr_close __P((VBR *));
+extern void vbr_close (VBR *);
 
 /*
 **  VBR_GETERROR -- return any stored error string from within the VBR
@@ -105,7 +96,7 @@ extern void vbr_close __P((VBR *));
 **  	A pointer to the stored string, or NULL if none was stored.
 */
 
-extern const u_char *vbr_geterror __P((VBR *));
+extern const u_char *vbr_geterror (VBR *);
 
 /*
 **  VBR_GETHEADER -- generate and store the VBR-Info header
@@ -120,7 +111,7 @@ extern const u_char *vbr_geterror __P((VBR *));
 **  	STAT_NORESOURCE -- "hdr" was too short
 */
 
-extern VBR_STAT vbr_getheader __P((VBR *, unsigned char *, size_t));
+extern VBR_STAT vbr_getheader (VBR *, unsigned char *, size_t);
 
 /*
 **  VBR_SETCERT -- store the VBR certifiers of this message
@@ -133,7 +124,7 @@ extern VBR_STAT vbr_getheader __P((VBR *, unsigned char *, size_t));
 **  	None (yet).
 */
 
-extern void vbr_setcert __P((VBR *, u_char *));
+extern void vbr_setcert (VBR *, u_char *);
 
 /*
 **  VBR_SETTYPE -- store the VBR type of this message
@@ -146,7 +137,7 @@ extern void vbr_setcert __P((VBR *, u_char *));
 **  	None (yet).
 */
 
-extern void vbr_settype __P((VBR *, u_char *));
+extern void vbr_settype (VBR *, u_char *);
 
 /*
 **  VBR_SETDOMAIN -- declare the sender's domain
@@ -159,7 +150,7 @@ extern void vbr_settype __P((VBR *, u_char *));
 **  	None (yet).
 */
 
-extern void vbr_setdomain __P((VBR *, u_char *));
+extern void vbr_setdomain (VBR *, u_char *);
 
 /*
 **  VBR_TRUSTEDCERTS -- set list of trusted certifiers
@@ -172,7 +163,7 @@ extern void vbr_setdomain __P((VBR *, u_char *));
 **  	None (yet).
 */
 
-extern void vbr_trustedcerts __P((VBR *, u_char **));
+extern void vbr_trustedcerts (VBR *, u_char **);
 
 /*
 **  VBR_QUERY -- query the vouching servers for results
@@ -195,7 +186,7 @@ extern void vbr_trustedcerts __P((VBR *, u_char **));
 **  	- there's no attempt to validate the values found
 */
 
-extern VBR_STAT vbr_query __P((VBR *, u_char **, u_char **));
+extern VBR_STAT vbr_query (VBR *, u_char **, u_char **);
 
 /*
 **  VBR_SETTIMEOUT -- set the DNS timeout
@@ -208,7 +199,7 @@ extern VBR_STAT vbr_query __P((VBR *, u_char **, u_char **));
 **  	A VBR_STAT_* constant.
 */
 
-extern VBR_STAT vbr_settimeout __P((VBR *, u_int));
+extern VBR_STAT vbr_settimeout (VBR *, u_int);
 
 /*
 **  VBR_SETCALLBACKINT -- set the DNS callback interval
@@ -221,7 +212,7 @@ extern VBR_STAT vbr_settimeout __P((VBR *, u_int));
 **  	A VBR_STAT_* constant.
 */
 
-extern VBR_STAT vbr_setcallbackint __P((VBR *, u_int));
+extern VBR_STAT vbr_setcallbackint (VBR *, u_int);
 
 /*
 **  VBR_SETCALLBACKCTX -- set the DNS callback context
@@ -234,7 +225,7 @@ extern VBR_STAT vbr_setcallbackint __P((VBR *, u_int));
 **  	A VBR_STAT_* constant.
 */
 
-extern VBR_STAT vbr_setcallbackctx __P((VBR *, void *));
+extern VBR_STAT vbr_setcallbackctx (VBR *, void *);
 
 /*
 **  VBR_SETDNSCALLBACK -- set the DNS wait callback
@@ -247,8 +238,8 @@ extern VBR_STAT vbr_setcallbackctx __P((VBR *, void *));
 **  	A VBR_STAT_* constant.
 */
 
-extern VBR_STAT vbr_setdnscallback __P((VBR *vbr,
-                                        void (*func)(const void *context)));
+extern VBR_STAT vbr_setdnscallback (VBR *vbr,
+                                        void (*func)(const void *context));
 
 /*
 **  VBR_DNS_SET_QUERY_SERVICE -- stores a handle representing the DNS
@@ -263,7 +254,7 @@ extern VBR_STAT vbr_setdnscallback __P((VBR *vbr,
 **  	Previously stored handle, or NULL if none.
 */
 
-extern void *vbr_dns_set_query_service __P((VBR *, void *));
+extern void *vbr_dns_set_query_service (VBR *, void *);
 
 /*
 **  VBR_DNS_SET_QUERY_START -- stores a pointer to a query start function
@@ -287,10 +278,10 @@ extern void *vbr_dns_set_query_service __P((VBR *, void *));
 **  		void **qh -- returned query handle
 */
 
-extern void vbr_dns_set_query_start __P((VBR *, int (*)(void *, int,
+extern void vbr_dns_set_query_start (VBR *, int (*)(void *, int,
                                                         unsigned char *,
                                                         unsigned char *,
-                                                        size_t, void **)));
+                                                        size_t, void **));
 
 /*
 **  VBR_DNS_SET_QUERY_CANCEL -- stores a pointer to a query cancel function
@@ -309,7 +300,7 @@ extern void vbr_dns_set_query_start __P((VBR *, int (*)(void *, int,
 **  		void *qh -- query handle to be canceled
 */
 
-extern void vbr_dns_set_query_cancel __P((VBR *, int (*)(void *, void *)));
+extern void vbr_dns_set_query_cancel (VBR *, int (*)(void *, void *));
 
 /*
 **  VBR_DNS_SET_QUERY_WAITREPLY -- stores a pointer to wait for a DNS reply
@@ -332,10 +323,10 @@ extern void vbr_dns_set_query_cancel __P((VBR *, int (*)(void *, void *)));
 **  		int *dnssec -- DNSSEC status returned
 */
 
-extern void vbr_dns_set_query_waitreply __P((VBR *, int (*)(void *, void *,
+extern void vbr_dns_set_query_waitreply (VBR *, int (*)(void *, void *,
                                                             struct timeval *,
                                                             size_t *, int *,
-                                                            int *)));
+                                                            int *));
 
 /*
 **  VBR_DNS_SET_NSLIST -- set function that updates resolver nameserver list
@@ -355,8 +346,8 @@ extern void vbr_dns_set_query_waitreply __P((VBR *, int (*)(void *, void *,
 **  			string
 */
 
-extern void vbr_dns_set_nslist __P((VBR *,
-                                    int (*)(void *, const char *)));
+extern void vbr_dns_set_nslist (VBR *,
+                                    int (*)(void *, const char *));
 
 /*
 **  VBR_DNS_SET_CLOSE -- shuts down the resolver
@@ -374,8 +365,8 @@ extern void vbr_dns_set_nslist __P((VBR *,
 **  		void *srv -- DNS service handle
 */
 
-extern void vbr_dns_set_close __P((VBR *,
-                                   void (*)(void *)));
+extern void vbr_dns_set_close (VBR *,
+                                   void (*)(void *));
 
 /*
 **  VBR_DNS_SET_INIT -- initializes the resolver
@@ -393,8 +384,8 @@ extern void vbr_dns_set_close __P((VBR *,
 **  		void **srv -- DNS service handle (updated)
 */
 
-extern void vbr_dns_set_init __P((VBR *,
-                                  int (*)(void **)));
+extern void vbr_dns_set_init (VBR *,
+                                  int (*)(void **));
 
 /*
 **  VBR_DNS_SET_CONFIG -- configures the resolver
@@ -413,8 +404,8 @@ extern void vbr_dns_set_init __P((VBR *,
 **  		const char *config -- arbitrary resolver configuration data
 */
 
-extern void vbr_dns_set_config __P((VBR *,
-                                    int (*)(void *, const char *)));
+extern void vbr_dns_set_config (VBR *,
+                                    int (*)(void *, const char *));
 
 /*
 **  VBR_DNS_SET_TRUSTANCHOR -- provides trust anchor data to the resolver
@@ -433,8 +424,8 @@ extern void vbr_dns_set_config __P((VBR *,
 **  		const char *trust -- arbitrary trust anchor data
 */
 
-extern void vbr_dns_set_trustanchor __P((VBR *,
-                                         int (*)(void *, const char *)));
+extern void vbr_dns_set_trustanchor (VBR *,
+                                         int (*)(void *, const char *));
 
 /*
 **  VBR_DNS_NSLIST -- requests update to a nameserver list
@@ -447,7 +438,7 @@ extern void vbr_dns_set_trustanchor __P((VBR *,
 **  	An VBR_STAT_* constant.
 */
 
-extern VBR_STAT vbr_dns_nslist __P((VBR *, const char *));
+extern VBR_STAT vbr_dns_nslist (VBR *, const char *);
 
 /*
 **  VBR_DNS_CONFIG -- requests a change to resolver configuration
@@ -460,7 +451,7 @@ extern VBR_STAT vbr_dns_nslist __P((VBR *, const char *));
 **  	An VBR_STAT_* constant.
 */
 
-extern VBR_STAT vbr_dns_config __P((VBR *, const char *));
+extern VBR_STAT vbr_dns_config (VBR *, const char *);
 
 /*
 **  VBR_DNS_TRUSTANCHOR -- requests a change to resolver trust anchor data
@@ -473,7 +464,7 @@ extern VBR_STAT vbr_dns_config __P((VBR *, const char *));
 **  	An VBR_STAT_* constant.
 */
 
-extern VBR_STAT vbr_dns_trustanchor __P((VBR *, const char *));
+extern VBR_STAT vbr_dns_trustanchor (VBR *, const char *);
 
 /*
 **  VBR_DNS_INIT -- force nameserver (re)initialization
@@ -485,6 +476,6 @@ extern VBR_STAT vbr_dns_trustanchor __P((VBR *, const char *));
 **  	An VBR_STAT_* constant.
 */
 
-extern VBR_STAT vbr_dns_init __P((VBR *));
+extern VBR_STAT vbr_dns_init (VBR *);
 
 #endif /* _VBR_H_ */

--- a/opendkim/config.c
+++ b/opendkim/config.c
@@ -47,7 +47,7 @@
 #endif /* ! TRUE */
 
 /* prototypes */
-static void config_attach __P((struct config *, struct config **));
+static void config_attach (struct config *, struct config **);
 
 /* errors */
 #define	CONF_UNKNOWN	(-1)		/* unknown status */

--- a/opendkim/config.h
+++ b/opendkim/config.h
@@ -43,13 +43,13 @@ struct configdef
 };
 
 /* prototypes */
-extern char *config_check __P((struct config *, struct configdef *));
-extern unsigned int config_dump __P((struct config *, FILE *, const char *));
-extern char *config_error __P((void));
-extern void config_free __P((struct config *));
-extern int config_get __P((struct config *, const char *, void *, size_t));
-extern struct config *config_load __P((char *, struct configdef *,
-                                       unsigned int *, char *, size_t, char **));
-extern _Bool config_validname __P((struct configdef *, const char *));
+extern char *config_check (struct config *, struct configdef *);
+extern unsigned int config_dump (struct config *, FILE *, const char *);
+extern char *config_error (void);
+extern void config_free (struct config *);
+extern int config_get (struct config *, const char *, void *, size_t);
+extern struct config *config_load (char *, struct configdef *,
+                                       unsigned int *, char *, size_t, char **);
+extern _Bool config_validname (struct configdef *, const char *);
 
 #endif /* _CONFIG_H_ */

--- a/opendkim/flowrate.h
+++ b/opendkim/flowrate.h
@@ -14,18 +14,9 @@
 /* opendkim includes */
 #include "opendkim-db.h"
 
-#ifdef __STDC__
-# ifndef __P
-#  define __P(x)  x
-# endif /* ! __P */
-#else /* __STDC__ */
-# ifndef __P
-#  define __P(x)  ()
-# endif /* ! __P */
-#endif /* __STDC__ */
 
 /* prototypes */
-extern int dkimf_rate_check __P((const char *, DKIMF_DB, DKIMF_DB, int, int,
-                                 unsigned int *));
+extern int dkimf_rate_check (const char *, DKIMF_DB, DKIMF_DB, int, int,
+                                 unsigned int *);
 
 #endif /* _FLOWRATE_H_ */

--- a/opendkim/opendkim-ar.h
+++ b/opendkim/opendkim-ar.h
@@ -98,6 +98,6 @@ struct authres
 **  	0 on success, -1 on failure.
 */
 
-extern int ares_parse __P((u_char *hdr, struct authres *ar));
+extern int ares_parse (u_char *hdr, struct authres *ar);
 
 #endif /* _OPENDKIM_AR_H_ */

--- a/opendkim/opendkim-arf.h
+++ b/opendkim/opendkim-arf.h
@@ -13,15 +13,6 @@
 /* system includes */
 #include <sys/types.h>
 
-#ifdef __STDC__
-# ifndef __P
-#  define __P(x)  x
-# endif /* ! __P */
-#else /* __STDC__ */
-# ifndef __P
-#  define __P(x)  ()
-# endif /* ! __P */
-#endif /* __STDC__ */
 
 #define	ARF_VERSION		"0.1"
 
@@ -50,7 +41,7 @@
 #define	ARF_OPTIONS_DKIM_EXPIRED "x"
 
 /* prototypes */
-extern char *arf_dkim_failure_string __P((int));
-extern char *arf_type_string __P((int));
+extern char *arf_dkim_failure_string (int);
+extern char *arf_type_string (int);
 
 #endif /* _DKIM_ARF_H_ */

--- a/opendkim/opendkim-crypto.h
+++ b/opendkim/opendkim-crypto.h
@@ -9,21 +9,12 @@
 #ifndef _DKIM_CRYPTO_H_
 #define _DKIM_CRYPTO_H_
 
-#ifdef __STDC__
-# ifndef __P
-#  define __P(x)  x
-# endif /* ! __P */
-#else /* __STDC__ */
-# ifndef __P
-#  define __P(x)  ()
-# endif /* ! __P */
-#endif /* __STDC__ */
 
 /* PROTOTYPES */
 #ifdef USE_GNUTLS
-extern const char *dkimf_crypto_geterror __P((void));
+extern const char *dkimf_crypto_geterror (void);
 #endif /* USE_GNUTLS */
-extern int dkimf_crypto_init __P((void));
-extern void dkimf_crypto_free __P((void));
+extern int dkimf_crypto_init (void);
+extern void dkimf_crypto_free (void);
 
 #endif /* _DKIM_CRYPTO_H_ */

--- a/opendkim/opendkim-db.h
+++ b/opendkim/opendkim-db.h
@@ -53,15 +53,6 @@
 
 #define DKIMF_LDAP_PARAM_MAX		10
 
-#ifdef __STDC__
-# ifndef __P
-#  define __P(x)  x
-# endif /* ! __P */
-#else /* __STDC__ */
-# ifndef __P
-#  define __P(x)  ()
-# endif /* ! __P */
-#endif /* __STDC__ */
 
 /* types */
 struct dkimf_db;
@@ -79,23 +70,23 @@ typedef struct dkimf_db_data * DKIMF_DBDATA;
 #define	DKIMF_DB_DATA_OPTIONAL	0x02		/* data is optional */
 
 /* prototypes */
-extern int dkimf_db_chown __P((DKIMF_DB, uid_t uid));
-extern int dkimf_db_close __P((DKIMF_DB));
-extern int dkimf_db_delete __P((DKIMF_DB, void *, size_t));
-extern void dkimf_db_flags __P((unsigned int));
-extern int dkimf_db_get __P((DKIMF_DB, void *, size_t,
-                             DKIMF_DBDATA, unsigned int, _Bool *));
-extern int dkimf_db_mkarray __P((DKIMF_DB, char ***, const char **));
-extern int dkimf_db_open __P((DKIMF_DB *, char *, u_int flags,
-                              pthread_mutex_t *, char **));
-extern int dkimf_db_put __P((DKIMF_DB, void *, size_t, void *, size_t));
-extern int dkimf_db_rewalk __P((DKIMF_DB, char *, DKIMF_DBDATA, unsigned int,
-                                void **));
-extern void dkimf_db_set_ldap_param __P((int, char *));
-extern int dkimf_db_strerror __P((DKIMF_DB, char *, size_t));
-extern int dkimf_db_type __P((DKIMF_DB));
-extern _Bool dkimf_db_can_walk __P((DKIMF_DB));
-extern int dkimf_db_walk __P((DKIMF_DB, _Bool, void *, size_t *,
-                              DKIMF_DBDATA, unsigned int));
+extern int dkimf_db_chown (DKIMF_DB, uid_t uid);
+extern int dkimf_db_close (DKIMF_DB);
+extern int dkimf_db_delete (DKIMF_DB, void *, size_t);
+extern void dkimf_db_flags (unsigned int);
+extern int dkimf_db_get (DKIMF_DB, void *, size_t,
+                             DKIMF_DBDATA, unsigned int, _Bool *);
+extern int dkimf_db_mkarray (DKIMF_DB, char ***, const char **);
+extern int dkimf_db_open (DKIMF_DB *, char *, u_int flags,
+                              pthread_mutex_t *, char **);
+extern int dkimf_db_put (DKIMF_DB, void *, size_t, void *, size_t);
+extern int dkimf_db_rewalk (DKIMF_DB, char *, DKIMF_DBDATA, unsigned int,
+                                void **);
+extern void dkimf_db_set_ldap_param (int, char *);
+extern int dkimf_db_strerror (DKIMF_DB, char *, size_t);
+extern int dkimf_db_type (DKIMF_DB);
+extern _Bool dkimf_db_can_walk (DKIMF_DB);
+extern int dkimf_db_walk (DKIMF_DB, _Bool, void *, size_t *,
+                              DKIMF_DBDATA, unsigned int);
 
 #endif /* _OPENDKIM_DB_H_ */

--- a/opendkim/opendkim-dns.h
+++ b/opendkim/opendkim-dns.h
@@ -34,20 +34,20 @@ struct dkimf_filedns;
 # include <unbound.h>
 
 /* prototypes */
-extern int dkimf_unbound_setup __P((DKIM_LIB *));
+extern int dkimf_unbound_setup (DKIM_LIB *);
 # ifdef _FFR_RBL
-extern int dkimf_rbl_unbound_setup __P((RBL *));
+extern int dkimf_rbl_unbound_setup (RBL *);
 # endif /* _FFR_RBL */
 # ifdef _FFR_VBR
-extern int dkimf_vbr_unbound_setup __P((VBR *));
+extern int dkimf_vbr_unbound_setup (VBR *);
 # endif /* _FFR_VBR */
 #endif /* USE_UNBOUND */
 
-extern int dkimf_filedns_free __P((struct dkimf_filedns *));
-extern int dkimf_filedns_setup __P((DKIM_LIB *, DKIMF_DB));
+extern int dkimf_filedns_free (struct dkimf_filedns *);
+extern int dkimf_filedns_setup (DKIM_LIB *, DKIMF_DB);
 
-extern int dkimf_dns_config __P((DKIM_LIB *, const char *));
-extern int dkimf_dns_setnameservers __P((DKIM_LIB *, const char *));
-extern int dkimf_dns_trustanchor __P((DKIM_LIB *, const char *));
+extern int dkimf_dns_config (DKIM_LIB *, const char *);
+extern int dkimf_dns_setnameservers (DKIM_LIB *, const char *);
+extern int dkimf_dns_trustanchor (DKIM_LIB *, const char *);
 
 #endif /* _OPENDKIM_DNS_H_ */

--- a/opendkim/opendkim-lua.h
+++ b/opendkim/opendkim-lua.h
@@ -35,29 +35,29 @@ struct dkimf_lua_gc
 #define	DKIMF_LUA_GC_DB		1
 
 /* prototypes */
-extern int dkimf_lua_db_hook __P((const char *, size_t, const char *,
+extern int dkimf_lua_db_hook (const char *, size_t, const char *,
                                   struct dkimf_lua_script_result *,
-                                  void **, size_t *));
-extern int dkimf_lua_final_hook __P((void *, const char *, size_t,
+                                  void **, size_t *);
+extern int dkimf_lua_final_hook (void *, const char *, size_t,
                                      const char *,
                                      struct dkimf_lua_script_result *,
-                                     void **, size_t *));
-extern void dkimf_lua_gc_add __P((struct dkimf_lua_gc *g, void *, int));
-extern void dkimf_lua_gc_cleanup __P((struct dkimf_lua_gc *));
-extern void dkimf_lua_gc_remove __P((struct dkimf_lua_gc *, void *));
-extern int dkimf_lua_screen_hook __P((void *, const char *, size_t,
+                                     void **, size_t *);
+extern void dkimf_lua_gc_add (struct dkimf_lua_gc *g, void *, int);
+extern void dkimf_lua_gc_cleanup (struct dkimf_lua_gc *);
+extern void dkimf_lua_gc_remove (struct dkimf_lua_gc *, void *);
+extern int dkimf_lua_screen_hook (void *, const char *, size_t,
                                       const char *,
                                       struct dkimf_lua_script_result *,
-                                      void **, size_t *));
-extern int dkimf_lua_setup_hook __P((void *, const char *, size_t,
+                                      void **, size_t *);
+extern int dkimf_lua_setup_hook (void *, const char *, size_t,
                                      const char *,
                                      struct dkimf_lua_script_result *,
-                                     void **, size_t *));
+                                     void **, size_t *);
 #ifdef _FFR_STATSEXT
-extern int dkimf_lua_stats_hook __P((void *, const char *, size_t,
+extern int dkimf_lua_stats_hook (void *, const char *, size_t,
                                      const char *,
                                      struct dkimf_lua_script_result *,
-                                     void **, size_t *));
+                                     void **, size_t *);
 #endif /* _FFR_STATSEXT */
 
 #endif /* _OPENDKIM_LUA_H_ */

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -690,49 +690,49 @@ struct lookup dkimf_statusstrings[] =
 
 /* PROTOTYPES */
 #ifdef LEAK_TRACKING
-void dkimf_debug_free __P((void *, char *, int));
-void *dkim_debug_malloc __P((size_t, char *, int));
-void *dkim_debug_realloc __P((void *, size_t, char *, int));
+void dkimf_debug_free (void *, char *, int);
+void *dkim_debug_malloc (size_t, char *, int);
+void *dkim_debug_realloc (void *, size_t, char *, int);
 
 # define free(x)	dkimf_debug_free((x), __FILE__, __LINE__)
 # define malloc(x)	dkimf_debug_malloc((x), __FILE__, __LINE__)
 # define realloc(x,y)	dkimf_debug_realloc((x), (y), __FILE__, __LINE__)
 #endif /* LEAK_TRACKING */
 
-sfsistat mlfi_abort __P((SMFICTX *));
-sfsistat mlfi_body __P((SMFICTX *, u_char *, size_t));
-sfsistat mlfi_close __P((SMFICTX *));
-sfsistat mlfi_connect __P((SMFICTX *, char *, _SOCK_ADDR *));
-sfsistat mlfi_envfrom __P((SMFICTX *, char **));
-sfsistat mlfi_envrcpt __P((SMFICTX *, char **));
-sfsistat mlfi_eoh __P((SMFICTX *));
-sfsistat mlfi_eom __P((SMFICTX *));
-sfsistat mlfi_header __P((SMFICTX *, char *, char *));
-sfsistat mlfi_negotiate __P((SMFICTX *, unsigned long, unsigned long,
+sfsistat mlfi_abort (SMFICTX *);
+sfsistat mlfi_body (SMFICTX *, u_char *, size_t);
+sfsistat mlfi_close (SMFICTX *);
+sfsistat mlfi_connect (SMFICTX *, char *, _SOCK_ADDR *);
+sfsistat mlfi_envfrom (SMFICTX *, char **);
+sfsistat mlfi_envrcpt (SMFICTX *, char **);
+sfsistat mlfi_eoh (SMFICTX *);
+sfsistat mlfi_eom (SMFICTX *);
+sfsistat mlfi_header (SMFICTX *, char *, char *);
+sfsistat mlfi_negotiate (SMFICTX *, unsigned long, unsigned long,
                                         unsigned long, unsigned long,
                                         unsigned long *, unsigned long *,
-                                        unsigned long *, unsigned long *));
+                                        unsigned long *, unsigned long *);
 
-static int dkimf_add_signrequest __P((struct msgctx *, DKIMF_DB,
-                                      char *, char *, ssize_t));
-sfsistat dkimf_addheader __P((SMFICTX *, char *, char *));
-sfsistat dkimf_addrcpt __P((SMFICTX *, char *));
-static int dkimf_apply_signtable __P((struct msgctx *, DKIMF_DB, DKIMF_DB,
+static int dkimf_add_signrequest (struct msgctx *, DKIMF_DB,
+                                      char *, char *, ssize_t);
+sfsistat dkimf_addheader (SMFICTX *, char *, char *);
+sfsistat dkimf_addrcpt (SMFICTX *, char *);
+static int dkimf_apply_signtable (struct msgctx *, DKIMF_DB, DKIMF_DB,
                                       unsigned char *, unsigned char *, char *,
-                                      size_t, _Bool));
-sfsistat dkimf_chgheader __P((SMFICTX *, char *, int, char *));
-static void dkimf_cleanup __P((SMFICTX *));
-static void dkimf_config_reload __P((void));
-sfsistat dkimf_delrcpt __P((SMFICTX *, char *));
-static Header dkimf_findheader __P((msgctx, char *, int));
-void *dkimf_getpriv __P((SMFICTX *));
-char *dkimf_getsymval __P((SMFICTX *, char *));
-sfsistat dkimf_insheader __P((SMFICTX *, int, char *, char *));
-sfsistat dkimf_quarantine __P((SMFICTX *, char *));
-void dkimf_sendprogress __P((const void *));
-sfsistat dkimf_setpriv __P((SMFICTX *, void *));
-sfsistat dkimf_setreply __P((SMFICTX *, char *, char *, char *));
-static void dkimf_sigreport __P((connctx, struct dkimf_config *, char *));
+                                      size_t, _Bool);
+sfsistat dkimf_chgheader (SMFICTX *, char *, int, char *);
+static void dkimf_cleanup (SMFICTX *);
+static void dkimf_config_reload (void);
+sfsistat dkimf_delrcpt (SMFICTX *, char *);
+static Header dkimf_findheader (msgctx, char *, int);
+void *dkimf_getpriv (SMFICTX *);
+char *dkimf_getsymval (SMFICTX *, char *);
+sfsistat dkimf_insheader (SMFICTX *, int, char *, char *);
+sfsistat dkimf_quarantine (SMFICTX *, char *);
+void dkimf_sendprogress (const void *);
+sfsistat dkimf_setpriv (SMFICTX *, void *);
+sfsistat dkimf_setreply (SMFICTX *, char *, char *, char *);
+static void dkimf_sigreport (connctx, struct dkimf_config *, char *);
 static void dkimf_log(struct dkimf_config *conf, int priority, const char *format, ...);
 
 /* GLOBALS */

--- a/opendkim/opendkim.h
+++ b/opendkim/opendkim.h
@@ -145,77 +145,77 @@ extern char *progname;
 
 /* prototypes, exported for test.c */
 #ifdef DKIMF_MILTER_PROTOTYPES
-extern sfsistat mlfi_connect __P((SMFICTX *, char *, _SOCK_ADDR *));
-extern sfsistat mlfi_envfrom __P((SMFICTX *, char **));
-extern sfsistat mlfi_envrcpt __P((SMFICTX *, char **));
-extern sfsistat mlfi_header __P((SMFICTX *, char *, char *));
-extern sfsistat mlfi_eoh __P((SMFICTX *));
-extern sfsistat mlfi_body __P((SMFICTX *, u_char *, size_t));
-extern sfsistat mlfi_eom __P((SMFICTX *));
-extern sfsistat mlfi_abort __P((SMFICTX *));
-extern sfsistat mlfi_close __P((SMFICTX *));
+extern sfsistat mlfi_connect (SMFICTX *, char *, _SOCK_ADDR *);
+extern sfsistat mlfi_envfrom (SMFICTX *, char **);
+extern sfsistat mlfi_envrcpt (SMFICTX *, char **);
+extern sfsistat mlfi_header (SMFICTX *, char *, char *);
+extern sfsistat mlfi_eoh (SMFICTX *);
+extern sfsistat mlfi_body (SMFICTX *, u_char *, size_t);
+extern sfsistat mlfi_eom (SMFICTX *);
+extern sfsistat mlfi_abort (SMFICTX *);
+extern sfsistat mlfi_close (SMFICTX *);
 #endif /* DKIMF_MILTER_PROTOTYPES */
 
-extern DKIM *dkimf_getdkim __P((void *));
-extern struct signreq *dkimf_getsrlist __P((void *));
+extern DKIM *dkimf_getdkim (void *);
+extern struct signreq *dkimf_getsrlist (void *);
 
 #ifdef USE_LDAP
-extern char *dkimf_get_ldap_param __P((int));
+extern char *dkimf_get_ldap_param (int);
 #endif /* USE_LDAP */
 
 #ifdef USE_LUA
 # ifdef DKIMF_LUA_PROTOTYPES
-extern void dkimf_import_globals __P((void *, lua_State *));
-extern int dkimf_xs_addheader __P((lua_State *));
-extern int dkimf_xs_addrcpt __P((lua_State *));
-extern int dkimf_xs_bodylength __P((lua_State *));
-extern int dkimf_xs_canonlength __P((lua_State *));
-extern int dkimf_xs_clienthost __P((lua_State *));
-extern int dkimf_xs_clientip __P((lua_State *));
-extern int dkimf_xs_dbclose __P((lua_State *));
-extern int dkimf_xs_dbhandle __P((lua_State *));
-extern int dkimf_xs_dbopen __P((lua_State *));
-extern int dkimf_xs_dbquery __P((lua_State *));
-extern int dkimf_xs_delheader __P((lua_State *));
-extern int dkimf_xs_delrcpt __P((lua_State *));
-extern int dkimf_xs_export __P((lua_State *));
-extern int dkimf_xs_fromdomain __P((lua_State *));
-extern int dkimf_xs_getenvfrom __P((lua_State *));
-extern int dkimf_xs_getheader __P((lua_State *));
-extern int dkimf_xs_getreputation __P((lua_State *));
-extern int dkimf_xs_getsigarray __P((lua_State *));
-extern int dkimf_xs_getsigcount __P((lua_State *));
-extern int dkimf_xs_getsigdomain __P((lua_State *));
-extern int dkimf_xs_getsighandle __P((lua_State *));
-extern int dkimf_xs_getsigidentity __P((lua_State *));
-extern int dkimf_xs_getsymval __P((lua_State *));
-extern int dkimf_xs_internalip __P((lua_State *));
-extern int dkimf_xs_log __P((lua_State *));
-extern int dkimf_xs_parsefield __P((lua_State *));
-extern int dkimf_xs_popauth __P((lua_State *));
-extern int dkimf_xs_quarantine __P((lua_State *));
-extern int dkimf_xs_rblcheck __P((lua_State *));
-extern int dkimf_xs_rcpt __P((lua_State *));
-extern int dkimf_xs_rcptarray __P((lua_State *));
-extern int dkimf_xs_rcptcount __P((lua_State *));
-extern int dkimf_xs_replaceheader __P((lua_State *));
-extern int dkimf_xs_resign __P((lua_State *));
-extern int dkimf_xs_requestsig __P((lua_State *));
-extern int dkimf_xs_setpartial __P((lua_State *));
-extern int dkimf_xs_setreply __P((lua_State *));
-extern int dkimf_xs_setresult __P((lua_State *));
-extern int dkimf_xs_sigbhresult __P((lua_State *));
-extern int dkimf_xs_sigignore __P((lua_State *));
-extern int dkimf_xs_signfor __P((lua_State *));
-extern int dkimf_xs_sigresult __P((lua_State *));
+extern void dkimf_import_globals (void *, lua_State *);
+extern int dkimf_xs_addheader (lua_State *);
+extern int dkimf_xs_addrcpt (lua_State *);
+extern int dkimf_xs_bodylength (lua_State *);
+extern int dkimf_xs_canonlength (lua_State *);
+extern int dkimf_xs_clienthost (lua_State *);
+extern int dkimf_xs_clientip (lua_State *);
+extern int dkimf_xs_dbclose (lua_State *);
+extern int dkimf_xs_dbhandle (lua_State *);
+extern int dkimf_xs_dbopen (lua_State *);
+extern int dkimf_xs_dbquery (lua_State *);
+extern int dkimf_xs_delheader (lua_State *);
+extern int dkimf_xs_delrcpt (lua_State *);
+extern int dkimf_xs_export (lua_State *);
+extern int dkimf_xs_fromdomain (lua_State *);
+extern int dkimf_xs_getenvfrom (lua_State *);
+extern int dkimf_xs_getheader (lua_State *);
+extern int dkimf_xs_getreputation (lua_State *);
+extern int dkimf_xs_getsigarray (lua_State *);
+extern int dkimf_xs_getsigcount (lua_State *);
+extern int dkimf_xs_getsigdomain (lua_State *);
+extern int dkimf_xs_getsighandle (lua_State *);
+extern int dkimf_xs_getsigidentity (lua_State *);
+extern int dkimf_xs_getsymval (lua_State *);
+extern int dkimf_xs_internalip (lua_State *);
+extern int dkimf_xs_log (lua_State *);
+extern int dkimf_xs_parsefield (lua_State *);
+extern int dkimf_xs_popauth (lua_State *);
+extern int dkimf_xs_quarantine (lua_State *);
+extern int dkimf_xs_rblcheck (lua_State *);
+extern int dkimf_xs_rcpt (lua_State *);
+extern int dkimf_xs_rcptarray (lua_State *);
+extern int dkimf_xs_rcptcount (lua_State *);
+extern int dkimf_xs_replaceheader (lua_State *);
+extern int dkimf_xs_resign (lua_State *);
+extern int dkimf_xs_requestsig (lua_State *);
+extern int dkimf_xs_setpartial (lua_State *);
+extern int dkimf_xs_setreply (lua_State *);
+extern int dkimf_xs_setresult (lua_State *);
+extern int dkimf_xs_sigbhresult (lua_State *);
+extern int dkimf_xs_sigignore (lua_State *);
+extern int dkimf_xs_signfor (lua_State *);
+extern int dkimf_xs_sigresult (lua_State *);
 #  ifdef _FFR_REPUTATION
-extern int dkimf_xs_spam __P((lua_State *));
+extern int dkimf_xs_spam (lua_State *);
 #  endif /* _FFR_REPUTATION */
 #  ifdef _FFR_STATSEXT
-extern int dkimf_xs_statsext __P((lua_State *));
+extern int dkimf_xs_statsext (lua_State *);
 #  endif /* _FFR_STATSEXT */
-extern int dkimf_xs_verify __P((lua_State *));
-extern int dkimf_xs_xtag __P((lua_State *));
+extern int dkimf_xs_verify (lua_State *);
+extern int dkimf_xs_xtag (lua_State *);
 # endif /* DKIMF_LUA_PROTOTYPES */
 #endif /* USE_LUA */
 

--- a/opendkim/reputation.h
+++ b/opendkim/reputation.h
@@ -26,14 +26,14 @@ struct reputation;
 typedef struct reputation * DKIMF_REP;
 
 /* PROTOTYPES */
-extern int dkimf_rep_init __P((DKIMF_REP *, time_t, unsigned int, unsigned int,
+extern int dkimf_rep_init (DKIMF_REP *, time_t, unsigned int, unsigned int,
                                char *, char *, DKIMF_DB, DKIMF_DB, DKIMF_DB,
-                               DKIMF_DB));
-extern int dkimf_rep_check __P((DKIMF_REP, DKIM_SIGINFO *, _Bool,
+                               DKIMF_DB);
+extern int dkimf_rep_check (DKIMF_REP, DKIM_SIGINFO *, _Bool,
                                 void *, size_t, unsigned long *, float *,
                                 unsigned long *, unsigned long *,
-                                char *, size_t));
-extern int dkimf_rep_chown_cache __P((DKIMF_REP, uid_t));
-extern void dkimf_rep_close __P((DKIMF_REP));
+                                char *, size_t);
+extern int dkimf_rep_chown_cache (DKIMF_REP, uid_t);
+extern void dkimf_rep_close (DKIMF_REP);
 
 #endif /* _REPUTATION_H_ */

--- a/opendkim/stats.h
+++ b/opendkim/stats.h
@@ -43,12 +43,12 @@
 #define DKIMS_SI_MAX		5
 
 /* PROTOTYPES */
-extern void dkimf_stats_init __P((void));
-extern int dkimf_stats_record __P((char *, u_char *, char *, char *, Header,
+extern void dkimf_stats_init (void);
+extern int dkimf_stats_record (char *, u_char *, char *, char *, Header,
                                    DKIM *,
 #ifdef _FFR_STATSEXT
                                    struct statsext *,
 #endif /* _FFR_STATSEXT */
-                                   int, int, struct sockaddr *));
+                                   int, int, struct sockaddr *);
 
 #endif /* _STATS_H_ */

--- a/opendkim/test.h
+++ b/opendkim/test.h
@@ -20,18 +20,18 @@
 #include "dkim.h"
 
 /* PROTOTYPES */
-extern int dkimf_testfiles __P((DKIM_LIB *, char *, uint64_t, bool, int));
+extern int dkimf_testfiles (DKIM_LIB *, char *, uint64_t, bool, int);
 
-extern int dkimf_test_addheader __P((void *, char *, char *));
-extern int dkimf_test_addrcpt __P((void *, char *));
-extern int dkimf_test_chgheader __P((void *, char *, int, char *));
-extern int dkimf_test_delrcpt __P((void *, char *));
-extern void *dkimf_test_getpriv __P((void *));
-extern char *dkimf_test_getsymval __P((void *, char *));
-extern int dkimf_test_insheader __P((void *, int, char *, char *));
-extern int dkimf_test_progress __P((void *));
-extern int dkimf_test_quarantine __P((void *, char *));
-extern int dkimf_test_setpriv __P((void *, void *));
-extern int dkimf_test_setreply __P((void *, char *, char *, char *));
+extern int dkimf_test_addheader (void *, char *, char *);
+extern int dkimf_test_addrcpt (void *, char *);
+extern int dkimf_test_chgheader (void *, char *, int, char *);
+extern int dkimf_test_delrcpt (void *, char *);
+extern void *dkimf_test_getpriv (void *);
+extern char *dkimf_test_getsymval (void *, char *);
+extern int dkimf_test_insheader (void *, int, char *, char *);
+extern int dkimf_test_progress (void *);
+extern int dkimf_test_quarantine (void *, char *);
+extern int dkimf_test_setpriv (void *, void *);
+extern int dkimf_test_setreply (void *, char *, char *, char *);
 
 #endif /* _TEST_H_ */

--- a/opendkim/util.h
+++ b/opendkim/util.h
@@ -38,49 +38,49 @@ struct replace
 #endif /* _FFR_REPLACE_RULES */
 
 /* PROTOTYPES */
-extern void dkimf_base64_encode_file __P((int, FILE *, int, int, int));
-extern _Bool dkimf_checkhost __P((DKIMF_DB, char *));
-extern _Bool dkimf_checkip __P((DKIMF_DB, struct sockaddr *));
+extern void dkimf_base64_encode_file (int, FILE *, int, int, int);
+extern _Bool dkimf_checkhost (DKIMF_DB, char *);
+extern _Bool dkimf_checkip (DKIMF_DB, struct sockaddr *);
 #ifdef POPAUTH
-extern _Bool dkimf_checkpopauth __P((DKIMF_DB, struct sockaddr *));
+extern _Bool dkimf_checkpopauth (DKIMF_DB, struct sockaddr *);
 #endif /* POPAUTH */
-extern _Bool dkimf_hostlist __P((char *, char **));
-extern size_t dkimf_inet_ntoa __P((struct in_addr, char *, size_t));
+extern _Bool dkimf_hostlist (char *, char **);
+extern size_t dkimf_inet_ntoa (struct in_addr, char *, size_t);
 #ifdef POPAUTH
-extern int dkimf_initpopauth __P((void));
+extern int dkimf_initpopauth (void);
 #endif /* POPAUTH */
 #ifdef _FFR_REPLACE_RULES
-extern void dkimf_free_replist __P((struct replace *));
-extern _Bool dkimf_load_replist __P((FILE *, struct replace **));
+extern void dkimf_free_replist (struct replace *);
+extern _Bool dkimf_load_replist (FILE *, struct replace **);
 #endif /* _FFR_REPLACE_RULES */
-extern void dkimf_ipstring __P((char *, size_t, struct sockaddr_storage *));
-extern _Bool dkimf_isblank __P((char *));
-extern void dkimf_lowercase __P((u_char *));
-extern void dkimf_mkpath __P((char *, size_t, char *, char *));
-extern _Bool dkimf_mkregexp __P((char *, char *, size_t));
-extern void dkimf_optlist __P((FILE *));
-extern void dkimf_setmaxfd __P((void));
-extern int dkimf_socket_cleanup __P((char *));
-extern void dkimf_stripbrackets __P((char *));
-extern void dkimf_stripcr __P((char *));
-extern _Bool dkimf_subdomain __P((char *d1, char *d2));
-extern void dkimf_trimspaces __P((u_char *));
+extern void dkimf_ipstring (char *, size_t, struct sockaddr_storage *);
+extern _Bool dkimf_isblank (char *);
+extern void dkimf_lowercase (u_char *);
+extern void dkimf_mkpath (char *, size_t, char *, char *);
+extern _Bool dkimf_mkregexp (char *, char *, size_t);
+extern void dkimf_optlist (FILE *);
+extern void dkimf_setmaxfd (void);
+extern int dkimf_socket_cleanup (char *);
+extern void dkimf_stripbrackets (char *);
+extern void dkimf_stripcr (char *);
+extern _Bool dkimf_subdomain (char *d1, char *d2);
+extern void dkimf_trimspaces (u_char *);
 
-extern struct dkimf_dstring *dkimf_dstring_new __P((int, int));
-extern void dkimf_dstring_free __P((struct dkimf_dstring *));
-extern _Bool dkimf_dstring_copy __P((struct dkimf_dstring *, u_char *));
-extern _Bool dkimf_dstring_cat __P((struct dkimf_dstring *, u_char *));
-extern _Bool dkimf_dstring_cat1 __P((struct dkimf_dstring *, int));
-extern _Bool dkimf_dstring_catn __P((struct dkimf_dstring *, u_char *, size_t));
-extern void dkimf_dstring_chop __P((struct dkimf_dstring *, int));
-extern u_char *dkimf_dstring_get __P((struct dkimf_dstring *));
-extern int dkimf_dstring_len __P((struct dkimf_dstring *));
-extern void dkimf_dstring_blank __P((struct dkimf_dstring *));
-extern size_t dkimf_dstring_printf __P((struct dkimf_dstring *, char *, ...));
+extern struct dkimf_dstring *dkimf_dstring_new (int, int);
+extern void dkimf_dstring_free (struct dkimf_dstring *);
+extern _Bool dkimf_dstring_copy (struct dkimf_dstring *, u_char *);
+extern _Bool dkimf_dstring_cat (struct dkimf_dstring *, u_char *);
+extern _Bool dkimf_dstring_cat1 (struct dkimf_dstring *, int);
+extern _Bool dkimf_dstring_catn (struct dkimf_dstring *, u_char *, size_t);
+extern void dkimf_dstring_chop (struct dkimf_dstring *, int);
+extern u_char *dkimf_dstring_get (struct dkimf_dstring *);
+extern int dkimf_dstring_len (struct dkimf_dstring *);
+extern void dkimf_dstring_blank (struct dkimf_dstring *);
+extern size_t dkimf_dstring_printf (struct dkimf_dstring *, char *, ...);
 
 #ifdef USE_UNBOUND
-extern _Bool dkimf_timespec_past __P((struct timespec *tv));
-extern int dkimf_wait_fd __P((int fd, struct timespec *until));
+extern _Bool dkimf_timespec_past (struct timespec *tv);
+extern int dkimf_wait_fd (int fd, struct timespec *until);
 #endif /* USE_UNBOUND */
 
 #endif /* _UTIL_H_ */


### PR DESCRIPTION
## Summary

- The `__P()` macro is a K&R C compatibility shim that wrapped function prototypes so they compiled with both ANSI and pre-ANSI compilers. No platform capable of running a mail server still needs this.
- `musl` libc (used by Alpine Linux and other minimal distros) does not define `__P()`, so the macro causes build failures there.
- `glibc` defines `__P(x)` as `x` only for legacy compatibility.
- Removes all 400+ uses of `__P()` and the `#ifdef __STDC__` define blocks in 36 files. Transformation is purely mechanical: `name __P((args))` becomes `name(args)`.

This is a prerequisite for musl/Alpine CI coverage (see project CI matrix notes).

Fixes #140

## Test plan

- [ ] `./configure && make` on a standard Linux build
- [ ] `./configure && make` on musl/Alpine (the motivating platform)
- [ ] CI passes