### PR TITLE
miltertest: allow MT_SMTPREPLY check after any callback, not just EOM

### DIFF
--- a/miltertest/miltertest.c
+++ b/miltertest/miltertest.c
@@ -167,6 +167,7 @@ struct mt_eom_request
 struct mt_context
 {
 	char		ctx_response;		/* milter response code */
+	char		ctx_smtp_reply[BUFRSZ];	/* last SMFIR_REPLYCODE data */
 	int		ctx_fd;			/* descriptor */
 	int		ctx_state;		/* current state */
 	unsigned long	ctx_mactions;		/* requested actions */
@@ -672,6 +673,11 @@ mt_assert_state(struct mt_context *ctx, int state)
 					return FALSE;
 
 				ctx->ctx_response = rcmd;
+				if (rcmd == SMFIR_REPLYCODE)
+					strlcpy(ctx->ctx_smtp_reply, buf,
+					        sizeof ctx->ctx_smtp_reply);
+				else
+					ctx->ctx_smtp_reply[0] = '\0';
 			}
 
 			if (rcmd != SMFIR_CONTINUE)
@@ -715,6 +721,11 @@ mt_assert_state(struct mt_context *ctx, int state)
 					return FALSE;
 
 				ctx->ctx_response = rcmd;
+				if (rcmd == SMFIR_REPLYCODE)
+					strlcpy(ctx->ctx_smtp_reply, buf,
+					        sizeof ctx->ctx_smtp_reply);
+				else
+					ctx->ctx_smtp_reply[0] = '\0';
 			}
 
 			if (rcmd != SMFIR_CONTINUE)
@@ -758,6 +769,11 @@ mt_assert_state(struct mt_context *ctx, int state)
 					return FALSE;
 
 				ctx->ctx_response = rcmd;
+				if (rcmd == SMFIR_REPLYCODE)
+					strlcpy(ctx->ctx_smtp_reply, buf,
+					        sizeof ctx->ctx_smtp_reply);
+				else
+					ctx->ctx_smtp_reply[0] = '\0';
 			}
 
 			if (rcmd != SMFIR_CONTINUE)
@@ -801,6 +817,11 @@ mt_assert_state(struct mt_context *ctx, int state)
 					return FALSE;
 
 				ctx->ctx_response = rcmd;
+				if (rcmd == SMFIR_REPLYCODE)
+					strlcpy(ctx->ctx_smtp_reply, buf,
+					        sizeof ctx->ctx_smtp_reply);
+				else
+					ctx->ctx_smtp_reply[0] = '\0';
 			}
 
 			if (rcmd != SMFIR_CONTINUE)
@@ -841,6 +862,11 @@ mt_assert_state(struct mt_context *ctx, int state)
 					return FALSE;
 
 				ctx->ctx_response = rcmd;
+				if (rcmd == SMFIR_REPLYCODE)
+					strlcpy(ctx->ctx_smtp_reply, buf,
+					        sizeof ctx->ctx_smtp_reply);
+				else
+					ctx->ctx_smtp_reply[0] = '\0';
 			}
 
 			if (rcmd != SMFIR_CONTINUE)
@@ -887,6 +913,11 @@ mt_assert_state(struct mt_context *ctx, int state)
 					return FALSE;
 
 				ctx->ctx_response = rcmd;
+				if (rcmd == SMFIR_REPLYCODE)
+					strlcpy(ctx->ctx_smtp_reply, buf,
+					        sizeof ctx->ctx_smtp_reply);
+				else
+					ctx->ctx_smtp_reply[0] = '\0';
 			}
 
 			if (rcmd != SMFIR_CONTINUE)
@@ -926,6 +957,11 @@ mt_assert_state(struct mt_context *ctx, int state)
 					return FALSE;
 
 				ctx->ctx_response = rcmd;
+				if (rcmd == SMFIR_REPLYCODE)
+					strlcpy(ctx->ctx_smtp_reply, buf,
+					        sizeof ctx->ctx_smtp_reply);
+				else
+					ctx->ctx_smtp_reply[0] = '\0';
 			}
 
 			if (rcmd != SMFIR_CONTINUE)
@@ -966,6 +1002,11 @@ mt_assert_state(struct mt_context *ctx, int state)
 					return FALSE;
 
 				ctx->ctx_response = rcmd;
+				if (rcmd == SMFIR_REPLYCODE)
+					strlcpy(ctx->ctx_smtp_reply, buf,
+					        sizeof ctx->ctx_smtp_reply);
+				else
+					ctx->ctx_smtp_reply[0] = '\0';
 			}
 
 			if (rcmd != SMFIR_CONTINUE)
