### PR TITLE
OpenSSL 3: replace deprecated SHA/MD context APIs with EVP

### DIFF
--- a/libopendkim/base32.c
+++ b/libopendkim/base32.c
@@ -158,22 +158,21 @@ dkim_base32_encode(char *buf, size_t *buflen, const void *data, size_t size)
 
 #ifdef TEST
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 
 int
 main(int argc, char **argv)
 {
 	int x;
 	size_t buflen;
-	SHA_CTX sha;
 	char buf[128];
 	unsigned char shaout[SHA_DIGEST_LENGTH];
 
 	memset(buf, '\0', sizeof buf);
 	buflen = sizeof buf;
 
-	SHA1_Init(&sha);
-	SHA1_Update(&sha, argv[1], strlen(argv[1]));
-	SHA1_Final(shaout, &sha);
+	(void) EVP_Digest(argv[1], strlen(argv[1]), shaout, NULL, EVP_sha1(),
+	                  NULL);
 
 	x = dkim_base32_encode(buf, &buflen, shaout, SHA_DIGEST_LENGTH);
 

--- a/libopendkim/dkim-atps.c
+++ b/libopendkim/dkim-atps.c
@@ -36,6 +36,7 @@
 #else /* USE_GNUTLS */
 /* openssl includes */
 # include <openssl/sha.h>
+# include <openssl/evp.h>
 #endif /* USE_GNUTLS */
 
 /* prototypes */
@@ -112,11 +113,6 @@ dkim_atps_check(DKIM *dkim, DKIM_SIGINFO *sig, struct timeval *timeout,
 	u_char *eom;
 #ifdef USE_GNUTLS
 	gnutls_hash_hd_t ctx;
-#else /* USE_GNUTLS */
-        SHA_CTX ctx;
-# ifdef HAVE_SHA256
-	SHA256_CTX ctx2;
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 	struct timeval to;
 	HEADER hdr;
@@ -197,16 +193,14 @@ dkim_atps_check(DKIM *dkim, DKIM_SIGINFO *sig, struct timeval *timeout,
 		switch (hash)
 		{
 		  case DKIM_HASHTYPE_SHA1:
-			SHA1_Init(&ctx);
-			SHA1_Update(&ctx, sdomain, strlen(sdomain));
-			SHA1_Final(digest, &ctx);
+			(void) EVP_Digest(sdomain, strlen(sdomain), digest,
+			                  NULL, EVP_sha1(), NULL);
 			break;
 
 #  ifdef HAVE_SHA256
 		  case DKIM_HASHTYPE_SHA256:
-			SHA256_Init(&ctx2);
-			SHA256_Update(&ctx2, sdomain, strlen(sdomain));
-			SHA256_Final(digest, &ctx2);
+			(void) EVP_Digest(sdomain, strlen(sdomain), digest,
+			                  NULL, EVP_sha256(), NULL);
 			break;
 #  endif /* HAVE_SHA256 */
 

--- a/libopendkim/dkim-canon.c
+++ b/libopendkim/dkim-canon.c
@@ -116,38 +116,27 @@ dkim_canon_free(DKIM *dkim, DKIM_CANON *canon)
 
 #else /* USE_GNUTLS */
 		  case DKIM_HASHTYPE_SHA1:
-		  {
-			struct dkim_sha1 *sha1;
-
-			sha1 = (struct dkim_sha1 *) canon->canon_hash;
-
-			if (sha1->sha1_tmpbio != NULL)
-			{
-				BIO_free(sha1->sha1_tmpbio);
-				sha1->sha1_tmpfd = -1;
-				sha1->sha1_tmpbio = NULL;
-			}
-
-			break;
-		  }
-
-# ifdef HAVE_SHA256
 		  case DKIM_HASHTYPE_SHA256:
 		  {
-			struct dkim_sha256 *sha256;
+			struct dkim_sha *sha;
 
-			sha256 = (struct dkim_sha256 *) canon->canon_hash;
+			sha = (struct dkim_sha *) canon->canon_hash;
 
-			if (sha256->sha256_tmpbio != NULL)
+			if (sha->sha_tmpbio != NULL)
 			{
-				BIO_free(sha256->sha256_tmpbio);
-				sha256->sha256_tmpfd = -1;
-				sha256->sha256_tmpbio = NULL;
+				BIO_free(sha->sha_tmpbio);
+				sha->sha_tmpfd = -1;
+				sha->sha_tmpbio = NULL;
+			}
+
+			if (sha->sha_ctx != NULL)
+			{
+				EVP_MD_CTX_free(sha->sha_ctx);
+				sha->sha_ctx = NULL;
 			}
 
 			break;
 		  }
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 
 		  default:
@@ -217,32 +206,18 @@ dkim_canon_write(DKIM_CANON *canon, u_char *buf, size_t buflen)
 	  }
 #else /* USE_GNUTLS */
 	  case DKIM_HASHTYPE_SHA1:
-	  {
-		struct dkim_sha1 *sha1;
-
-		sha1 = (struct dkim_sha1 *) canon->canon_hash;
-		SHA1_Update(&sha1->sha1_ctx, buf, buflen);
-
-		if (sha1->sha1_tmpbio != NULL)
-			BIO_write(sha1->sha1_tmpbio, buf, buflen);
-
-		break;
-	  }
-
-# ifdef HAVE_SHA256
 	  case DKIM_HASHTYPE_SHA256:
 	  {
-		struct dkim_sha256 *sha256;
+		struct dkim_sha *sha;
 
-		sha256 = (struct dkim_sha256 *) canon->canon_hash;
-		SHA256_Update(&sha256->sha256_ctx, buf, buflen);
+		sha = (struct dkim_sha *) canon->canon_hash;
+		EVP_DigestUpdate(sha->sha_ctx, buf, buflen);
 
-		if (sha256->sha256_tmpbio != NULL)
-			BIO_write(sha256->sha256_tmpbio, buf, buflen);
+		if (sha->sha_tmpbio != NULL)
+			BIO_write(sha->sha_tmpbio, buf, buflen);
 
 		break;
 	  }
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 	}
 
@@ -700,76 +675,51 @@ dkim_canon_init(DKIM *dkim, _Bool tmp, _Bool keep)
 		  }
 #else /* USE_GNUTLS */
 		  case DKIM_HASHTYPE_SHA1:
-		  {
-			struct dkim_sha1 *sha1;
-
-			sha1 = (struct dkim_sha1 *) DKIM_MALLOC(dkim,
-			                                        sizeof(struct dkim_sha1));
-			if (sha1 == NULL)
-			{
-				dkim_error(dkim,
-				           "unable to allocate %d byte(s)",
-				           sizeof(struct dkim_sha1));
-				return DKIM_STAT_NORESOURCE;
-			}
-
-			memset(sha1, '\0', sizeof(struct dkim_sha1));
-			SHA1_Init(&sha1->sha1_ctx);
-
-			if (tmp)
-			{
-				status = dkim_tmpfile(dkim, &fd, keep);
-				if (status != DKIM_STAT_OK)
-				{
-					DKIM_FREE(dkim, sha1);
-					return status;
-				}
-
-				sha1->sha1_tmpfd = fd;
-				sha1->sha1_tmpbio = BIO_new_fd(fd, 1);
-			}
-
-			cur->canon_hash = sha1;
-
-		  	break;
-		  }
-
-# ifdef HAVE_SHA256
 		  case DKIM_HASHTYPE_SHA256:
 		  {
-			struct dkim_sha256 *sha256;
+			struct dkim_sha *sha;
 
-			sha256 = (struct dkim_sha256 *) DKIM_MALLOC(dkim,
-			                                            sizeof(struct dkim_sha256));
-			if (sha256 == NULL)
+			sha = (struct dkim_sha *) DKIM_MALLOC(dkim,
+			                                      sizeof(struct dkim_sha));
+			if (sha == NULL)
 			{
 				dkim_error(dkim,
 				           "unable to allocate %d byte(s)",
-				           sizeof(struct dkim_sha256));
+				           sizeof(struct dkim_sha));
 				return DKIM_STAT_NORESOURCE;
 			}
 
-			memset(sha256, '\0', sizeof(struct dkim_sha256));
-			SHA256_Init(&sha256->sha256_ctx);
+			memset(sha, '\0', sizeof(struct dkim_sha));
+
+			sha->sha_ctx = EVP_MD_CTX_new();
+			if (cur->canon_hashtype == DKIM_HASHTYPE_SHA1)
+			{
+				(void) EVP_DigestInit_ex(sha->sha_ctx,
+				                         EVP_sha1(), NULL);
+			}
+			else
+			{
+				(void) EVP_DigestInit_ex(sha->sha_ctx,
+				                         EVP_sha256(), NULL);
+			}
 
 			if (tmp)
 			{
 				status = dkim_tmpfile(dkim, &fd, keep);
 				if (status != DKIM_STAT_OK)
 				{
-					DKIM_FREE(dkim, sha256);
+					DKIM_FREE(dkim, sha);
 					return status;
 				}
 
-				sha256->sha256_tmpfd = fd;
-				sha256->sha256_tmpbio = BIO_new_fd(fd, 1);
+				sha->sha_tmpfd = fd;
+				sha->sha_tmpbio = BIO_new_fd(fd, 1);
 			}
 
-			cur->canon_hash = sha256;
+			cur->canon_hash = sha;
 
 		  	break;
 		  }
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 
 		  default:
