### PR TITLE
opendkim: improve too-much-header-data log and SMTP reply (issue #143)

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -11525,8 +11525,11 @@ mlfi_header(SMFICTX *ctx, char *headerf, char *headerv)
 	if (conf->conf_maxhdrsz > 0 &&
 	    dfc->mctx_hdrbytes + strlen(headerf) + strlen(headerv) + 2 > conf->conf_maxhdrsz)
 	{
-		dkimf_log(conf, LOG_NOTICE, "too much header data");
-
+		dkimf_log(conf, LOG_NOTICE,
+		          "%s: too much header data (header '%s' would exceed limit of %u bytes)",
+		          dfc->mctx_jobid, headerf, conf->conf_maxhdrsz);
+		(void) dkimf_setreply(ctx, "552", "5.3.4",
+		                      "header size exceeds maximum");
 		return dkimf_miltercode(ctx,
 		                        conf->conf_handling.hndl_security,
 		                        NULL);


### PR DESCRIPTION
## Summary

- The bare `"too much header data"` log message gave no context - no job ID, no header name, no size info
- Added job ID, offending header field name, and the configured `MaximumHeaders` limit to the log line
- Added a `552 5.3.4` SMTP reply so the sending MTA receives a descriptive permanent error rather than a generic service-unavailable response
- `OnSecurity` config still controls accept/reject/tempfail behavior; this just makes each outcome more informative

Fixes #143

Credit to @andreasschulze for the original diagnosis and proposed approach.