### PR TITLE
Fix spelling in docs/code comments

### DIFF
--- a/BRANCHES
+++ b/BRANCHES
@@ -61,7 +61,7 @@ br-msk-lua	Experimenting with LUA for scriptable policy hooks
 br-msk-lua-dataset
 		Experimental addition of a new "lua:" dataset type.
 
-br-msk-lua-dbs	Support for abitrary data set operations from Lua scripts.
+br-msk-lua-dbs	Support for arbitrary data set operations from Lua scripts.
 
 br-msk-openldap	OpenLDAP integration work
 

--- a/INSTALL
+++ b/INSTALL
@@ -50,7 +50,7 @@ doesn't find it, you will need to specify the location with
 --with-db-libdir
 --with-db-lib
 		These provide a finer control over the location of BerkeleyDB
-		include, library path and libary name where the default 
+		include, library path and library name where the default
 		locations of --with-db are not enough.
 
 --with-domain	Specifies the local domain name in use.  Used only for

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -37,7 +37,7 @@ release, and a summary of the changes in that release.
 	Fix bug #237: Fix processing of "SoftStart".
 	CONFIG: Add compatibility with openssl-1.1.0.  Patch from
 		Scott Kitterman.
-	CONTRIB: Simplfy some logic in contrib/repute.  Patch from
+	CONTRIB: Simplify some logic in contrib/repute.  Patch from
 		Dilyan Palauzov.
 	LIBOPENDKIM: Feature request #190: Reject signature object requests
 		where the domain name or selector includes non-printable
@@ -60,7 +60,7 @@ release, and a summary of the changes in that release.
 		as dkim_test_key2(). For API compatibility, function interface
 		of dkim_test_key() is not changed, but it only calls
 		dkim_test_key2(). Patch from Yasuhito Futatsuki.
-	TOOLS: Feature requrest #187: Add option to match subdomains when
+	TOOLS: Feature request #187: Add option to match subdomains when
 		generating zone files.  Patch from Andreas Schulze.
 	TOOLS: issue #183: On opendkim-testkey, add support for ed25519 keys.
 		Patch from Yasuhito Futatsuki.
@@ -863,7 +863,7 @@ release, and a summary of the changes in that release.
 		and final callbacks.  Problem noted by Heikki Gruner.
 	LIBOPENDKIM: Fix up initialization under _FFR_OVERSIGN.  Problem
 		noted by Eray Aslan.
-	BUILD: Adjust gprof code to accomodate systems that put profiling
+	BUILD: Adjust gprof code to accommodate systems that put profiling
 		output in <binary>.gmon rather than gmon.out.
 
 2.4.0		2011/06/06
@@ -1097,7 +1097,7 @@ release, and a summary of the changes in that release.
 		becomes unresponsive during response processing.  Problem
 		noted by Gary Mills.
 	BUILD: Move all scripts and executables except opendkim to a bin
-		directory for adminstrator convenience.  They were previously
+		directory for administrator convenience.  They were previously
 		in sbin.
 	BUILD: Fix bug #SF3101842: Fix opendkim-genzone build when OpenDBX
 		is in use.
@@ -1127,7 +1127,7 @@ release, and a summary of the changes in that release.
 	LIBOPENDKIM: Fix bug #SF3081964: dkim.h requires <sys/time.h>.
 		Patch from Kaspar Brand.
 	LIBOPENDKIM: Fix bug #SF3087251: Use thread-safe resolver functions
-		when avaialble.  Problem noted by Christian Pelissier.
+		when available.  Problem noted by Christian Pelissier.
 	LIBOPENDKIM: Cancel completed reputation queries.  Problem noted
 		by John Wood.
 	LIBOPENDKIM: Simplify DKIM_OPTS_ALWAYSHDRS handling.
@@ -1486,7 +1486,7 @@ release, and a summary of the changes in that release.
 		which isn't big enough for IPv6 addresses.  Use a
 		(struct sockaddr_storage) instead.  Problem noted by
 		Werner Wiethege.