@@ -1421,32 +1371,19 @@ dkim_canon_runheaders(DKIM *dkim)
 
 #else /* USE_GNUTLS */
 		  case DKIM_HASHTYPE_SHA1:
-		  {
-			struct dkim_sha1 *sha1;
-
-			sha1 = (struct dkim_sha1 *) cur->canon_hash;
-			SHA1_Final(sha1->sha1_out, &sha1->sha1_ctx);
-
-			if (sha1->sha1_tmpbio != NULL)
-				(void) BIO_flush(sha1->sha1_tmpbio);
-
-			break;
-		  }
-
-# ifdef HAVE_SHA256
 		  case DKIM_HASHTYPE_SHA256:
 		  {
-			struct dkim_sha256 *sha256;
+			struct dkim_sha *sha;
 
-			sha256 = (struct dkim_sha256 *) cur->canon_hash;
-			SHA256_Final(sha256->sha256_out, &sha256->sha256_ctx);
+			sha = (struct dkim_sha *) cur->canon_hash;
+			EVP_DigestFinal_ex(sha->sha_ctx, sha->sha_out,
+			                   &sha->sha_outlen);
 
-			if (sha256->sha256_tmpbio != NULL)
-				(void) BIO_flush(sha256->sha256_tmpbio);
+			if (sha->sha_tmpbio != NULL)
+				(void) BIO_flush(sha->sha_tmpbio);
 
 			break;
 		  }
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 
 		  default:
