### PR TITLE
opendkim: print configure arguments in -v output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2600,4 +2600,7 @@ AC_CONFIG_FILES([	Makefile
 			reputation/opendkim-rephistory.8
 			reputation/repute.pc
 ])
+AC_DEFINE_UNQUOTED([CONFIGURE_ARGS], ["$ac_configure_args"],
+                   [Arguments passed to configure])
+
 AC_OUTPUT

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -15825,6 +15825,7 @@ main(int argc, char **argv)
 				/* we can do nothing eveif dkim_stat is not
 				   DKIM_STAT_OK ... */
 			}
+			printf("\tConfigured with: %s\n", CONFIGURE_ARGS);
 			dkimf_optlist(stdout);
 			return EX_OK;
 


### PR DESCRIPTION
Captures `$ac_configure_args` at configure time into `CONFIGURE_ARGS` in `build-config.h` and prints it in `opendkim -v`, e.g.:

```
opendkim: OpenDKIM Filter v2.11.0
        Compiled with OpenSSL 3.0.7
        ...
        Configured with: '--enable-lua' '--with-unbound' 'CFLAGS=-O2'
```

Makes it straightforward to reproduce a packaged build from source or diagnose support requests involving non-standard builds. Closes #357.