-	Fix initalization and processing of ODBX requests.
+	Fix initialization and processing of ODBX requests.
 	Fix DB get operations for Sleepycat versions prior to 2.0.0.
 	Set a flag when crypto initialization is done so that cleanup
 		occurs on shutdown.  Problem noted by Deiva Shanmugam.

--- a/RELEASE_NOTES.Sendmail
+++ b/RELEASE_NOTES.Sendmail
@@ -738,12 +738,12 @@ were logged internally at Sendmail, Inc.
 		of messages bearing multiple signatures.  This included the
 		following changes:
 		o Extend draft-ietf-dkim-ssp-00 support to cover
-			multiply-signed messags.
+			multiply-signed messages.
 		o Introduce DKIM_SIGERROR type/constants for associating
 			an error code with each individual signature.
-		o New libary flag DKIM_LIBFLAG_DELAYSIGPROC delays all
+		o New library flag DKIM_LIBFLAG_DELAYSIGPROC delays all
 			signature processing until dkim_eom().
-		o New libary flag DKIM_LIBFLAG_EOHCHECK causes dkim_eoh()
+		o New library flag DKIM_LIBFLAG_EOHCHECK causes dkim_eoh()
 			to return an error if it was unable to find any
 			valid signatures when verifying.
 		o Add new DKIM_CANON data type, referring to a

--- a/contrib/docs/chroot
+++ b/contrib/docs/chroot
@@ -5,7 +5,7 @@ Contributed by Andreas Schulze
 
 Running opendkim chroot adds an additional layer of complexity. It is disabled
 by default.  Only advanced users only should try to enable that special
-configuration.  To successfull setup a chroot jail you must configure opendkim
+configuration.  To successfully setup a chroot jail you must configure opendkim
 to run *without* that restriction first!
 
 enabling chroot jail
@@ -15,7 +15,7 @@ opendkim.conf.  Then you must restart opendkim.
 
 setting up syslog
 =================
-opendkim requieres a syslog socket inside the chroot.  You have to edit your
+opendkim requires a syslog socket inside the chroot.  You have to edit your
 syslog daemon configuration.
 
   for rsyslog:
@@ -42,7 +42,7 @@ be placed inside /path/to/chroot.
 
 setup entropie
 ==============
-opendkim needs access to /dev/random or a similiar random generator.
+opendkim needs access to /dev/random or a similar random generator.
 
   for linux:
   install -d /path/to/chroot/dev/

--- a/contrib/ldap/README.LDAP
+++ b/contrib/ldap/README.LDAP
@@ -81,7 +81,7 @@ to disclose the full signer identity in signatures.
 
 
 Single signature
-In its simpliest form the query retrieves a single signing key. It will be the
+In its simplest form the query retrieves a single signing key. It will be the
 key from the identity that matches opendkims query strategy best.
 
 The following example uses the opendkim.schema to configure such a query in

--- a/libopendkim/README
+++ b/libopendkim/README
@@ -27,5 +27,5 @@ Cryptography libraries, such as openssl and gnutls, that can be used with
 libopendkim may have initialization requirements.  libopendkim will not
 initialize these libraries for you, as doing so may interfere with other
 aspects of the application calling this library.  It is therefore the
-responsibility of the calling application to initailize the crypto library
+responsibility of the calling application to initialize the crypto library
 before attempting DKIM signing or validation, or unexpected errors can occur.

--- a/libopendkim/dkim-mailparse.c
+++ b/libopendkim/dkim-mailparse.c
@@ -6,7 +6,7 @@
 **    All rights reserved.
 */
 