@@ -1557,34 +1494,22 @@ dkim_canon_signature(DKIM *dkim, struct dkim_header *hdr)
 
 			break;
 		  }
+
 #else /* USE_GNUTLS */
 		  case DKIM_HASHTYPE_SHA1:
-		  {
-			struct dkim_sha1 *sha1;
-
-			sha1 = (struct dkim_sha1 *) cur->canon_hash;
-			SHA1_Final(sha1->sha1_out, &sha1->sha1_ctx);
-
-			if (sha1->sha1_tmpbio != NULL)
-				(void) BIO_flush(sha1->sha1_tmpbio);
-
-			break;
-		  }
-
-# ifdef HAVE_SHA256
 		  case DKIM_HASHTYPE_SHA256:
 		  {
-			struct dkim_sha256 *sha256;
+			struct dkim_sha *sha;
 
-			sha256 = (struct dkim_sha256 *) cur->canon_hash;
-			SHA256_Final(sha256->sha256_out, &sha256->sha256_ctx);
+			sha = (struct dkim_sha *) cur->canon_hash;
+			EVP_DigestFinal_ex(sha->sha_ctx, sha->sha_out,
+			                   &sha->sha_outlen);
 
-			if (sha256->sha256_tmpbio != NULL)
-				(void) BIO_flush(sha256->sha256_tmpbio);
+			if (sha->sha_tmpbio != NULL)
+				(void) BIO_flush(sha->sha_tmpbio);
 
 			break;
 		  }
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 
 		  default:
@@ -1995,32 +1920,19 @@ dkim_canon_closebody(DKIM *dkim)
 		  }
 #else /* USE_GNUTLS */
 		  case DKIM_HASHTYPE_SHA1:
-		  {
-			struct dkim_sha1 *sha1;
-
-			sha1 = (struct dkim_sha1 *) cur->canon_hash;
-			SHA1_Final(sha1->sha1_out, &sha1->sha1_ctx);
-
-			if (sha1->sha1_tmpbio != NULL)
-				(void) BIO_flush(sha1->sha1_tmpbio);
-
-			break;
-		  }
-
-# ifdef HAVE_SHA256
 		  case DKIM_HASHTYPE_SHA256:
 		  {
-			struct dkim_sha256 *sha256;
+			struct dkim_sha *sha;
 
-			sha256 = (struct dkim_sha256 *) cur->canon_hash;
-			SHA256_Final(sha256->sha256_out, &sha256->sha256_ctx);
+			sha = (struct dkim_sha *) cur->canon_hash;
+			EVP_DigestFinal_ex(sha->sha_ctx, sha->sha_out,
+			                   &sha->sha_outlen);
 
-			if (sha256->sha256_tmpbio != NULL)
-				(void) BIO_flush(sha256->sha256_tmpbio);
+			if (sha->sha_tmpbio != NULL)
+				(void) BIO_flush(sha->sha_tmpbio);
 
 			break;
 		  }
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 
 		  default:
@@ -2072,28 +1984,16 @@ dkim_canon_getfinal(DKIM_CANON *canon, u_char **digest, size_t *dlen)
 	  }
 #else /* USE_GNUTLS */
 	  case DKIM_HASHTYPE_SHA1:
-	  {
-		struct dkim_sha1 *sha1;
-
-		sha1 = (struct dkim_sha1 *) canon->canon_hash;
-		*digest = sha1->sha1_out;
-		*dlen = sizeof sha1->sha1_out;
-
-		return DKIM_STAT_OK;
-	  }
-
-# ifdef HAVE_SHA256
 	  case DKIM_HASHTYPE_SHA256:
 	  {
-		struct dkim_sha256 *sha256;
+		struct dkim_sha *sha;
 
-		sha256 = (struct dkim_sha256 *) canon->canon_hash;
-		*digest = sha256->sha256_out;
-		*dlen = sizeof sha256->sha256_out;
+		sha = (struct dkim_sha *) canon->canon_hash;
+		*digest = sha->sha_out;
+		*dlen = sha->sha_outlen;
 
 		return DKIM_STAT_OK;
 	  }
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 
 	  default:

