### PR TITLE
ci: add workflow_dispatch for manual CI triggering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ develop ]
   pull_request:
     branches: [ develop ]
+  workflow_dispatch:
 
 jobs:
   build-test-linux:


### PR DESCRIPTION
Adds `workflow_dispatch` so CI can be triggered manually from the Actions tab on any branch, including legacy PRs that predate automated CI.