@@ -1551,6 +1592,7 @@ mt_connect(lua_State *l)
 	new->ctx_state = STATE_INIT;
 	new->ctx_fd = fd;
 	new->ctx_response = '\0';
+	new->ctx_smtp_reply[0] = '\0';
 	new->ctx_eomreqs = NULL;
 	new->ctx_mactions = 0;
 	new->ctx_mpopts = 0;
@@ -1831,6 +1873,10 @@ mt_negotiate(lua_State *l)
 	}
 
 	ctx->ctx_response = rcmd;
+	if (rcmd == SMFIR_REPLYCODE)
+		strlcpy(ctx->ctx_smtp_reply, buf, sizeof ctx->ctx_smtp_reply);
+	else
+		ctx->ctx_smtp_reply[0] = '\0';
 	ctx->ctx_state = STATE_NEGOTIATED;
 
 	/* decode and store requested protocol steps and actions */
@@ -2144,6 +2190,10 @@ mt_conninfo(lua_State *l)
 	}
 
 	ctx->ctx_response = rcmd;
+	if (rcmd == SMFIR_REPLYCODE)
+		strlcpy(ctx->ctx_smtp_reply, buf, sizeof ctx->ctx_smtp_reply);
+	else
+		ctx->ctx_smtp_reply[0] = '\0';
 	ctx->ctx_state = STATE_CONNINFO;
 
 	if (verbose > 0)
@@ -2235,6 +2285,10 @@ mt_unknown(lua_State *l)
 	}
 
 	ctx->ctx_response = rcmd;
+	if (rcmd == SMFIR_REPLYCODE)
+		strlcpy(ctx->ctx_smtp_reply, buf, sizeof ctx->ctx_smtp_reply);
+	else
+		ctx->ctx_smtp_reply[0] = '\0';
 
 	if (verbose > 0)
 	{
@@ -2320,6 +2374,10 @@ mt_helo(lua_State *l)
 	}
 
 	ctx->ctx_response = rcmd;
+	if (rcmd == SMFIR_REPLYCODE)
+		strlcpy(ctx->ctx_smtp_reply, buf, sizeof ctx->ctx_smtp_reply);
+	else
+		ctx->ctx_smtp_reply[0] = '\0';
 	ctx->ctx_state = STATE_HELO;
 
 	if (verbose > 0)
@@ -2414,6 +2472,10 @@ mt_mailfrom(lua_State *l)
 	}
 
 	ctx->ctx_response = rcmd;
+	if (rcmd == SMFIR_REPLYCODE)
+		strlcpy(ctx->ctx_smtp_reply, buf, sizeof ctx->ctx_smtp_reply);
+	else
+		ctx->ctx_smtp_reply[0] = '\0';
 	ctx->ctx_state = STATE_ENVFROM;
 	mt_flush_eomreqs(ctx);
 
@@ -2516,6 +2578,10 @@ mt_rcptto(lua_State *l)
 	}
 
 	ctx->ctx_response = rcmd;
+	if (rcmd == SMFIR_REPLYCODE)
+		strlcpy(ctx->ctx_smtp_reply, buf, sizeof ctx->ctx_smtp_reply);
+	else
+		ctx->ctx_smtp_reply[0] = '\0';
 	ctx->ctx_state = STATE_ENVRCPT;
 
 	if (verbose > 0)
@@ -2595,6 +2661,10 @@ mt_data(lua_State *l)
 	}
 
 	ctx->ctx_response = rcmd;
+	if (rcmd == SMFIR_REPLYCODE)
+		strlcpy(ctx->ctx_smtp_reply, buf, sizeof ctx->ctx_smtp_reply);
+	else
+		ctx->ctx_smtp_reply[0] = '\0';
 	ctx->ctx_state = STATE_DATA;
 
 	if (verbose > 0)
@@ -2692,6 +2762,10 @@ mt_header(lua_State *l)
 	}
 
 	ctx->ctx_response = rcmd;
+	if (rcmd == SMFIR_REPLYCODE)
+		strlcpy(ctx->ctx_smtp_reply, buf, sizeof ctx->ctx_smtp_reply);
+	else
+		ctx->ctx_smtp_reply[0] = '\0';
 	ctx->ctx_state = STATE_HEADER;
 
 	if (verbose > 0)
@@ -2765,6 +2839,10 @@ mt_eoh(lua_State *l)
 	}
 
 	ctx->ctx_response = rcmd;