--- a/libopendkim/dkim-test.c
+++ b/libopendkim/dkim-test.c
@@ -464,7 +464,7 @@ dkim_test_key2(DKIM_LIB *lib, char *selector, char *domain,
 		}
 		else
 		{
-			crypto->crypto_keysize = EVP_PKEY_get_size(crypto->crypto_pkey);
+			crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
 
 			outkey = BIO_new(BIO_s_mem());
 			if (outkey == NULL)

--- a/libopendkim/dkim-test.c
+++ b/libopendkim/dkim-test.c
@@ -27,6 +27,7 @@
 # include <openssl/bio.h>
 # include <openssl/rsa.h>
 # include <openssl/evp.h>
+# include <openssl/x509.h>
 #endif /* USE_GNUTLS */
 
 /* libopendkim includes */
@@ -463,7 +464,7 @@ dkim_test_key2(DKIM_LIB *lib, char *selector, char *domain,
 		}
 		else
 		{
-			crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
+			crypto->crypto_keysize = EVP_PKEY_get_size(crypto->crypto_pkey);
 
 			outkey = BIO_new(BIO_s_mem());
 			if (outkey == NULL)

--- a/libopendkim/dkim-types.h
+++ b/libopendkim/dkim-types.h
@@ -207,12 +207,10 @@ struct dkim_crypto
 	gnutls_datum_t 		crypto_rsaout;
 	gnutls_datum_t 		crypto_keydata;
 #else /* USE_GNUTLS */
-	u_char			crypto_pad;
 	int			crypto_keysize;
 	size_t			crypto_inlen;
 	size_t			crypto_outlen;
 	EVP_PKEY *		crypto_pkey;
-	void *			crypto_key;
 	BIO *			crypto_keydata;
 	u_char *		crypto_in;
 	u_char *		crypto_out;

--- a/libopendkim/dkim-types.h
+++ b/libopendkim/dkim-types.h
@@ -37,6 +37,7 @@
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/sha.h>
+# include <openssl/evp.h>
 #endif /* USE_GNUTLS */
 
 #ifdef QUERY_CACHE
@@ -151,36 +152,22 @@ struct dkim_siginfo
 	struct dkim_dstring *	sig_sslerrbuf;
 };
 
-#ifdef USE_GNUTLS
 /* struct dkim_sha -- stuff needed to do a sha hash */
 struct dkim_sha
 {
+#ifdef USE_GNUTLS
 	int			sha_tmpfd;
 	u_int			sha_outlen;
 	gnutls_hash_hd_t	sha_hd;
 	u_char *		sha_out;
-};
 #else /* USE_GNUTLS */
-/* struct dkim_sha1 -- stuff needed to do a sha1 hash */
-struct dkim_sha1
-{
-	int			sha1_tmpfd;
-	BIO *			sha1_tmpbio;
-	SHA_CTX			sha1_ctx;
-	u_char			sha1_out[SHA_DIGEST_LENGTH];
-};
-
-# ifdef HAVE_SHA256
-/* struct dkim_sha256 -- stuff needed to do a sha256 hash */
-struct dkim_sha256
-{
-	int			sha256_tmpfd;
-	BIO *			sha256_tmpbio;
-	SHA256_CTX		sha256_ctx;
-	u_char			sha256_out[SHA256_DIGEST_LENGTH];
-};
-# endif /* HAVE_SHA256 */
+	int			sha_tmpfd;
+	BIO *			sha_tmpbio;
+	EVP_MD_CTX *		sha_ctx;
+	u_char			sha_out[EVP_MAX_MD_SIZE];
+	u_int			sha_outlen;
 #endif /* USE_GNUTLS */
+};
 
 /* struct dkim_canon -- a canonicalization status handle */
 struct dkim_canon

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -7650,40 +7650,22 @@ dkim_sig_getreportinfo(DKIM *dkim, DKIM_SIGINFO *sig,
 		  }
 #else /* USE_GNUTLS */
 		  case DKIM_HASHTYPE_SHA1:
-		  {
-			struct dkim_sha1 *sha1;
-
-			sha1 = (struct dkim_sha1 *) sig->sig_hdrcanon->canon_hash;
-			if (hfd != NULL)
-				*hfd = sha1->sha1_tmpfd;
-
-			if (bfd != NULL)
-			{
-				sha1 = (struct dkim_sha1 *) sig->sig_bodycanon->canon_hash;
-				*bfd = sha1->sha1_tmpfd;
-			}
-
-			break;
-		  }
-
-# ifdef HAVE_SHA256
 		  case DKIM_HASHTYPE_SHA256:
 		  {
-			struct dkim_sha256 *sha256;
+			struct dkim_sha *sha;
 
-			sha256 = (struct dkim_sha256 *) sig->sig_hdrcanon->canon_hash;
+			sha = (struct dkim_sha *) sig->sig_hdrcanon->canon_hash;
 			if (hfd != NULL)
-				*hfd = sha256->sha256_tmpfd;
+				*hfd = sha->sha_tmpfd;
 
 			if (bfd != NULL)
 			{
-				sha256 = (struct dkim_sha256 *) sig->sig_bodycanon->canon_hash;
-				*bfd = sha256->sha256_tmpfd;
+				sha = (struct dkim_sha *) sig->sig_bodycanon->canon_hash;
+				*bfd = sha->sha_tmpfd;
 			}
 
 			break;
 		  }
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 
 		  default:

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -1264,7 +1264,7 @@ dkim_privkey_load(DKIM *dkim)
 		}
 	}
 
-	crypto->crypto_outlen = EVP_PKEY_get_size(crypto->crypto_pkey);
+	crypto->crypto_outlen = EVP_PKEY_size(crypto->crypto_pkey);
 	crypto->crypto_keysize = crypto->crypto_outlen * 8;
 
 	crypto->crypto_out = DKIM_MALLOC(dkim, crypto->crypto_outlen);
