### PR TITLE
Fix compiler warnings (-Wincompatible-pointer-types, -Wformat-truncation)

### DIFF
--- a/libopendkim/dkim-util.c
+++ b/libopendkim/dkim-util.c
@@ -138,13 +138,14 @@ dkim_tmpfile(DKIM *dkim, int *fp, _Bool keep)
 
 	if (dkim->dkim_id != NULL)
 	{
-		snprintf(path, MAXPATHLEN, "%s/dkim.%s.XXXXXX",
-		         dkim->dkim_libhandle->dkiml_tmpdir, dkim->dkim_id);
+		snprintf(path, sizeof path, "%.*s/dkim.%.*s.XXXXXX",
+		         (int)(MAXPATHLEN / 2), dkim->dkim_libhandle->dkiml_tmpdir,
+		         (int)(MAXPATHLEN / 2 - 14), dkim->dkim_id);
 	}
 	else
 	{
-		snprintf(path, MAXPATHLEN, "%s/dkim.XXXXXX",
-		         dkim->dkim_libhandle->dkiml_tmpdir);
+		snprintf(path, sizeof path, "%.*s/dkim.XXXXXX",
+		         (int)(MAXPATHLEN - 13), dkim->dkim_libhandle->dkiml_tmpdir);
 	}
 
 	for (p = path + strlen((char *) dkim->dkim_libhandle->dkiml_tmpdir) + 1;

--- a/opendkim/opendkim-genzone.c
+++ b/opendkim/opendkim-genzone.c
@@ -268,7 +268,7 @@ main(int argc, char **argv)
 	char keyname[BUFRSZ + 1];
 	char domain[BUFRSZ + 1];
 	char selector[BUFRSZ + 1];
-	char tmpbuf[BUFRSZ + 1];
+	char tmpbuf[LARGEBUFRSZ + 1];
 	char hostname[DKIM_MAXHOSTNAMELEN + 1];
 	char keydata[LARGEBUFRSZ];
 	char derdata[LARGEBUFRSZ];

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -5563,12 +5563,15 @@ dkimf_reportaddr(struct dkimf_config *conf)
 	if (pw == NULL)
 	{
 		snprintf(reportaddr, sizeof reportaddr,
-		         "%u@%s", uid, myhostname);
+		         "%u@%.*s", uid,
+		         (int)(sizeof reportaddr - 12), myhostname);
 	}
 	else
 	{
 		snprintf(reportaddr, sizeof reportaddr,
-		         "%s@%s", pw->pw_name, myhostname);
+		         "%.*s@%.*s",
+		         (int)((sizeof reportaddr - 2) / 2), pw->pw_name,
+		         (int)((sizeof reportaddr - 2) / 2), myhostname);
 	}
 
 	snprintf(reportcmd, sizeof reportcmd, "%s -t -f%s",
@@ -8184,7 +8187,8 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 			pw = getpwnam(tmp);
 			if (pw == NULL)
 			{
-				snprintf(err, errlen, "%s: no such user", tmp);
+				snprintf(err, errlen, "%.*s: no such user",
+				         errlen > 15 ? (int)(errlen - 15) : 0, tmp);
 				close(fd);
 				return -1;
 			}
@@ -12888,8 +12892,8 @@ mlfi_eoh(SMFICTX *ctx)
 				
 		if (!idset)
 		{
-			snprintf((char *) identity, sizeof identity, "@%s",
-			         dfc->mctx_domain);
+			snprintf((char *) identity, sizeof identity, "@%.*s",
+			         (int)(sizeof identity - 2), dfc->mctx_domain);
 		}
 
 		if (dfc->mctx_srhead != NULL)
@@ -15528,7 +15532,7 @@ main(int argc, char **argv)
 	DKIM_STAT dkim_stat;
 	DKIM_ITER_CTX *iter_ctx;
 	int entry_code;
-	char *entry_name;
+	const char *entry_name;
 
 	/* initialize */
 	reload = FALSE;


### PR DESCRIPTION
Fixes #359.

## Changes

**`-Wincompatible-pointer-types`** (`opendkim.c`):
`dkim_nametable_first`/`dkim_nametable_next` expect `const char **` for
the name output parameter. Declare `entry_name` as `const char *` to
match. Fixes all four instances at once.

**`-Wformat-truncation`**:

- `libopendkim/dkim-util.c`: Use `sizeof path` (not `MAXPATHLEN`) as
  the snprintf size, and add explicit `%.*s` widths on the directory
  and job-ID components so the compiler can verify the result fits.

- `opendkim/opendkim-genzone.c`: `tmpbuf` enlarged from `BUFRSZ+1`
  (1025 bytes) to `LARGEBUFRSZ+1` (8193 bytes). Selector and domain
  can each be up to `BUFRSZ` bytes, so the old buffer was genuinely
  too small for pathological inputs.

- `opendkim/opendkim.c`: Use `%.*s` with explicit widths in the
  `reportaddr` formatting (uid/hostname and name/hostname variants),
  the `"no such user"` error message, and the `@domain` identity
  construction to make output bounds explicit to the compiler.