### PR TITLE
opendkim: insert A-R and DKIM-Signature headers at index 0 (issue #24)

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -3617,7 +3617,7 @@ dkimf_xs_addheader(lua_State *l)
 
 	if (ctx == NULL)
 		lua_pushnil(l);
-	else if (dkimf_insheader(ctx, 1, name, value) == MI_SUCCESS)
+	else if (dkimf_insheader(ctx, 0, name, value) == MI_SUCCESS)
 		lua_pushnumber(l, 1);
 	else
 		lua_pushnil(l);
@@ -4185,7 +4185,7 @@ dkimf_add_ar_fields(struct msgctx *dfc, struct dkimf_config *conf,
 	assert(conf != NULL);
 	assert(ctx != NULL);
 
-	if (dkimf_insheader(ctx, 1, AUTHRESULTSHDR,
+	if (dkimf_insheader(ctx, 0, AUTHRESULTSHDR,
 	                    (char *) dfc->mctx_dkimar) == MI_FAILURE)
 	{
 		dkimf_log(conf, LOG_ERR, "%s: %s header add failed",
@@ -13540,7 +13540,7 @@ mlfi_eom(SMFICTX *ctx)
 		         dkimf_lookup_inttostr(dfc->mctx_status,
 		                               dkimf_statusstrings));
 
-		if (dkimf_insheader(ctx, 1, AUTHRESULTSHDR,
+		if (dkimf_insheader(ctx, 0, AUTHRESULTSHDR,
 		                    (char *) header) == MI_FAILURE)
 		{
 			dkimf_log(conf, LOG_ERR,
@@ -14942,7 +14942,7 @@ mlfi_eom(SMFICTX *ctx)
 						        sizeof header);
 					}
 		
-					if (dkimf_insheader(ctx, 1,
+					if (dkimf_insheader(ctx, 0,
 					                    AUTHRESULTSHDR,
 					                    (char *) header) == MI_FAILURE)
 					{
@@ -15130,7 +15130,7 @@ mlfi_eom(SMFICTX *ctx)
 			dkimf_stripcr((char *) start);
 			dkimf_dstring_cat(dfc->mctx_tmpstr, start);
 
-			if (dkimf_insheader(ctx, 1, DKIM_SIGNHEADER,
+			if (dkimf_insheader(ctx, 0, DKIM_SIGNHEADER,
 			                    (char *) dkimf_dstring_get(dfc->mctx_tmpstr)) == MI_FAILURE)
 			{
 				dkimf_log(conf, LOG_ERR,
@@ -15163,7 +15163,7 @@ mlfi_eom(SMFICTX *ctx)
 		/* add VBR-Info header if generated */
 		if (dfc->mctx_vbrinfo != NULL)
 		{
-			if (dkimf_insheader(ctx, 1, VBR_INFOHEADER,
+			if (dkimf_insheader(ctx, 0, VBR_INFOHEADER,
 			                    dfc->mctx_vbrinfo) == MI_FAILURE)
 			{
 				dkimf_log(conf, LOG_ERR,
@@ -15208,7 +15208,7 @@ mlfi_eom(SMFICTX *ctx)
 		         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
 		                                 : (u_char *) JOBIDUNKNOWN);
 
-		if (dkimf_insheader(ctx, 1, SWHEADERNAME, xfhdr) != MI_SUCCESS)
+		if (dkimf_insheader(ctx, 0, SWHEADERNAME, xfhdr) != MI_SUCCESS)
 		{
 			dkimf_log(conf, LOG_ERR, "%s: %s header add failed",
 				  dfc->mctx_jobid, SWHEADERNAME);


### PR DESCRIPTION
## Summary

- RFC 8601 sections 4 and 7.1 explicitly require `Authentication-Results` to be inserted before the MTA's `Received` header
- SpamAssassin and other verifiers use the position of AR headers relative to trusted `Received` headers to determine trust
- All `dkimf_insheader()` calls used index `1` (insert after the first header); changed to `0` (prepend before all headers) across all 7 call sites: `Authentication-Results`, `DKIM-Signature`, `VBR-Info`, and `X-OpenDKIM`

Credit to @glts (original PR #126) and @fanto666 for the patch.

Fixes #24