### PR TITLE
libopendkim: don't error on missing CRLF when l= body length tag is used

### DIFF
--- a/libopendkim/dkim-canon.c
+++ b/libopendkim/dkim-canon.c
@@ -1938,7 +1938,8 @@ dkim_canon_closebody(DKIM *dkim)
 		/* handle unprocessed content */
 		if (dkim_dstring_len(cur->canon_buf) > 0)
 		{
-			if ((dkim->dkim_libhandle->dkiml_flags & DKIM_LIBFLAGS_FIXCRLF) != 0)
+			if ((dkim->dkim_libhandle->dkiml_flags & DKIM_LIBFLAGS_FIXCRLF) != 0 ||
+			    cur->canon_remain != (ssize_t) -1)
 			{
 				dkim_canon_buffer(cur,
 				                  dkim_dstring_get(cur->canon_buf),

--- a/libopendkim/tests/Makefile.am
+++ b/libopendkim/tests/Makefile.am
@@ -44,6 +44,7 @@ check_PROGRAMS = t-setup t-test00 t-test01 t-test02 t-test03 t-test04 \
 	t-test157 t-test158 t-test159 t-test160 \
 	t-test200 t-test201 t-test202 t-test203 \
 	t-test204 t-test205 \
+	t-test206 t-test207 \
 	t-signperf t-verifyperf
 check_SCRIPTS = t-signperf-sha1 t-signperf-relaxed-relaxed \
 	t-signperf-simple-simple \
@@ -234,6 +235,8 @@ t_test202_SOURCES = t-test202.c t-testdata.h
 t_test203_SOURCES = t-test203.c t-testdata.h
 t_test204_SOURCES = t-test204.c t-testdata.h
 t_test205_SOURCES = t-test205.c t-testdata.h
+t_test206_SOURCES = t-test206.c t-testdata.h
+t_test207_SOURCES = t-test207.c t-testdata.h
 
 MOSTLYCLEANFILES=
 

--- a/libopendkim/tests/t-test149.c
+++ b/libopendkim/tests/t-test149.c
@@ -156,7 +156,7 @@ main(int argc, char **argv)
 	assert(status == DKIM_STAT_OK);
 
 	status = dkim_eom(dkim, NULL);
-	assert(status == DKIM_STAT_SYNTAX);
+	assert(status == DKIM_STAT_OK);
 
 	status = dkim_free(dkim);
 	assert(status == DKIM_STAT_OK);

--- a/libopendkim/tests/t-test206.c
+++ b/libopendkim/tests/t-test206.c
@@ -1,0 +1,152 @@
+/*
+**  Copyright (c) 2005-2008 Sendmail, Inc. and its suppliers.
+**    All rights reserved.
+**
+**  Copyright (c) 2009, 2011-2013, 2026, The Trusted Domain Project.
+**    All rights reserved.
+*/
+
+/*
+**  t-test206 -- sign+verify with l= where body does not end in CRLF should
+**               succeed; verifies fix for issue #45 ("CRLF at end of body
+**               missing" false positive when l= truncation is in use)
+*/
+
+#include "build-config.h"
+
+/* system includes */
+#include <sys/types.h>
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef USE_GNUTLS
+# include <gnutls/gnutls.h>
+#endif /* USE_GNUTLS */
+
+/* libopendkim includes */
+#include "../dkim.h"
+#include "t-testdata.h"
+
+#define MAXHEADER 4096
+
+/* body content that does not end in CRLF */
+#define TBODY_NOCRLF		"Body without CRLF"
+#define TBODY_NOCRLF_LEN	17
+
+static DKIM_STAT
+key_lookup(DKIM *dkim, DKIM_SIGINFO *sig, unsigned char *buf, size_t buflen)
+{
+	assert(buf != NULL);
+	memset(buf, '\0', buflen);
+	strncpy((char *) buf, PUBLICKEY, buflen - 1);
+	return DKIM_STAT_OK;
+}
+
+int
+main(int argc, char **argv)
+{
+#ifdef TEST_KEEP_FILES
+	u_int flags;
+#endif /* TEST_KEEP_FILES */
+	DKIM_STAT status;
+	DKIM *dkim;
+	DKIM_LIB *lib;
+	dkim_sigkey_t key;
+	unsigned char sig_hdr[MAXHEADER + 1];
+	unsigned char hdr[MAXHEADER + 1];
+
+	printf("*** l= truncation: body without CRLF does not trigger syntax error\n");
+
+#ifdef USE_GNUTLS
+	(void) gnutls_global_init();
+#endif /* USE_GNUTLS */
+
+	lib = dkim_init(NULL, NULL);
+	assert(lib != NULL);
+
+#ifdef TEST_KEEP_FILES
+	flags = (DKIM_LIBFLAGS_TMPFILES|DKIM_LIBFLAGS_KEEPFILES);
+	(void) dkim_options(lib, DKIM_OP_SETOPT, DKIM_OPTS_FLAGS, &flags,
+	                    sizeof flags);
+#endif /* TEST_KEEP_FILES */
+
+	/*
+	**  Sign with an explicit body length (produces l= in the signature).
+	**  The body fed here does not end in CRLF, which is the scenario that
+	**  previously triggered "CRLF at end of body missing" during sign too.
+	*/
+	key = KEY;
+	dkim = dkim_sign(lib, JOBID, NULL, key, SELECTOR, DOMAIN,
+	                 DKIM_CANON_RELAXED, DKIM_CANON_RELAXED,
+	                 DKIM_SIGN_RSASHA256,
+	                 (ssize_t) TBODY_NOCRLF_LEN, &status);
+	assert(dkim != NULL);
+
+	status = dkim_header(dkim, HEADER05, strlen(HEADER05));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_header(dkim, HEADER06, strlen(HEADER06));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_header(dkim, HEADER07, strlen(HEADER07));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_header(dkim, HEADER08, strlen(HEADER08));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_eoh(dkim);
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_body(dkim, (u_char *) TBODY_NOCRLF, TBODY_NOCRLF_LEN);
+	assert(status == DKIM_STAT_OK);
+
+	/* sign eom must not fail with DKIM_STAT_SYNTAX */
+	status = dkim_eom(dkim, NULL);
+	assert(status == DKIM_STAT_OK);
+
+	memset(sig_hdr, '\0', sizeof sig_hdr);
+	status = dkim_getsighdr(dkim, sig_hdr, sizeof sig_hdr,
+	                        strlen(DKIM_SIGNHEADER) + 2);
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_free(dkim);
+	assert(status == DKIM_STAT_OK);
+
+	/*
+	**  Verify: feed the same truncated body without CRLF.
+	**  The verifier sees l= in the signature (canon_remain != -1) and must
+	**  canonicalize the truncated body by appending CRLF rather than
+	**  returning DKIM_STAT_SYNTAX.
+	*/
+	status = dkim_set_key_lookup(lib, key_lookup);
+	assert(status == DKIM_STAT_OK);
+
+	dkim = dkim_verify(lib, JOBID, NULL, &status);
+	assert(dkim != NULL);
+
+	snprintf((char *) hdr, sizeof hdr, "%s: %s", DKIM_SIGNHEADER, sig_hdr);
+	status = dkim_header(dkim, hdr, strlen((char *) hdr));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_header(dkim, HEADER05, strlen(HEADER05));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_header(dkim, HEADER06, strlen(HEADER06));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_header(dkim, HEADER07, strlen(HEADER07));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_header(dkim, HEADER08, strlen(HEADER08));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_eoh(dkim);
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_body(dkim, (u_char *) TBODY_NOCRLF, TBODY_NOCRLF_LEN);
+	assert(status == DKIM_STAT_OK);
+
+	/* verify eom must not fail with DKIM_STAT_SYNTAX */
+	status = dkim_eom(dkim, NULL);
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_free(dkim);
+	assert(status == DKIM_STAT_OK);
+
+	dkim_close(lib);
+
+	return 0;
+}

--- a/libopendkim/tests/t-test207.c
+++ b/libopendkim/tests/t-test207.c
@@ -1,0 +1,145 @@
+/*
+**  Copyright (c) 2005-2008 Sendmail, Inc. and its suppliers.
+**    All rights reserved.
+**
+**  Copyright (c) 2009, 2011-2013, 2026, The Trusted Domain Project.
+**    All rights reserved.
+*/
+
+/*
+**  t-test207 -- regression: body without trailing CRLF and no l= tag still
+**               raises DKIM_STAT_SYNTAX (issue #45)
+*/
+
+#include "build-config.h"
+
+/* system includes */
+#include <sys/types.h>
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef USE_GNUTLS
+# include <gnutls/gnutls.h>
+#endif /* USE_GNUTLS */
+
+/* libopendkim includes */
+#include "../dkim.h"
+#include "t-testdata.h"
+
+#define MAXHEADER 4096
+
+/* body content that does not end in CRLF */
+#define TBODY_NOCRLF		"Body without CRLF"
+#define TBODY_NOCRLF_LEN	17
+
+static DKIM_STAT
+key_lookup(DKIM *dkim, DKIM_SIGINFO *sig, unsigned char *buf, size_t buflen)
+{
+	assert(buf != NULL);
+	memset(buf, '\0', buflen);
+	strncpy((char *) buf, PUBLICKEY, buflen - 1);
+	return DKIM_STAT_OK;
+}
+
+int
+main(int argc, char **argv)
+{
+#ifdef TEST_KEEP_FILES
+	u_int flags;
+#endif /* TEST_KEEP_FILES */
+	DKIM_STAT status;
+	DKIM *dkim;
+	DKIM_LIB *lib;
+	dkim_sigkey_t key;
+	unsigned char sig_hdr[MAXHEADER + 1];
+	unsigned char hdr[MAXHEADER + 1];
+
+	printf("*** no l=: body without CRLF still raises syntax error\n");
+
+#ifdef USE_GNUTLS
+	(void) gnutls_global_init();
+#endif /* USE_GNUTLS */
+
+	lib = dkim_init(NULL, NULL);
+	assert(lib != NULL);
+
+#ifdef TEST_KEEP_FILES
+	flags = (DKIM_LIBFLAGS_TMPFILES|DKIM_LIBFLAGS_KEEPFILES);
+	(void) dkim_options(lib, DKIM_OP_SETOPT, DKIM_OPTS_FLAGS, &flags,
+	                    sizeof flags);
+#endif /* TEST_KEEP_FILES */
+
+	/* sign without body length limit (no l= in signature) */
+	key = KEY;
+	dkim = dkim_sign(lib, JOBID, NULL, key, SELECTOR, DOMAIN,
+	                 DKIM_CANON_RELAXED, DKIM_CANON_RELAXED,
+	                 DKIM_SIGN_RSASHA256, -1L, &status);
+	assert(dkim != NULL);
+
+	status = dkim_header(dkim, HEADER05, strlen(HEADER05));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_header(dkim, HEADER06, strlen(HEADER06));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_header(dkim, HEADER07, strlen(HEADER07));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_header(dkim, HEADER08, strlen(HEADER08));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_eoh(dkim);
+	assert(status == DKIM_STAT_OK);
+
+	/* sign with a proper CRLF-terminated body to get a valid signature */
+	status = dkim_body(dkim, BODY00, strlen(BODY00));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_eom(dkim, NULL);
+	assert(status == DKIM_STAT_OK);
+
+	memset(sig_hdr, '\0', sizeof sig_hdr);
+	status = dkim_getsighdr(dkim, sig_hdr, sizeof sig_hdr,
+	                        strlen(DKIM_SIGNHEADER) + 2);
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_free(dkim);
+	assert(status == DKIM_STAT_OK);
+
+	/*
+	**  Verify: feed a body without trailing CRLF.  Since the signature has
+	**  no l= tag (canon_remain == -1), this must still raise DKIM_STAT_SYNTAX
+	**  and not silently accept the malformed input.
+	*/
+	status = dkim_set_key_lookup(lib, key_lookup);
+	assert(status == DKIM_STAT_OK);
+
+	dkim = dkim_verify(lib, JOBID, NULL, &status);
+	assert(dkim != NULL);
+
+	snprintf((char *) hdr, sizeof hdr, "%s: %s", DKIM_SIGNHEADER, sig_hdr);
+	status = dkim_header(dkim, hdr, strlen((char *) hdr));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_header(dkim, HEADER05, strlen(HEADER05));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_header(dkim, HEADER06, strlen(HEADER06));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_header(dkim, HEADER07, strlen(HEADER07));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_header(dkim, HEADER08, strlen(HEADER08));
+	assert(status == DKIM_STAT_OK);
+	status = dkim_eoh(dkim);
+	assert(status == DKIM_STAT_OK);
+
+	/* feed body WITHOUT trailing CRLF */
+	status = dkim_body(dkim, (u_char *) TBODY_NOCRLF, TBODY_NOCRLF_LEN);
+	assert(status == DKIM_STAT_OK);
+
+	/* without l=, missing CRLF must still be a syntax error */
+	status = dkim_eom(dkim, NULL);
+	assert(status == DKIM_STAT_SYNTAX);
+
+	status = dkim_free(dkim);
+	assert(status == DKIM_STAT_OK);
+
+	dkim_close(lib);
+
+	return 0;
+}


### PR DESCRIPTION
## Summary

When a DKIM signature includes `l=`, the MTA delivers only that many body bytes and replies with `SMFIS_SKIP`. The truncated body may not end with CRLF - which is expected per RFC 6376 §3.7: both simple and relaxed canonicalization append a CRLF to any non-empty body that doesn't already end with one.

The bug: `dkim_canon_closebody()` returned `DKIM_STAT_SYNTAX` ("CRLF at end of body missing") whenever there was buffered content without a trailing CRLF, unless `DKIM_LIBFLAGS_FIXCRLF` was set. With `l=` this was a false positive.

**Fix:** when `canon_remain != -1` (i.e. `l=` was present and set a body length limit), always take the append-CRLF path. `canon_remain` is set from the `l=` value during signature parsing and decrements to 0 after the body bytes are processed - it is never -1 when `l=` is in use. The error path is preserved for signatures without `l=`, consistent with mskucherawy's comment in the original thread.

**Tests added:**
- `t-test206`: sign with explicit body length and body without CRLF; verify that both sign and verify succeed
- `t-test207`: regression - without `l=`, body without CRLF still raises `DKIM_STAT_SYNTAX`

Fixes #45

## Test plan

- [ ] `make check` passes including t-test206 and t-test207
- [ ] CI passes