-/* system inludes */
+/* system includes */
 #include <sys/types.h>
 #include <ctype.h>
 #include <string.h>

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -1304,7 +1304,7 @@ dkim_privkey_load(DKIM *dkim)
 }
 
 /*
-**  DKIM_CHECK_REQUIREDHDRS -- see if all requried headers are present
+**  DKIM_CHECK_REQUIREDHDRS -- see if all required headers are present
 **
 **  Parameters:
 **  	dkim -- DKIM handle
@@ -6135,7 +6135,7 @@ dkim_ohdrs(DKIM *dkim, DKIM_SIGINFO *sig, u_char **ptrs, int *pcnt)
 		}
 	}
 
-	/* none useable; return error */
+	/* none usable; return error */
 	if (sig == NULL)
 		return DKIM_STAT_INVALID;
 
@@ -7421,7 +7421,7 @@ dkim_getsighdr_d(DKIM *dkim, size_t initial, u_char **buf, size_t *buflen)
 **  	dkim -- libopendkim handle
 **  	buf -- buffer into which to write
 **  	buflen -- bytes available at "buf"
-**  	initial -- width aleady consumed for the first line
+**  	initial -- width already consumed for the first line
 **
 **  Return value:
 **  	A DKIM_STAT_* constant.
@@ -7908,7 +7908,7 @@ dkim_sig_getcanonlen(DKIM *dkim, DKIM_SIGINFO *sig, ssize_t *msglen,
 }
 
 /*
-**  DKIM_SIG_GETFLAGS -- retreive signature handle flags
+**  DKIM_SIG_GETFLAGS -- retrieve signature handle flags
 **
 **  Parameters:
 **  	sig -- DKIM_SIGINFO handle
@@ -7927,7 +7927,7 @@ dkim_sig_getflags(DKIM_SIGINFO *sig)
 }
 
 /*
-**  DKIM_SIG_GETBH -- retreive signature handle "bh" test state
+**  DKIM_SIG_GETBH -- retrieve signature handle "bh" test state
 **
 **  Parameters:
 **  	sig -- DKIM_SIGINFO handle

--- a/libopendkim/dkim.h
+++ b/libopendkim/dkim.h
@@ -853,7 +853,7 @@ extern DKIM_STAT dkim_options __P((DKIM_LIB *dkimlib, int op, dkim_opts_t opt,
                                    void *ptr, size_t len));
 
 /*
-**  DKIM_SIG_GETFLAGS -- retreive signature handle flags
+**  DKIM_SIG_GETFLAGS -- retrieve signature handle flags
 **
 **  Parameters:
 **  	sig -- DKIM_SIGINFO handle
@@ -866,7 +866,7 @@ extern DKIM_STAT dkim_options __P((DKIM_LIB *dkimlib, int op, dkim_opts_t opt,
 extern unsigned int dkim_sig_getflags __P((DKIM_SIGINFO *sig));
 
 /*
-**  DKIM_SIG_GETBH -- retreive signature handle "bh" test state
+**  DKIM_SIG_GETBH -- retrieve signature handle "bh" test state
 **
 **  Parameters:
 **  	sig -- DKIM_SIGINFO handle
@@ -879,7 +879,7 @@ extern unsigned int dkim_sig_getflags __P((DKIM_SIGINFO *sig));
 extern int dkim_sig_getbh __P((DKIM_SIGINFO *sig));
 
 /*
-**  DKIM_SIG_GETKEYSIZE -- retreive key size after verifying
+**  DKIM_SIG_GETKEYSIZE -- retrieve key size after verifying
 **
 **  Parameters:
 **  	sig -- DKIM_SIGINFO handle
@@ -893,7 +893,7 @@ extern DKIM_STAT dkim_sig_getkeysize __P((DKIM_SIGINFO *sig,
                                           unsigned int *bits));
 
 /*
-**  DKIM_SIG_GETSIGNALG -- retreive signature algorithm after verifying
+**  DKIM_SIG_GETSIGNALG -- retrieve signature algorithm after verifying
 **
 **  Parameters:
 **  	sig -- DKIM_SIGINFO handle
@@ -906,7 +906,7 @@ extern DKIM_STAT dkim_sig_getkeysize __P((DKIM_SIGINFO *sig,
 extern DKIM_STAT dkim_sig_getsignalg __P((DKIM_SIGINFO *sig, dkim_alg_t *alg));
 
 /*
-**  DKIM_SIG_GETSIGNTIME -- retreive signature timestamp after verifying
+**  DKIM_SIG_GETSIGNTIME -- retrieve signature timestamp after verifying
 **
 **  Parameters:
 **  	sig -- DKIM_SIGINFO handle

--- a/libopendkim/docs/dkim_options.html
+++ b/libopendkim/docs/dkim_options.html
@@ -148,7 +148,7 @@ of the library's operation.
                                 Attempting <tt>DKIM_OP_GETOPT</tt> on this
                                 option returns an error as it is converted
                                 internally to regular expressions and not
-				currently stored in a useable form.</td></tr>
+				currently stored in a usable form.</td></tr>
            <tr valign="top"><td><tt>DKIM_OPTS_SKIPHDRS</tt></td>
                             <td><tt>data</tt> refers to an unordered,
                                 NULL-terminated array of header names which
@@ -171,7 +171,7 @@ of the library's operation.
                                 Attempting <tt>DKIM_OP_GETOPT</tt> on this
                                 option returns an error as it is converted
                                 to regular expressions and not currently
-                                stored in a useable form.</td></tr>
+                                stored in a usable form.</td></tr>
            <tr valign="top"><td><tt>DKIM_OPTS_TMPDIR</tt></td>
                             <td><tt>data</tt> refers to a string which is
                                 the directory <tt>libopendkim</tt> should use for
@@ -200,7 +200,7 @@ of the library's operation.
 <tr>
 <th valign="top" align=left>FLAGS</th> 
 <td>
-When setting or retreiving library flags, the method is to specify
+When setting or retrieving library flags, the method is to specify
 a bitwise-OR of flag bits in an unsigned integer.  The recognized flags
 are:
 <table border="1" cellspacing=0>
@@ -265,7 +265,7 @@ are:
   <td>Perform a signature check at the end of
       <a href="dkim_eoh.html"><tt>dkim_eoh()</tt></a>.
       This will cause <tt>dkim_eoh()</tt> to return an error code if no
-      useable signatures were found in the message. </td>
+      usable signatures were found in the message. </td>
  </tr>
  <tr>
   <td><tt>DKIM_LIBFLAGS_FIXCRLF</tt></td>

--- a/libopendkim/docs/dkim_privkey_load.html
+++ b/libopendkim/docs/dkim_privkey_load.html
@@ -25,7 +25,7 @@ Attempt to load and prepare a private key for signing.
 <th width="80">Called When</th>
 <td><tt>dkim_privkey_load()</tt> is called after 
     <a href="dkim_sign.html"><tt>dkim_sign()</tt></a> is called to create
-    a message signing handle.  It attemps to parse the key provided
+    a message signing handle.  It attempts to parse the key provided
     as an argument to that function and extract some parameters of it.
     This same operation will be done implicitly by
     <a href="dkim_eom.html"><tt>dkim_eom()</tt></a> if not called explicitly

--- a/libopendkim/docs/dkim_sig_getsignalg.html
+++ b/libopendkim/docs/dkim_sig_getsignalg.html
@@ -52,7 +52,7 @@ Retrieve the signature algorithm used to sign a message after verification.
     <tr bgcolor="#dddddd"><th>Value</th><th>Description</th></tr>
     <tr valign="top"><td><tt>DKIM_STAT_INVALID</tt></td>
 	<td>The function was called before <tt>dkim_sig_process()</tt> or
-        <tt>dkim_eom()</tt> processed the siganture.
+        <tt>dkim_eom()</tt> processed the signature.
 	</td></tr>
     <tr valign="top"><td><tt>DKIM_STAT_OK</tt></td>
 	<td>Successful completion.

--- a/libopendkim/docs/dkim_signhdrs.html
+++ b/libopendkim/docs/dkim_signhdrs.html
@@ -50,7 +50,7 @@ default.
 <th valign="top" align=left>NOTES</th> 
 <td>
 <ul>
-<li>This overides the list of header field names previously selected as the
+<li>This overrides the list of header field names previously selected as the
 library default by a call to
 <a href="dkim_options.html"><tt>dkim_options()</tt></a>.  It affects only the
 handle passed to the function.  If not called, the default set configured for

--- a/libopendkim/tests/Makefile.am
+++ b/libopendkim/tests/Makefile.am
@@ -294,7 +294,7 @@ check-local: check-TESTS description.html
 		--description-file description.html
 
 # remove t- prefix and replace - with _ from testnames because lcov doesn't handle it
-# keep consistant with gcov-helper.sh
+# keep consistent with gcov-helper.sh
 
 description.txt: $(check_PROGRAMS) $(check_SCRIPTS)
 	rm -f $@

--- a/libopendkim/tests/lcov-helper.sh
+++ b/libopendkim/tests/lcov-helper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 $1
 x=$?
-# keep consistant with Makefile.am
+# keep consistent with Makefile.am
 testname=${1/.\/t-}
 testname=${testname//-/_}
 lcov --capture --directory .. --output-file $1.info --test-name ${testname} --quiet

--- a/libut/ut.c
+++ b/libut/ut.c
@@ -106,7 +106,7 @@ ut_hexdigit(int c)
 
 /*
 **  UT_PCT_ENCODED -- determine whether or not a pct-encoded byte has
-**                    been encoutered
+**                    been encountered
 **
 **  Parameters:
 **  	p -- string to scan

--- a/libvbr/vbr.3
+++ b/libvbr/vbr.3
@@ -243,7 +243,7 @@ further description for the most recent failed operation.
 
 Calling
 .B vbr_getheader()
-can be used to generate an RFC-compliant VBR-Info: haeder field based on data
+can be used to generate an RFC-compliant VBR-Info: header field based on data
 provided by other accessor functions, namely
 .I vbr_setcert(),
 .I vbr_settype()

--- a/libvbr/vbr.c
+++ b/libvbr/vbr.c
@@ -552,7 +552,7 @@ vbr_res_waitreply(void *srv, void *qh, struct timeval *to, size_t *bytes,
 **  	buflen -- size of output buffer
 **
 **  Return value:
-**  	TRUE iff ansbuf contains an IN TXT reply that could be deocde.
+**  	TRUE iff ansbuf contains an IN TXT reply that could be decoded.
 */
 
 static _Bool

