### PR TITLE
opendkim: fix overlapping buffer in SubDomains domain walk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ develop ]
   pull_request:
     branches: [ develop ]
+  workflow_dispatch:
 
 jobs:
   build-test-linux:

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -12335,8 +12335,9 @@ mlfi_eoh(SMFICTX *ctx)
 
 				if (domainok)
 				{
-					strlcpy((char *) dfc->mctx_domain, p,
-					        sizeof dfc->mctx_domain);
+					/* p points into mctx_domain; use memmove */
+					memmove(dfc->mctx_domain, p,
+					        strlen(p) + 1);
 					break;
 				}
 			}


### PR DESCRIPTION
When `SubDomains yes` is configured, the domain walk uses `strchr()` to scan forward through `mctx_domain` and `p` ends up pointing into that same buffer. Calling `strlcpy(mctx_domain, p, ...)` is therefore an overlapping copy - undefined behavior per POSIX.

On Linux/glibc this happens to work, but on FreeBSD the undefined behavior manifests as a corrupted `d=` tag, so every signed message using SubDomains gets an invalid signature that won't verify. Silent failure.

Fix replaces `strlcpy()` with `memmove()` which is defined for overlapping buffers. Since `p` always points ahead of `mctx_domain` (we're shifting the string left), `memmove()` handles this correctly.

Supersedes #239.