### PR TITLE
opendkim: don't add A-R header in sign-only mode when sender unresolvable (issue #130)

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -11866,9 +11866,12 @@ mlfi_eoh(SMFICTX *ctx)
 			  "%s: can't determine message sender; accepting",
 			  dfc->mctx_jobid);
 
-		dfc->mctx_addheader = TRUE;
-		dfc->mctx_headeronly = TRUE;
-		dfc->mctx_status = DKIMF_STATUS_BADFORMAT;
+		if ((conf->conf_mode & DKIMF_MODE_VERIFIER) != 0)
+		{
+			dfc->mctx_addheader = TRUE;
+			dfc->mctx_headeronly = TRUE;
+			dfc->mctx_status = DKIMF_STATUS_BADFORMAT;
+		}
 		dkimf_dstring_free(addr);
 		return SMFIS_CONTINUE;
 	}
@@ -11918,9 +11921,12 @@ mlfi_eoh(SMFICTX *ctx)
 #endif /* _FFR_DEFAULT_SENDER */
 		}
 
-		dfc->mctx_addheader = TRUE;
-		dfc->mctx_headeronly = TRUE;
-		dfc->mctx_status = DKIMF_STATUS_BADFORMAT;
+		if ((conf->conf_mode & DKIMF_MODE_VERIFIER) != 0)
+		{
+			dfc->mctx_addheader = TRUE;
+			dfc->mctx_headeronly = TRUE;
+			dfc->mctx_status = DKIMF_STATUS_BADFORMAT;
+		}
 		dkimf_dstring_free(addr);
 		return SMFIS_CONTINUE;
 	}


### PR DESCRIPTION
## Summary

- In `mlfi_eoh()`, when the message sender can't be determined or parsed, opendkim was unconditionally setting `mctx_addheader = TRUE` and inserting an `Authentication-Results: ... dkim=permerror (bad message/signature format)` header
- In sign-only mode (`Mode s`), no A-R headers should ever be added - that's verification output
- Fix: guard both sites with `(conf->conf_mode & DKIMF_MODE_VERIFIER) != 0` so the BADFORMAT A-R header is only inserted when verification is active

Fixes #130