@@ -5845,7 +5845,7 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 		{
 			EVP_MD_CTX *md_ctx;
 
-			if (EVP_PKEY_get_id(crypto->crypto_pkey) != EVP_PKEY_ED25519)
+			if (EVP_PKEY_id(crypto->crypto_pkey) != EVP_PKEY_ED25519)
 			{
 				dkim_error(dkim,
 				           "s=%s d=%s: not an ED25519 key",
@@ -5899,12 +5899,12 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 
 			EVP_MD_CTX_free(md_ctx);
 
-			crypto->crypto_keysize = EVP_PKEY_get_size(crypto->crypto_pkey);
+			crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
 		}
 		else
 # endif /* HAVE_ED25519 */
 		{
-			if (EVP_PKEY_get_base_id(crypto->crypto_pkey) != EVP_PKEY_RSA)
+			if (EVP_PKEY_base_id(crypto->crypto_pkey) != EVP_PKEY_RSA)
 			{
 				dkim_error(dkim,
 				           "s=%s d=%s: not an RSA key",
@@ -5918,7 +5918,7 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 				return DKIM_STAT_OK;
 			}
 
-			crypto->crypto_keysize = EVP_PKEY_get_size(crypto->crypto_pkey);
+			crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
 
 			crypto->crypto_in = sig->sig_sig;
 			crypto->crypto_inlen = sig->sig_siglen;

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -75,6 +75,7 @@
 # include <openssl/bio.h>
 # include <openssl/err.h>
 # include <openssl/sha.h>
+# include <openssl/evp.h>
 #endif /* USE_GNUTLS */
 
 /* libopendkim includes */
@@ -199,12 +200,6 @@ void dkim_error __P((DKIM *, const char *, ...));
 # define BIO_CLOBBER(x)	if ((x) != NULL) \
 			{ \
 				BIO_free((x)); \
-				(x) = NULL; \
-			}
-
-# define RSA_CLOBBER(x)	if ((x) != NULL) \
-			{ \
-				RSA_free((x)); \
 				(x) = NULL; \
 			}
 
@@ -1269,32 +1264,14 @@ dkim_privkey_load(DKIM *dkim)
 		}
 	}
 
-	if (dkim->dkim_signalg == DKIM_SIGN_ED25519SHA256)
-	{
-		crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey) * 8;
-	}
-	else
-	{
-		crypto->crypto_key = EVP_PKEY_get1_RSA(crypto->crypto_pkey);
-		if (crypto->crypto_key == NULL)
-		{
-			dkim_load_ssl_errors(dkim, 0);
-			dkim_error(dkim, "EVP_PKEY_get1_RSA() failed");
-			BIO_CLOBBER(crypto->crypto_keydata);
-			return DKIM_STAT_NORESOURCE;
-		}
+	crypto->crypto_outlen = EVP_PKEY_get_size(crypto->crypto_pkey);
+	crypto->crypto_keysize = crypto->crypto_outlen * 8;
 
-		crypto->crypto_keysize = RSA_size(crypto->crypto_key) * 8;
-		crypto->crypto_pad = RSA_PKCS1_PADDING;
-	}
-
-	crypto->crypto_outlen = crypto->crypto_keysize / 8;
 	crypto->crypto_out = DKIM_MALLOC(dkim, crypto->crypto_outlen);
 	if (crypto->crypto_out == NULL)
 	{
 		dkim_error(dkim, "unable to allocate %d byte(s)",
-		           crypto->crypto_keysize / 8);
-		RSA_free(crypto->crypto_key);
+		           crypto->crypto_outlen);
 		BIO_CLOBBER(crypto->crypto_keydata);
 		return DKIM_STAT_NORESOURCE;
 	}