--- a/libvbr/vbr.pc.in
+++ b/libvbr/vbr.pc.in
@@ -6,7 +6,7 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: VBR (Vouch by reference library)
-Description: Library for assisting in Vouch By Refence functions
+Description: Library for assisting in Vouch By Reference functions
 URL: http://opendkim.org
 Version: @VERSION@
 Libs: -L${libdir} -lvbr

--- a/opendkim/README
+++ b/opendkim/README
@@ -54,7 +54,7 @@ Consult your documentation for other packet filter and policy systems.
 CONFIGURING OPENDKIM
 ====================
 
-NOTE: If you will only be verfiying incoming mail and will not be signing,
+NOTE: If you will only be verifying incoming mail and will not be signing,
 start at step (5).
 
 (1) Choose a selector name.  A selector is simply a symbolic name given to
@@ -86,7 +86,7 @@ start at step (5).
     For a translation of the parameters and value pairs, see RFC6376.  Using 
     "t=y" is indicates you are in "test mode", advising verifiers that they
     should not take any real action based on success or failure of the use
-    of this key after verifing a message.  Remove the "t=y" once you have
+    of this key after verifying a message.  Remove the "t=y" once you have
     tested the DKIM signing of your messages to your satisfaction.
 
     You might want to set a short TTL on this record during testing so
