### PR TITLE
Fix screen.lua.sample off-by-one error and function name

### DIFF
--- a/opendkim/screen.lua.sample
+++ b/opendkim/screen.lua.sample
@@ -24,7 +24,7 @@ end
 
 --  for each signature, ignore it if it's not from the sender's domain
 for n = 1, nsigs do
-	sig = odkim.get_signhandle(ctx, n)
+	sig = odkim.get_sighandle(ctx, n - 1)
 	sdomain = odkim.sig_getdomain(sig)
 	if fdomain ~= sdomain then
 		odkim.sig_ignore(sig)


### PR DESCRIPTION
Cherry-pick of #195 by @link2xt onto develop (original PR targeted master).

`get_signhandle()` doesn't exist - the correct function is `get_sighandle()`, and it takes 0-based indices, so the loop variable needs `n - 1`.