@@ -3674,7 +3651,6 @@ static DKIM_STAT
 dkim_eom_sign(DKIM *dkim)
 {
 	int status;
-	size_t l = 0;
 	size_t diglen;
 	size_t siglen = 0;
 	size_t len;
@@ -3810,9 +3786,7 @@ dkim_eom_sign(DKIM *dkim)
 #ifdef USE_GNUTLS
 	if (crypto->crypto_privkey == NULL)
 #else /* USE_GNUTLS */
-	if (!(crypto->crypto_key != NULL ||
-	      (sig->sig_signalg == DKIM_SIGN_ED25519SHA256 &&
-	       crypto->crypto_pkey != NULL)))
+	if (crypto->crypto_pkey == NULL)
 #endif /* USE_GNUTLS */
 	{
 		dkim_error(dkim, "private key load failed");
@@ -3948,38 +3922,82 @@ dkim_eom_sign(DKIM *dkim)
 	  case DKIM_SIGN_RSASHA1:
 	  case DKIM_SIGN_RSASHA256:
 	  {
-		int nid;
 		struct dkim_crypto *crypto;
+		EVP_PKEY_CTX *pkey_ctx;
+		const EVP_MD *md;
 
 		crypto = (struct dkim_crypto *) sig->sig_signature;
 
-		nid = NID_sha1;
+		pkey_ctx = EVP_PKEY_CTX_new(crypto->crypto_pkey, NULL);
 
-		if (dkim_libfeature(dkim->dkim_libhandle,
-		                    DKIM_FEATURE_SHA256) &&
-		    sig->sig_hashtype == DKIM_HASHTYPE_SHA256)
-			nid = NID_sha256;
+		if (pkey_ctx == NULL)
+		{
+			dkim_error(dkim, "failed to allocate EVP_PKEY context");
+			BIO_CLOBBER(crypto->crypto_keydata);
+			return DKIM_STAT_NORESOURCE;
+		}
 
-		status = RSA_sign(nid, digest, diglen,
-	                          crypto->crypto_out, (int *) &l,
-		                  crypto->crypto_key);
-		if (status != 1 || l == 0)
+		if (EVP_PKEY_sign_init(pkey_ctx) <= 0)
 		{
 			dkim_load_ssl_errors(dkim, 0);
 			dkim_error(dkim,
-			           "signature generation failed (status %d, length %d)",
-			           status, l);
+			           "failed to initialize EVP_PKEY context");
 
-			RSA_free(crypto->crypto_key);
+			EVP_PKEY_CTX_free(pkey_ctx);
 			BIO_CLOBBER(crypto->crypto_keydata);
 
 			return DKIM_STAT_INTERNAL;
 		}
 
-		crypto->crypto_outlen = l;
+		if (EVP_PKEY_CTX_set_rsa_padding(pkey_ctx, RSA_PKCS1_PADDING) <= 0)
+		{
+			dkim_load_ssl_errors(dkim, 0);
+			dkim_error(dkim, "failed to set RSA padding mode");
+
+			EVP_PKEY_CTX_free(pkey_ctx);
+			BIO_CLOBBER(crypto->crypto_keydata);
+
+			return DKIM_STAT_INTERNAL;
+		}
+
+		md = EVP_sha1();
+
+		if (dkim_libfeature(dkim->dkim_libhandle,
+		                    DKIM_FEATURE_SHA256) &&
+		    sig->sig_hashtype == DKIM_HASHTYPE_SHA256)
+			md = EVP_sha256();
+
+		if (EVP_PKEY_CTX_set_signature_md(pkey_ctx, md) <= 0)
+		{
+			dkim_load_ssl_errors(dkim, 0);
+			dkim_error(dkim, "failed to set message digest type");
+
+			EVP_PKEY_CTX_free(pkey_ctx);
+			BIO_CLOBBER(crypto->crypto_keydata);
+
+			return DKIM_STAT_INTERNAL;
+		}
+
+		status = EVP_PKEY_sign(pkey_ctx, crypto->crypto_out,
+		                       &crypto->crypto_outlen, digest, diglen);
+
+		if (status != 1 || crypto->crypto_outlen == 0)
+		{
+			dkim_load_ssl_errors(dkim, 0);
+			dkim_error(dkim,
+			           "signature generation failed (status %d, length %d)",
+			           status, crypto->crypto_outlen);
+
+			EVP_PKEY_CTX_free(pkey_ctx);
+			BIO_CLOBBER(crypto->crypto_keydata);
+
+			return DKIM_STAT_INTERNAL;
+		}
 
 		signature = crypto->crypto_out;
 		siglen = crypto->crypto_outlen;
+
+		EVP_PKEY_CTX_free(pkey_ctx);
 
 		break;
 	  }
@@ -3999,7 +4017,6 @@ dkim_eom_sign(DKIM *dkim)
 			dkim_error(dkim,
 			           "failed to initialize digest context");
 
-			RSA_free(crypto->crypto_key);
 			BIO_CLOBBER(crypto->crypto_keydata);
 
 			return DKIM_STAT_INTERNAL;
@@ -4009,9 +4026,9 @@ dkim_eom_sign(DKIM *dkim)
 		                            NULL, NULL, crypto->crypto_pkey);
 		if (status == 1)
 		{
-			l = crypto->crypto_outlen;
-			status = EVP_DigestSign(md_ctx, crypto->crypto_out, &l,
-		                                digest, diglen);
+			status = EVP_DigestSign(md_ctx, crypto->crypto_out,
+			                        &crypto->crypto_outlen, digest,
+			                        diglen);
 		}
 
 		if (status != 1)
@@ -4019,15 +4036,13 @@ dkim_eom_sign(DKIM *dkim)
 			/* dkim_load_ssl_errors(dkim, 0); */
 			dkim_error(dkim,
 			           "signature generation failed (status %d, length %d, %s)",
-			           status, l, ERR_error_string(ERR_get_error(), NULL));
+			           status, crypto->crypto_outlen,
+			           ERR_error_string(ERR_get_error(), NULL));
 
-			RSA_free(crypto->crypto_key);
 			BIO_CLOBBER(crypto->crypto_keydata);
 
 			return DKIM_STAT_INTERNAL;
 		}
-
-		crypto->crypto_outlen = l;
 
 		signature = crypto->crypto_out;
 		siglen = crypto->crypto_outlen;
@@ -5182,7 +5197,6 @@ dkim_free(DKIM *dkim)
 #else /* USE_GNUTLS */
 					BIO_CLOBBER(crypto->crypto_keydata);
 					EVP_CLOBBER(crypto->crypto_pkey);
-					RSA_CLOBBER(crypto->crypto_key);
 					CLOBBER(crypto->crypto_out);
 #endif /* USE_GNUTLS */
 				}
@@ -5594,6 +5608,8 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 # endif /* GNUTLS_VERSION_MAJOR == 3 */
 #else /* USE_GNUTLS */
 	BIO *key;
+	EVP_PKEY_CTX *pkey_ctx;
+	const EVP_MD *md;
 #endif /* USE_GNUTLS */
 	u_char *digest = NULL;
 	struct dkim_crypto *crypto;
