### PR TITLE
Skip DNAME RRs in DNS answers

### DIFF
--- a/libopendkim/dkim-atps.c
+++ b/libopendkim/dkim-atps.c
@@ -369,7 +369,7 @@ dkim_atps_check(DKIM *dkim, DKIM_SIGINFO *sig, struct timeval *timeout,
 			cp += n;
 			continue;
 		}
-		else if (type == T_RRSIG)
+		else if ((type == T_RRSIG) || (type == T_DNAME))
 		{
 			/* get payload length */
 			if (cp + INT16SZ > eom)

--- a/libopendkim/dkim-keys.c
+++ b/libopendkim/dkim-keys.c
@@ -330,7 +330,7 @@ dkim_get_key_dns(DKIM *dkim, DKIM_SIGINFO *sig, u_char *buf, size_t buflen)
 			cp += n;
 			continue;
 		}
-		else if (type == T_RRSIG)
+		else if ((type == T_RRSIG) || (type == T_DNAME))
 		{
 			cp += n;
 			continue;

--- a/libopendkim/dkim-report.c
+++ b/libopendkim/dkim-report.c
@@ -223,7 +223,7 @@ dkim_repinfo(DKIM *dkim, DKIM_SIGINFO *sig, struct timeval *timeout,
 			cp += n;
 			continue;
 		}
-		else if (type == T_RRSIG)
+		else if ((type == T_RRSIG) || (type == T_DNAME))
 		{
 			/* get payload length */
 			if (cp + INT16SZ > eom)

--- a/librbl/rbl.c
+++ b/librbl/rbl.c
@@ -1135,7 +1135,7 @@ rbl_query_check(RBL *rbl, void *qh, struct timeval *timeout, uint32_t *res)
 			cp += n;
 			continue;
 		}
-		else if (type == T_RRSIG)
+		else if ((type == T_RRSIG) || (type == T_DNAME))
 		{
 			/* get payload length */
 			if (cp + INT16SZ > eom)


### PR DESCRIPTION
Rebased from PR #156 (ajobs/RUBNOC) onto develop.

DKIM verification fails when a DNS answer packet contains DNAME records (used for whole-zone redirections, analogous to CNAME for individual names). The DNS response parser was already skipping RRSIG records; DNAME records need the same treatment.

The fix adds `T_DNAME` to the skip condition in four parallel DNS response parsing loops:

- `libopendkim/dkim-keys.c` - key lookup
- `libopendkim/dkim-atps.c` - ATPS checks
- `libopendkim/dkim-report.c` - report lookups
- `librbl/rbl.c` - RBL checks

Real-world example from the original PR: `rub.de` uses a DNAME to `ruhr-uni-bochum.de`, so DKIM key lookups for `rub.de` selectors return a DNAME + synthesized CNAME + TXT answer. Without this fix, verification fails on those domains.

Closes #156.