### PR TITLE
opendkim: fix always-false NULL check on mctx_domain array (issue #88)

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -4977,7 +4977,7 @@ dkimf_add_signrequest(struct msgctx *dfc, DKIMF_DB keytable, char *keyname,
 		}
 
 		if (domain[0] == '%' && domain[1] == '\0' &&
-		    dfc->mctx_domain == NULL)
+		    dfc->mctx_domain[0] == '\0')
 		{
 			if (dolog)
 			{


### PR DESCRIPTION
## Summary

- `mctx_domain` is declared as `unsigned char mctx_domain[DKIM_MAXHOSTNAMELEN + 1]` - a fixed-size array, not a pointer
- The comparison `dfc->mctx_domain == NULL` is always false, meaning the error-log-and-return path at that site was dead code
- Changed to `dfc->mctx_domain[0] == '\0'` to correctly detect an unset message domain, consistent with the same check at line 11952

Fixes #88