@@ -5829,7 +5845,7 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 		{
 			EVP_MD_CTX *md_ctx;
 
-			if (EVP_PKEY_id(crypto->crypto_pkey) != EVP_PKEY_ED25519)
+			if (EVP_PKEY_get_id(crypto->crypto_pkey) != EVP_PKEY_ED25519)
 			{
 				dkim_error(dkim,
 				           "s=%s d=%s: not an ED25519 key",
@@ -5883,17 +5899,15 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 
 			EVP_MD_CTX_free(md_ctx);
 
-			crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
+			crypto->crypto_keysize = EVP_PKEY_get_size(crypto->crypto_pkey);
 		}
 		else
 # endif /* HAVE_ED25519 */
 		{
-			crypto->crypto_key = EVP_PKEY_get1_RSA(crypto->crypto_pkey);
-			if (crypto->crypto_key == NULL)
+			if (EVP_PKEY_get_base_id(crypto->crypto_pkey) != EVP_PKEY_RSA)
 			{
-				dkim_sig_load_ssl_errors(dkim, sig, 0);
 				dkim_error(dkim,
-				           "s=%s d=%s: EVP_PKEY_get1_RSA() failed",
+				           "s=%s d=%s: not an RSA key",
 				           dkim_sig_getselector(sig),
 				           dkim_sig_getdomain(sig));
 
@@ -5904,23 +5918,69 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 				return DKIM_STAT_OK;
 			}
 
-			crypto->crypto_keysize = RSA_size(crypto->crypto_key);
-			crypto->crypto_pad = RSA_PKCS1_PADDING;
+			crypto->crypto_keysize = EVP_PKEY_get_size(crypto->crypto_pkey);
 
 			crypto->crypto_in = sig->sig_sig;
 			crypto->crypto_inlen = sig->sig_siglen;
 
-			nid = NID_sha1;
+			pkey_ctx = EVP_PKEY_CTX_new(crypto->crypto_pkey, NULL);
+
+			if (pkey_ctx == NULL)
+			{
+				dkim_error(dkim,
+				           "failed to allocate EVP_PKEY context");
+				BIO_CLOBBER(key);
+				return DKIM_STAT_NORESOURCE;
+			}
+
+			if (EVP_PKEY_verify_init(pkey_ctx) <= 0)
+			{
+				dkim_sig_load_ssl_errors(dkim, sig, 0);
+				dkim_error(dkim,
+				           "failed to initialize EVP_PKEY context");
+
+				EVP_PKEY_CTX_free(pkey_ctx);
+				BIO_CLOBBER(key);
+
+				return DKIM_STAT_INTERNAL;
+			}
+
+			if (EVP_PKEY_CTX_set_rsa_padding(pkey_ctx, RSA_PKCS1_PADDING) <= 0)
+			{
+				dkim_sig_load_ssl_errors(dkim, sig, 0);
+				dkim_error(dkim,
+				           "failed to set RSA padding mode");
+
+				EVP_PKEY_CTX_free(pkey_ctx);
+				BIO_CLOBBER(key);
+
+				return DKIM_STAT_INTERNAL;
+			}
+
+			md = EVP_sha1();
 
 			if (dkim_libfeature(dkim->dkim_libhandle,
 			                    DKIM_FEATURE_SHA256) &&
 			    sig->sig_hashtype == DKIM_HASHTYPE_SHA256)
-				nid = NID_sha256;
+				md = EVP_sha256();
 
-			vstat = RSA_verify(nid, digest, diglen,
-			                   crypto->crypto_in,
-			                   crypto->crypto_inlen,
-			                   crypto->crypto_key);
+			if (EVP_PKEY_CTX_set_signature_md(pkey_ctx, md) <= 0)
+			{
+				dkim_sig_load_ssl_errors(dkim, sig, 0);
+				dkim_error(dkim,
+				           "failed to set message digest type");
+
+				EVP_PKEY_CTX_free(pkey_ctx);
+				BIO_CLOBBER(key);
+
+				return DKIM_STAT_INTERNAL;
+			}
+
+			vstat = EVP_PKEY_verify(pkey_ctx, crypto->crypto_in,
+			                        crypto->crypto_inlen, digest,
+			                        diglen);
+
+			EVP_PKEY_CTX_free(pkey_ctx);
 		}
 
 		dkim_sig_load_ssl_errors(dkim, sig, 0);
@@ -5928,13 +5988,7 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 		sig->sig_keybits = 8 * crypto->crypto_keysize;
 
 		BIO_CLOBBER(key);
-		EVP_PKEY_free(crypto->crypto_pkey);
-		crypto->crypto_pkey = NULL;
-		if (crypto->crypto_key != NULL)
-		{
-			RSA_free(crypto->crypto_key);
-			crypto->crypto_key = NULL;
-		}
+		EVP_CLOBBER(crypto->crypto_pkey);
 #endif /* USE_GNUTLS */
 
 		if (vstat == 1)

--- a/opendkim/opendkim-atpszone.c
+++ b/opendkim/opendkim-atpszone.c
@@ -144,11 +144,6 @@ main(int argc, char **argv)
 	DKIMF_DB db;
 #ifdef USE_GNUTLS
 	gnutls_hash_hd_t sha;
-#else /* USE_GNUTLS */
-	SHA_CTX sha;
-# ifdef HAVE_SHA256
-	SHA256_CTX sha256;
-# endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 	char domain[DKIM_MAXHOSTNAMELEN + 1];
 	char hostname[DKIM_MAXHOSTNAMELEN + 1];
@@ -443,20 +438,19 @@ main(int argc, char **argv)
 # ifdef HAVE_SHA256
 			if (hash == NULL || strcasecmp(hash, "sha256") == 0)
 			{
-				SHA256_Init(&sha256);
-				SHA256_Update(&sha256, domain, strlen(domain));
-				SHA256_Final(shaout, &sha256);
+				(void) EVP_Digest(domain, strlen(domain),
+				                  shaout, NULL, EVP_sha256(),
+				                  NULL);
 			}
 			else
 			{
-				SHA1_Init(&sha);
-				SHA1_Update(&sha, domain, strlen(domain));
-				SHA1_Final(shaout, &sha);
+				(void) EVP_Digest(domain, strlen(domain),
+				                  shaout, NULL, EVP_sha1(),
+				                  NULL);
 			}
 # else /* HAVE_SHA256 */
-			SHA1_Init(&sha);
-			SHA1_Update(&sha, domain, strlen(domain));
-			SHA1_Final(shaout, &sha);
+			(void) EVP_Digest(domain, strlen(domain), shaout, NULL,
+			                  EVP_sha1(), NULL);
 # endif /* HAVE_SHA256 */
 #endif /* USE_GNUTLS */
 

--- a/opendkim/opendkim-genzone.c
+++ b/opendkim/opendkim-genzone.c
@@ -835,7 +835,7 @@ main(int argc, char **argv)
 			}
 		}
 
