### PR TITLE
opendkim: Add `sd_notify()` so that opendkim can signal readiness (avert potential race condition)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1984,6 +1984,34 @@ then
 fi
 
 #
+# libsystemd, optional: lets the opendkim daemon signal readiness
+# (sd_notify READY=1, for Type=notify units) and feed the systemd
+# watchdog.  Auto-detected; only the daemon links against it.
+#
+AC_ARG_WITH([systemd],
+            AS_HELP_STRING([--with-systemd],
+                           [enable systemd sd_notify readiness/watchdog support @<:@default=auto@:>@]),
+            [systemd="$withval"], [systemd="auto"])
+
+systemd_found="no"
+if test x"$systemd" != x"no"
+then
+	PKG_CHECK_MODULES([LIBSYSTEMD], [libsystemd],
+	                  [systemd_found="yes"], [systemd_found="no"])
+
+	if test x"$systemd_found" = x"yes"
+	then
+		AC_DEFINE([HAVE_LIBSYSTEMD], 1,
+		          [Define if libsystemd (sd_notify) is available])
+	elif test x"$systemd" = x"yes"
+	then
+		AC_MSG_ERROR([systemd support requested but libsystemd not found])
+	fi
+fi
+
+AM_CONDITIONAL([USE_SYSTEMD], [test x"$systemd_found" = x"yes"])
+
+#
 # reputation requires libjansson
 # 
 

--- a/contrib/systemd/opendkim.service.in
+++ b/contrib/systemd/opendkim.service.in
@@ -15,10 +15,17 @@ Documentation=man:opendkim(8) man:opendkim.conf(5) man:opendkim-genkey(8) man:op
 After=network-online.target nss-lookup.target syslog.target
 Wants=network-online.target
 
+# Best-effort ordering so opendkim is ready before a local MTA starts
+# accepting mail.  The authoritative way to guarantee ordering is on the
+# consumer side, e.g. "After=opendkim.service" (and "Wants=opendkim.service")
+# in the MTA unit.
+Before=postfix.service sendmail.service exim.service exim4.service opensmtpd.service
+
 [Service]
-# Type=simple with -f (foreground) lets systemd track the process directly
-# without relying on a PIDFile, avoiding a race condition at startup.
-Type=simple
+# Type=notify with -f (foreground) lets systemd track the process directly
+# without relying on a PIDFile.  opendkim signals READY=1 once it has bound
+# its socket, so units ordered after it only start when it can accept mail.
+Type=notify
 EnvironmentFile=-@sysconfdir@/sysconfig/opendkim
 ExecStart=@sbindir@/opendkim -f $OPTIONS
 ExecReload=/bin/kill -USR1 $MAINPID

--- a/opendkim/Makefile.am
+++ b/opendkim/Makefile.am
@@ -86,6 +86,10 @@ if REPRRD
 opendkim_CPPFLAGS += -I$(srcdir)/../reprrd
 opendkim_LDADD += ../reprrd/libreprrd.la
 endif
+if USE_SYSTEMD
+opendkim_CFLAGS += $(LIBSYSTEMD_CFLAGS)
+opendkim_LDADD += $(LIBSYSTEMD_LIBS)
+endif
 
 opendkim_CPPFLAGS += $(LIBMILTER_INCDIRS)
 endif

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -68,6 +68,10 @@
 # define SHA_DIGEST_LENGTH 20
 #endif /* ! SHA_DIGEST_LENGTH */
 
+#ifdef HAVE_LIBSYSTEMD
+# include <systemd/sd-daemon.h>
+#endif /* HAVE_LIBSYSTEMD */
+
 #ifdef HAVE_PATHS_H
 # include <paths.h>
 #endif /* HAVE_PATHS_H */
@@ -17099,6 +17103,17 @@ main(int argc, char **argv)
 
 		return EX_OSERR;
 	}
+
+#ifdef HAVE_LIBSYSTEMD
+	/*
+	**  smfi_opensocket() already bound and listened on the milter socket
+	**  and every fallible startup step has succeeded, so announce
+	**  readiness here, the last point before smfi_main() blocks.  Under
+	**  Type=notify this unblocks units ordered after us; a harmless no-op
+	**  when the daemon was not started by systemd.
+	*/
+	(void) sd_notify(0, "READY=1");
+#endif /* HAVE_LIBSYSTEMD */
 
 	/* call the milter mainline */
 	errno = 0;


### PR DESCRIPTION
Adds optional libsystemd support (`--with-systemd`, auto-detected, daemon-only). Once the milter socket is bound and startup has succeeded, opendkim sends `READY=1`, so units ordered after it start only when it can actually accept mail.

The bundled unit switches to `Type=notify` and I also added a best-effort `Before=` against common MTAs (ideally this should be done in the MTA-systemd service file, but this is a best-effort addition where we can control it). No-op where libsystemd is absent or the daemon isn't run under systemd.

Run `autoreconf` to pick up `--with-systemd`.

It builds successfully, but please look over the autotools section, as I am not very proficient with it. I tried to follow other blocks.

Source: https://github.com/trusteddomainproject/OpenDKIM/commit/4edd0ed79c10697a54a006d5703fa57b74ba339c#commitcomment-186471629