@@ -108,7 +108,7 @@ start at step (5).
 
         dig -t ns DOMAIN
 
-    If the key can be retreived correctly then opendkim-testkey can be used to
+    If the key can be retrieved correctly then opendkim-testkey can be used to
     verify that the key matches the private key.
 
         opendkim-testkey -d DOMAIN -s SELECTOR -k rsa.private
@@ -126,7 +126,7 @@ start at step (5).
 (5) Take a look at the opendkim.conf.simple as an example configuration file 
     for your domain.  If you wish to sign mail that comes from sources other 
     than the localhost address (127.0.0.1), include these in CIDR notation in
-    the confiugration file for the InternalHosts configuration option.
+    the configuration file for the InternalHosts configuration option.
 
 (6) Start opendkim.  You will need at least the "-p" option.  The current
     recommended set of command line options is:
@@ -331,7 +331,7 @@ NOTES ON POSTFIX REWRITING OF MESSAGES
 Like other MIME-aware MTAs, Postfix downgrades 8bit body content to 7bit when
 a remote SMTP server does not announce 8BITMIME support.  If DKIM signatures
 must survive transmission to servers that don't announce 8BITMIME, it is
-recommented to downgrade before signing (for example, specify
+recommended to downgrade before signing (for example, specify
 "-o smtp_discard_ehlo_keywords=8bitmime,silent-discard" for an SMTP client
 that delivers to a null filter or to amavisd).
 

--- a/opendkim/config.c
+++ b/opendkim/config.c
@@ -63,7 +63,7 @@ static void config_attach __P((struct config *, struct config **));
 static int conf_error;			/* configuration error number */
 
 /*
-**  CONFIG_GETLINE -- read a line of arbitary length from a stream
+**  CONFIG_GETLINE -- read a line of arbitrary length from a stream
 **
 **  Parameters:
 **  	in -- input stream

--- a/opendkim/final.lua.sample
+++ b/opendkim/final.lua.sample
@@ -9,7 +9,7 @@
 --  received and processed but before the filter renders its final verdict.
 --  The main use of this script is to determine whether or not the message
 --  is acceptable to the verifier, and what final filtering action should be
---  taken.  For exmaple, if the message failed Author Domain Signing
+--  taken.  For example, if the message failed Author Domain Signing
 --  Practises tests, or had additional data appended to it beyond what the
 --  signature covered, or even if the signature simply failed to verify,
 --  this script can detect such things and take whatever action is desired.

--- a/opendkim/opendkim-db.c
+++ b/opendkim/opendkim-db.c
@@ -846,7 +846,7 @@ dkimf_db_datasplit(char *buf, size_t buflen,
 **  Parameters:
 **  	buf -- parameter (the actual query)
 **  	query -- query string (a domain name?)
-**  	out -- outbut buffer
+**  	out -- output buffer
 **  	outlen -- size of "out"
 **
 **  Return value:
@@ -1809,7 +1809,7 @@ dkimf_db_erl_decode_response(ei_x_buff *resp, const char *notfound,
 **  	Currently defined types:
 **  	csl -- "name" contains a comma-separated list
 **  	file -- a flat file; may be simply a list of names if only a
-**  	        memership test is needed, or it can be "key value" lines
+**  	        membership test is needed, or it can be "key value" lines
 **  	        in which case dkimf_db_get() can be used to extract the
 **  	        value of a named key
 **  	refile -- a flat file containing patterns (i.e. strings with the
@@ -1818,7 +1818,7 @@ dkimf_db_erl_decode_response(ei_x_buff *resp, const char *notfound,
 **  	      for membership tests or key-value pairs
 **  	dsn -- a data store name, meaning SQL or ODBC in the backend,
 **  	       with interface provided by OpenDBX
-**  	ldap -- an LDAP server, interace provide by OpenLDAP
+**  	ldap -- an LDAP server, interface provided by OpenLDAP
 **  	lua -- a Lua script; the returned value is the result
 **  	erlang -- an erlang function to be called in a distributed erlang node
 */

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -6135,7 +6135,7 @@ dkimf_parsehandler(struct config *cfg, char *name, struct handling *hndl,
 /*
 **  DKIMF_CONFIG_LOAD -- load a configuration handle based on file content
 **
-**  Paramters:
+**  Parameters:
 **  	data -- configuration data loaded from config file
 **  	conf -- configuration structure to load
 **  	err -- where to write errors

--- a/opendkim/tests/cp-test
+++ b/opendkim/tests/cp-test
@@ -2,7 +2,7 @@
 
 # small tool to copy a test case
 
-# XXX TODO arg 3 should be a description approprately inserted to the files
+# XXX TODO arg 3 should be a description appropriately inserted to the files
 
 if [ $# -lt 2 ]
 then

--- a/opendkim/tests/lcov-helper.sh
+++ b/opendkim/tests/lcov-helper.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 $1
 x=$?
-# keep consistant with Makefile.am
+# keep consistent with Makefile.am
 testname=${1/.\/t-}
 testname=${testname//-/_}
 lcov --capture --directory ../.. --output-file $1.info --test-name ${testname} --quiet

--- a/opendkim/tests/t-verify-report.lua
+++ b/opendkim/tests/t-verify-report.lua
@@ -36,7 +36,7 @@ if mt.getreply(conn) ~= SMFIR_CONTINUE then
 	error("mt.conninfo() unexpected reply")
 end
 
--- send HELO unles it was negotiated out
+-- send HELO unless it was negotiated out
 if not mt.test_option(conn, SMFIP_NOHELO) then
 	if mt.helo(conn, "localhost") ~= nil then
 		error("mt.helo() failed")

--- a/opendkim/tests/t-verify-syntax.lua
+++ b/opendkim/tests/t-verify-syntax.lua
@@ -1,6 +1,6 @@
 -- Copyright (c) 2010-2013, The Trusted Domain Project.  All rights reserved.
 
--- Syntax error proccessing test
+-- Syntax error processing test
 -- 
 -- Confirms that an message with a syntax error TEMPFAILs
 

--- a/reputation/repute.c
+++ b/reputation/repute.c
@@ -128,7 +128,7 @@ repute_curl_writedata(char *ptr, size_t size, size_t nmemb, void *userdata)
 **  	rep -- returned reputation
 **  	conf -- confidence
 **  	sample -- sample size
-**  	limit -- recommented flow limit
+**  	limit -- recommended flow limit
 **  	when -- timestamp on the report
 **
 **  Return value:
@@ -614,7 +614,7 @@ repute_new(const char *server, unsigned int reporter)
 /*
 **  REPUTE_CLOSE -- tear down a REPUTE handle
 **
-**  Paramters:
+**  Parameters:
 **  	rep -- REPUTE handle to shut down
 **
 **  Return value:

--- a/reputation/repute.php
+++ b/reputation/repute.php
@@ -8,7 +8,7 @@
 #
 
 #
-# load local configuration for databae values
+# load local configuration for database values
 #
 require "repute-config.php";
 

--- a/www/upgrading.html
+++ b/www/upgrading.html
@@ -46,7 +46,7 @@ that package.  However, a few things have changed:
 
 <ul>
  <li> In version 2.1.0 of OpenDKIM, a number of command line options were
-      removed as they are redundant to the configuraton file and generally
+      removed as they are redundant to the configuration file and generally
       access to them at the command line is not useful (i.e. there's little
       chance one would need to change them quickly, such as during testing).
       See the <a href="#2.1.0">OpenDKIM 2.1.0</a> section for specifics.


### PR DESCRIPTION
Cherry-pick of #180 by @selsky, rebased onto develop with one minor conflict resolved in RELEASE_NOTES (develop had added new entries around the same line).

No logic changes - purely mechanical spelling corrections across 32 files.