-		if (EVP_PKEY_get_base_id(pkey) != EVP_PKEY_RSA)
+		if (EVP_PKEY_base_id(pkey) != EVP_PKEY_RSA)
 		{
 			fprintf(stderr, "%s: not an RSA key\n", progname);
 			(void) dkimf_db_close(db);

--- a/opendkim/opendkim-genzone.c
+++ b/opendkim/opendkim-genzone.c
@@ -26,7 +26,6 @@
 # include <gnutls/abstract.h>
 # include <gnutls/x509.h>
 #else /* USE_GNUTLS */
-# include <openssl/rsa.h>
 # include <openssl/pem.h>
 # include <openssl/evp.h>
 # include <openssl/bio.h>
@@ -264,7 +263,6 @@ main(int argc, char **argv)
 	BIO *private;
 	BIO *outbio = NULL;
 	EVP_PKEY *pkey;
-	RSA *rsa;
 #endif /* USE_GNUTLS */
 	DKIMF_DB db;
 	char keyname[BUFRSZ + 1];
@@ -837,12 +835,9 @@ main(int argc, char **argv)
 			}
 		}
 
-		rsa = EVP_PKEY_get1_RSA(pkey);
-		if (rsa == NULL)
+		if (EVP_PKEY_get_base_id(pkey) != EVP_PKEY_RSA)
 		{
-			fprintf(stderr,
-			        "%s: EVP_PKEY_get1_RSA() failed\n",
-			        progname);
+			fprintf(stderr, "%s: not an RSA key\n", progname);
 			(void) dkimf_db_close(db);
 			(void) BIO_free(private);
 			(void) EVP_PKEY_free(pkey);
@@ -851,11 +846,11 @@ main(int argc, char **argv)
 		}
 
 		/* convert private to public */
-		status = PEM_write_bio_RSA_PUBKEY(outbio, rsa);
+		status = PEM_write_bio_PUBKEY(outbio, pkey);
 		if (status == 0)
 		{
 			fprintf(stderr,
-			        "%s: PEM_write_bio_RSA_PUBKEY() failed\n",
+			        "%s: PEM_write_bio_PUBKEY() failed\n",
 			        progname);
 			(void) dkimf_db_close(db);
 			(void) BIO_free(private);


### PR DESCRIPTION
Rebased from PR #162 (glts/OpenDKIM) onto current develop, with conflicts resolved.

## What this does

Replaces the old algorithm-specific hash APIs (deprecated in OpenSSL 3, at risk of removal) with the unified EVP digest interface:

- `SHA1_Init/Update/Final` and `SHA256_Init/Update/Final` replaced with `EVP_MD_CTX_new`, `EVP_DigestInit_ex`, `EVP_DigestUpdate`, `EVP_DigestFinal_ex`
- Unifies the separate `dkim_sha1` and `dkim_sha256` structs into a single `dkim_sha` struct
- Drops `#ifdef HAVE_SHA256` guards (SHA-256 is always available on supported OpenSSL versions)
- `i2d_RSA_PUBKEY_bio` -> `i2d_PUBKEY_bio` for generality

## Compatibility

- **OpenSSL 1.1.1**: maintained. The `EVP_PKEY_size()`, `EVP_PKEY_id()`, and `EVP_PKEY_base_id()` names (compatible with both 1.1.1 and 3.x) are used rather than the 3.x-only `EVP_PKEY_get_*` variants.
- **OpenSSL 3.x**: already tested in CI (ubuntu-latest) and on AlmaLinux 9.

## Conflict resolution

The one conflict in `libopendkim/dkim-test.c` was between this PR's RSA-only key comparison code and the ed25519 key comparison support added in PR #299. The resolution keeps the full ed25519/RSA branching from develop.

Closes #162.