+	if (rcmd == SMFIR_REPLYCODE)
+		strlcpy(ctx->ctx_smtp_reply, buf, sizeof ctx->ctx_smtp_reply);
+	else
+		ctx->ctx_smtp_reply[0] = '\0';
 	ctx->ctx_state = STATE_EOH;
 
 	if (verbose > 0)
@@ -2841,6 +2919,10 @@ mt_bodystring(lua_State *l)
 	}
 
 	ctx->ctx_response = rcmd;
+	if (rcmd == SMFIR_REPLYCODE)
+		strlcpy(ctx->ctx_smtp_reply, buf, sizeof ctx->ctx_smtp_reply);
+	else
+		ctx->ctx_smtp_reply[0] = '\0';
 	ctx->ctx_state = STATE_BODY;
 
 	if (verbose > 0)
@@ -2932,6 +3014,10 @@ mt_bodyrandom(lua_State *l)
 		}
 
 		ctx->ctx_response = rcmd;
+		if (rcmd == SMFIR_REPLYCODE)
+			strlcpy(ctx->ctx_smtp_reply, buf, sizeof ctx->ctx_smtp_reply);
+		else
+			ctx->ctx_smtp_reply[0] = '\0';
 		ctx->ctx_state = STATE_BODY;
 
 		if (verbose > 0)
@@ -3050,6 +3136,10 @@ mt_bodyfile(lua_State *l)
 	fclose(f);
 
 	ctx->ctx_response = rcmd;
+	if (rcmd == SMFIR_REPLYCODE)
+		strlcpy(ctx->ctx_smtp_reply, chunk, sizeof ctx->ctx_smtp_reply);
+	else
+		ctx->ctx_smtp_reply[0] = '\0';
 	ctx->ctx_state = STATE_BODY;
 
 	lua_pushnil(l);
@@ -3637,22 +3727,29 @@ mt_eom_check(lua_State *l)
 
 		lua_pop(l, lua_gettop(l));
 
-		for (r = ctx->ctx_eomreqs; r != NULL; r = r->eom_next)
 		{
-			if (r->eom_request == SMFIR_REPLYCODE)
+			char rbuf[BUFRSZ];
+
+			snprintf(rbuf, sizeof rbuf, "%s%s%s%s%s",
+			         smtp,
+			         esc == NULL ? "" : " ", esc == NULL ? "" : esc,
+			         text == NULL ? "" : " ", text == NULL ? "" : text);
+
+			for (r = ctx->ctx_eomreqs; r != NULL; r = r->eom_next)
 			{
-				char rbuf[BUFRSZ];
-
-				snprintf(rbuf, sizeof rbuf, "%s%s%s%s%s",
-				         smtp,
-				         esc == NULL ? "" : " ", esc == NULL ? "" : esc,
-				         text == NULL ? "" : " ", text == NULL ? "" : text);
-
-				if (strcmp(rbuf, (char *) r->eom_rdata) == 0)
+				if (r->eom_request == SMFIR_REPLYCODE &&
+				    strcmp(rbuf, (char *) r->eom_rdata) == 0)
 				{
 					lua_pushboolean(l, 1);
 					return 1;
 				}
+			}
+
+			if (ctx->ctx_smtp_reply[0] != '\0' &&
+			    strcmp(rbuf, ctx->ctx_smtp_reply) == 0)
+			{
+				lua_pushboolean(l, 1);
+				return 1;
 			}
 		}
 


### PR DESCRIPTION
## Problem

`mt.eom_check(ctx, MT_SMTPREPLY, ...)` only worked after `mt.eom()` because SMFIR_REPLYCODE data was only captured in the EOM request accumulator (`ctx_eomreqs`). Milters can send a custom SMTP reply from any callback - for example, rejecting a message in `mailfrom` or `rcptto` - making it impossible to test those replies with miltertest.

## Fix

- Add `char ctx_smtp_reply[BUFRSZ]` to `struct mt_context` to capture the last SMFIR_REPLYCODE data from any non-EOM callback.
- Every callback that reads a milter response (connect, helo, mailfrom, rcptto, data, header, eoh, bodystring, bodyrandom, bodyfile, and the automatic state-advancement paths in `mt_assert_state`) now saves the reply string when `rcmd == SMFIR_REPLYCODE` and clears the field otherwise.
- `mt_eom_check(MT_SMTPREPLY)` checks `ctx_eomreqs` first (the EOM path, unchanged), then falls back to `ctx_smtp_reply` (the non-EOM path).

This means `mt.eom_check(ctx, MT_SMTPREPLY, "550", "5.1.1", "User unknown")` now works immediately after `mt.mailfrom()` or `mt.rcptto()` without requiring an EOM phase.

Fixes #95.