### PR TITLE
Handle SHA1 unavailability gracefully on restricted platforms (issue #364)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -951,30 +951,56 @@ then
 	    [AC_LANG_PROGRAM([[
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
+#include <string.h>
 ]],[[
 	EVP_PKEY_CTX *kctx;
+	EVP_PKEY_CTX *sctx;
 	EVP_PKEY *pkey = NULL;
-	EVP_MD_CTX *mctx;
+	EVP_MD_CTX *hctx;
+	unsigned char hash[20];
+	unsigned int hashlen = sizeof(hash);
 	unsigned char sig[256];
 	size_t siglen = sizeof(sig);
 	const unsigned char data[] = "test";
 	int ret = 1;
 
+	/* Generate a 2048-bit key (matches production key sizes). */
 	kctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
 	if (!kctx) return 1;
-	if (EVP_PKEY_keygen_init(kctx) <= 0) return 1;
-	if (EVP_PKEY_CTX_set_rsa_keygen_bits(kctx, 1024) <= 0) return 1;
-	if (EVP_PKEY_keygen(kctx, &pkey) <= 0) return 1;
+	if (EVP_PKEY_keygen_init(kctx) <= 0) goto keydone;
+	if (EVP_PKEY_CTX_set_rsa_keygen_bits(kctx, 2048) <= 0) goto keydone;
+	if (EVP_PKEY_keygen(kctx, &pkey) <= 0) goto keydone;
+keydone:
 	EVP_PKEY_CTX_free(kctx);
+	if (!pkey) return 1;
 
-	mctx = EVP_MD_CTX_new();
-	if (!mctx) return 1;
-	if (EVP_DigestSignInit(mctx, NULL, EVP_sha1(), NULL, pkey) <= 0) goto done;
-	if (EVP_DigestSignUpdate(mctx, data, sizeof(data)) <= 0) goto done;
-	if (EVP_DigestSignFinal(mctx, sig, &siglen) <= 0) goto done;
+	/* Compute SHA1 hash of data. */
+	hctx = EVP_MD_CTX_new();
+	if (!hctx) goto done;
+	if (EVP_DigestInit_ex(hctx, EVP_sha1(), NULL) <= 0) goto done;
+	if (EVP_DigestUpdate(hctx, data, sizeof(data)) <= 0) goto done;
+	if (EVP_DigestFinal_ex(hctx, hash, &hashlen) <= 0) goto done;
+	EVP_MD_CTX_free(hctx);
+	hctx = NULL;
+
+	/*
+	 * Sign the pre-computed hash using the same EVP_PKEY_sign API
+	 * path that libopendkim uses internally.  This is intentionally
+	 * different from EVP_DigestSign so that system restrictions on
+	 * SHA1 as a signature digest (e.g., RHEL 9 evp_properties) are
+	 * detected here rather than at run time.
+	 */
+	sctx = EVP_PKEY_CTX_new(pkey, NULL);
+	if (!sctx) goto done;
+	if (EVP_PKEY_sign_init(sctx) <= 0) goto sigdone;
+	if (EVP_PKEY_CTX_set_rsa_padding(sctx, RSA_PKCS1_PADDING) <= 0) goto sigdone;
+	if (EVP_PKEY_CTX_set_signature_md(sctx, EVP_sha1()) <= 0) goto sigdone;
+	if (EVP_PKEY_sign(sctx, sig, &siglen, hash, hashlen) <= 0) goto sigdone;
 	ret = 0;
+sigdone:
+	EVP_PKEY_CTX_free(sctx);
 done:
-	EVP_MD_CTX_free(mctx);
+	if (hctx) EVP_MD_CTX_free(hctx);
 	EVP_PKEY_free(pkey);
 	return ret;
 ]])],

--- a/configure.ac
+++ b/configure.ac
@@ -944,7 +944,6 @@ then
 #include <sys/types.h>
 #include <openssl/sha.h>])
 
-	ac_cv_have_sha1_signing=yes
 	AC_CACHE_CHECK([whether RSA-SHA1 signing is available],
 	               [ac_cv_have_sha1_signing],
 	  [AC_RUN_IFELSE(

--- a/configure.ac
+++ b/configure.ac
@@ -803,6 +803,7 @@ then
 fi
 
 AM_CONDITIONAL([USE_GNUTLS], [test x"$gnutls_found" = x"yes"])
+AM_CONDITIONAL([HAVE_SHA1_SIGNING], [test x"$ac_cv_have_sha1_signing" = x"yes"])
 
 #
 # OpenSSL
@@ -942,6 +943,50 @@ then
 	              [
 #include <sys/types.h>
 #include <openssl/sha.h>])
+
+	ac_cv_have_sha1_signing=yes
+	AC_CACHE_CHECK([whether RSA-SHA1 signing is available],
+	               [ac_cv_have_sha1_signing],
+	  [AC_RUN_IFELSE(
+	    [AC_LANG_PROGRAM([[
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+]],[[
+	EVP_PKEY_CTX *kctx;
+	EVP_PKEY *pkey = NULL;
+	EVP_MD_CTX *mctx;
+	unsigned char sig[256];
+	size_t siglen = sizeof(sig);
+	const unsigned char data[] = "test";
+	int ret = 1;
+
+	kctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+	if (!kctx) return 1;
+	if (EVP_PKEY_keygen_init(kctx) <= 0) return 1;
+	if (EVP_PKEY_CTX_set_rsa_keygen_bits(kctx, 1024) <= 0) return 1;
+	if (EVP_PKEY_keygen(kctx, &pkey) <= 0) return 1;
+	EVP_PKEY_CTX_free(kctx);
+
+	mctx = EVP_MD_CTX_new();
+	if (!mctx) return 1;
+	if (EVP_DigestSignInit(mctx, NULL, EVP_sha1(), NULL, pkey) <= 0) goto done;
+	if (EVP_DigestSignUpdate(mctx, data, sizeof(data)) <= 0) goto done;
+	if (EVP_DigestSignFinal(mctx, sig, &siglen) <= 0) goto done;
+	ret = 0;
+done:
+	EVP_MD_CTX_free(mctx);
+	EVP_PKEY_free(pkey);
+	return ret;
+]])],
+	    [ac_cv_have_sha1_signing=yes],
+	    [ac_cv_have_sha1_signing=no],
+	    [ac_cv_have_sha1_signing=yes])])
+	if test x"$ac_cv_have_sha1_signing" = x"yes"; then
+		AC_DEFINE([HAVE_SHA1_SIGNING], 1,
+		          [Define to 1 if RSA-SHA1 signing is available on this platform])
+	else
+		AC_MSG_WARN([RSA-SHA1 signing is not available; RSA-SHA1 signing will be disabled and related tests skipped])
+	fi
 
 	CFLAGS="$saved_CFLAGS"
 	CPPFLAGS="$saved_CPPFLAGS"

--- a/libopendkim/dkim-types.h
+++ b/libopendkim/dkim-types.h
@@ -337,6 +337,7 @@ struct dkim_lib
 	_Bool			dkiml_signre;
 	_Bool			dkiml_skipre;
 	_Bool			dkiml_dnsinit_done;
+	_Bool			dkiml_sha1_available;
 	u_int			dkiml_timeout;
 	u_int			dkiml_version;
 	u_int			dkiml_callback_int;

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -3816,6 +3816,15 @@ dkim_eom_sign(DKIM *dkim)
 		assert(sig->sig_hashtype == DKIM_HASHTYPE_SHA1 ||
 		       sig->sig_hashtype == DKIM_HASHTYPE_SHA256);
 
+#ifndef HAVE_SHA1_SIGNING
+		if (sig->sig_hashtype == DKIM_HASHTYPE_SHA1)
+		{
+			dkim_error(dkim,
+			           "RSA-SHA1 signing not available on this platform");
+			return DKIM_STAT_SIGGEN;
+		}
+#endif /* HAVE_SHA1_SIGNING */
+
 		if (sig->sig_hashtype == DKIM_HASHTYPE_SHA256)
 		{
 			assert(dkim_libfeature(dkim->dkim_libhandle,
@@ -5918,6 +5927,22 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 				return DKIM_STAT_OK;
 			}
 
+#ifndef HAVE_SHA1_SIGNING
+			if (sig->sig_hashtype == DKIM_HASHTYPE_SHA1)
+			{
+				dkim_error(dkim,
+				           "s=%s d=%s: RSA-SHA1 verification not available on this platform",
+				           dkim_sig_getselector(sig),
+				           dkim_sig_getdomain(sig));
+
+				BIO_CLOBBER(key);
+
+				sig->sig_error = DKIM_SIGERROR_UNSUPPORTED_A;
+
+				return DKIM_STAT_OK;
+			}
+#endif /* HAVE_SHA1_SIGNING */
+
 			crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
 
 			crypto->crypto_in = sig->sig_sig;
@@ -5968,12 +5993,16 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 			{
 				dkim_sig_load_ssl_errors(dkim, sig, 0);
 				dkim_error(dkim,
-				           "failed to set message digest type");
+				           "s=%s d=%s: signature digest algorithm not accepted by platform crypto policy",
+				           dkim_sig_getselector(sig),
+				           dkim_sig_getdomain(sig));
 
 				EVP_PKEY_CTX_free(pkey_ctx);
 				BIO_CLOBBER(key);
 
-				return DKIM_STAT_INTERNAL;
+				sig->sig_error = DKIM_SIGERROR_UNSUPPORTED_A;
+
+				return DKIM_STAT_OK;
 			}
 
 			vstat = EVP_PKEY_verify(pkey_ctx, crypto->crypto_in,

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -3816,14 +3816,13 @@ dkim_eom_sign(DKIM *dkim)
 		assert(sig->sig_hashtype == DKIM_HASHTYPE_SHA1 ||
 		       sig->sig_hashtype == DKIM_HASHTYPE_SHA256);
 
-#ifndef HAVE_SHA1_SIGNING
-		if (sig->sig_hashtype == DKIM_HASHTYPE_SHA1)
+		if (sig->sig_hashtype == DKIM_HASHTYPE_SHA1 &&
+		    !dkim->dkim_libhandle->dkiml_sha1_available)
 		{
 			dkim_error(dkim,
 			           "RSA-SHA1 signing not available on this platform");
 			return DKIM_STAT_SIGGEN;
 		}
-#endif /* HAVE_SHA1_SIGNING */
 
 		if (sig->sig_hashtype == DKIM_HASHTYPE_SHA256)
 		{
@@ -3979,12 +3978,13 @@ dkim_eom_sign(DKIM *dkim)
 		if (EVP_PKEY_CTX_set_signature_md(pkey_ctx, md) <= 0)
 		{
 			dkim_load_ssl_errors(dkim, 0);
-			dkim_error(dkim, "failed to set message digest type");
+			dkim_error(dkim,
+			           "signature digest algorithm not accepted by platform crypto policy");
 
 			EVP_PKEY_CTX_free(pkey_ctx);
 			BIO_CLOBBER(crypto->crypto_keydata);
 
-			return DKIM_STAT_INTERNAL;
+			return DKIM_STAT_SIGGEN;
 		}
 
 		status = EVP_PKEY_sign(pkey_ctx, crypto->crypto_out,
@@ -4482,6 +4482,65 @@ dkim_close_openssl(void)
 
 /* ========================= PUBLIC SECTION ========================== */
 
+#ifndef USE_GNUTLS
+/*
+**  DKIM_PROBE_SHA1_SIGNING -- test whether RSA-SHA1 signing is permitted
+**  by the current platform crypto policy
+**
+**  Parameters:
+**  	None.
+**
+**  Return value:
+**  	TRUE if RSA-SHA1 signing works, FALSE if not.
+*/
+
+static _Bool
+dkim_probe_sha1_signing(void)
+{
+	_Bool result = FALSE;
+	EVP_PKEY_CTX *kctx = NULL;
+	EVP_PKEY_CTX *sctx = NULL;
+	EVP_PKEY *pkey = NULL;
+
+	ERR_clear_error();
+
+	if (EVP_sha1() == NULL)
+		return FALSE;
+
+	kctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+	if (kctx == NULL)
+		goto cleanup;
+	if (EVP_PKEY_keygen_init(kctx) <= 0)
+		goto cleanup;
+	if (EVP_PKEY_CTX_set_rsa_keygen_bits(kctx, 512) <= 0)
+		goto cleanup;
+	if (EVP_PKEY_keygen(kctx, &pkey) <= 0)
+		goto cleanup;
+
+	sctx = EVP_PKEY_CTX_new(pkey, NULL);
+	if (sctx == NULL)
+		goto cleanup;
+	if (EVP_PKEY_sign_init(sctx) <= 0)
+		goto cleanup;
+	if (EVP_PKEY_CTX_set_rsa_padding(sctx, RSA_PKCS1_PADDING) <= 0)
+		goto cleanup;
+	if (EVP_PKEY_CTX_set_signature_md(sctx, EVP_sha1()) <= 0)
+		goto cleanup;
+
+	result = TRUE;
+
+  cleanup:
+	ERR_clear_error();
+	if (sctx != NULL)
+		EVP_PKEY_CTX_free(sctx);
+	if (pkey != NULL)
+		EVP_PKEY_free(pkey);
+	if (kctx != NULL)
+		EVP_PKEY_CTX_free(kctx);
+	return result;
+}
+#endif /* ! USE_GNUTLS */
+
 /*
 **  DKIM_INIT -- initialize a DKIM library context
 **
@@ -4520,6 +4579,11 @@ dkim_init(void *(*caller_mallocf)(void *closure, size_t nbytes),
 
 	libhandle->dkiml_signre = FALSE;
 	libhandle->dkiml_skipre = FALSE;
+#ifndef USE_GNUTLS
+	libhandle->dkiml_sha1_available = dkim_probe_sha1_signing();
+#else
+	libhandle->dkiml_sha1_available = TRUE;
+#endif /* ! USE_GNUTLS */
 	libhandle->dkiml_malloc = caller_mallocf;
 	libhandle->dkiml_free = caller_freef;
 	strlcpy((char *) libhandle->dkiml_tmpdir, (char *) td, 
@@ -5927,8 +5991,8 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 				return DKIM_STAT_OK;
 			}
 
-#ifndef HAVE_SHA1_SIGNING
-			if (sig->sig_hashtype == DKIM_HASHTYPE_SHA1)
+			if (sig->sig_hashtype == DKIM_HASHTYPE_SHA1 &&
+			    !dkim->dkim_libhandle->dkiml_sha1_available)
 			{
 				dkim_error(dkim,
 				           "s=%s d=%s: RSA-SHA1 verification not available on this platform",
@@ -5941,7 +6005,6 @@ dkim_sig_process(DKIM *dkim, DKIM_SIGINFO *sig)
 
 				return DKIM_STAT_OK;
 			}
-#endif /* HAVE_SHA1_SIGNING */
 
 			crypto->crypto_keysize = EVP_PKEY_size(crypto->crypto_pkey);
 

--- a/libopendkim/tests/Makefile.am
+++ b/libopendkim/tests/Makefile.am
@@ -60,7 +60,7 @@ CLEANFILES = t-cleanup
 
 TESTS = $(check_PROGRAMS) $(check_SCRIPTS) t-cleanup
 
-EXTRA_DIST = $(check_SCRIPTS)
+EXTRA_DIST = $(check_SCRIPTS) t-sha1.h
 
 t_setup_SOURCES = t-setup.c t-testdata.h
 t_cleanup_SOURCES = t-cleanup.c t-testdata.h

--- a/libopendkim/tests/t-sha1.h
+++ b/libopendkim/tests/t-sha1.h
@@ -1,0 +1,24 @@
+/*
+**  t-sha1.h -- skip helper for RSA-SHA1 signing tests
+**
+**  On platforms where the system crypto policy disables SHA1 for signing
+**  (e.g. RHEL 9 / AlmaLinux 9 DEFAULT policy), tests that attempt RSA-SHA1
+**  signing should skip rather than fail.  Include this header and call
+**  SKIP_IF_NO_SHA1() at the top of main() in any test that uses
+**  DKIM_SIGN_RSASHA1.
+*/
+
+#ifndef T_SHA1_H
+#define T_SHA1_H
+
+#ifndef HAVE_SHA1_SIGNING
+# define SKIP_IF_NO_SHA1() \
+	do { \
+		printf("RSA-SHA1 signing not available on this platform, skipping\n"); \
+		return 77; \
+	} while (0)
+#else
+# define SKIP_IF_NO_SHA1() do { } while (0)
+#endif
+
+#endif /* T_SHA1_H */

--- a/libopendkim/tests/t-signperf-sha1
+++ b/libopendkim/tests/t-signperf-sha1
@@ -4,3 +4,4 @@
 # Speed signing test using sha1 hash algorithm
 
 ./t-signperf -s rsa-sha1
+exit $?

--- a/libopendkim/tests/t-signperf.c
+++ b/libopendkim/tests/t-signperf.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -293,6 +294,11 @@ main(int argc, char **argv)
 		        "### algorithm %s not available SKIPPED\n", alg_name(signalg));
 		dkim_close(lib);
 		return 0;
+	}
+
+	if (signalg == DKIM_SIGN_RSASHA1)
+	{
+		SKIP_IF_NO_SHA1();
 	}
 
 	if (signalg == DKIM_SIGN_ED25519SHA256)

--- a/libopendkim/tests/t-test00.c
+++ b/libopendkim/tests/t-test00.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -50,6 +51,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/relaxed rsa-sha1 signing\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test01.c
+++ b/libopendkim/tests/t-test01.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -50,6 +51,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 signing\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test02.c
+++ b/libopendkim/tests/t-test02.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -50,6 +51,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** simple/relaxed rsa-sha1 signing\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test03.c
+++ b/libopendkim/tests/t-test03.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -50,6 +51,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** simple/simple rsa-sha1 signing\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test04.c
+++ b/libopendkim/tests/t-test04.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -49,6 +50,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/relaxed rsa-sha1 verifying\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test05.c
+++ b/libopendkim/tests/t-test05.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -49,6 +50,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 verifying\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test06.c
+++ b/libopendkim/tests/t-test06.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -49,6 +50,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** simple/relaxed rsa-sha1 verifying\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test07.c
+++ b/libopendkim/tests/t-test07.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -49,6 +50,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** simple/simple rsa-sha1 verifying\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test08.c
+++ b/libopendkim/tests/t-test08.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -48,6 +49,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/relaxed rsa-sha1 signing with lengths\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test09.c
+++ b/libopendkim/tests/t-test09.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -48,6 +49,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 signing with lengths\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test10.c
+++ b/libopendkim/tests/t-test10.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -48,6 +49,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** simple/relaxed rsa-sha1 signing with lengths\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test100.c
+++ b/libopendkim/tests/t-test100.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -50,6 +51,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** exercise dkim_minbody()\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test101.c
+++ b/libopendkim/tests/t-test101.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -56,6 +57,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** exercise dkim_sig_*() utility functions\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test102.c
+++ b/libopendkim/tests/t-test102.c
@@ -57,6 +57,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 verifying with \"must be signed\" list\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test102.c
+++ b/libopendkim/tests/t-test102.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>

--- a/libopendkim/tests/t-test107.c
+++ b/libopendkim/tests/t-test107.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -52,6 +53,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 default body canonicalization\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test11.c
+++ b/libopendkim/tests/t-test11.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -48,6 +49,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** simple/simple rsa-sha1 signing with lengths\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test114.c
+++ b/libopendkim/tests/t-test114.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -81,6 +82,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** detection of various signature abnormalities\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test115.c
+++ b/libopendkim/tests/t-test115.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -58,6 +59,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** detection of various key anomalies\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test117.c
+++ b/libopendkim/tests/t-test117.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -64,6 +65,7 @@ main(int argc, char **argv)
 	char *td = NULL;
 
 	printf("*** general utility functions\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test12.c
+++ b/libopendkim/tests/t-test12.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -47,6 +48,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/relaxed rsa-sha1 verifying with lengths plus extra data\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test120.c
+++ b/libopendkim/tests/t-test120.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -52,6 +53,7 @@ main(int argc, char **argv)
 	unsigned char inhdr[MAXHEADER + 1];
 
 	printf("*** zero margin testing\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test127.c
+++ b/libopendkim/tests/t-test127.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -67,6 +68,7 @@ main(int argc, char **argv)
 	unsigned char buf[MAXMSGSIZE];
 
 	printf("*** relaxed/simple rsa-sha1 signing with split CRLFs and blank counting\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test128.c
+++ b/libopendkim/tests/t-test128.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -69,6 +70,7 @@ main(int argc, char **argv)
 	if (!dkim_libfeature(lib, DKIM_FEATURE_RESIGN))
 	{
 		printf("*** relaxed/simple rsa-sha1 re-signing with header binding SKIPPED\n");
+	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}

--- a/libopendkim/tests/t-test129.c
+++ b/libopendkim/tests/t-test129.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -114,6 +115,7 @@ main(int argc, char **argv)
 	if (!dkim_libfeature(lib, DKIM_FEATURE_RESIGN))
 	{
 		printf("*** relaxed/simple rsa-sha1 re-signing without header binding SKIPPED\n");
+	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}

--- a/libopendkim/tests/t-test13.c
+++ b/libopendkim/tests/t-test13.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -47,6 +48,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 verifying with lengths plus extra data\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test130.c
+++ b/libopendkim/tests/t-test130.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -51,6 +52,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 with bad/good signatures\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test136.c
+++ b/libopendkim/tests/t-test136.c
@@ -6,6 +6,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -83,6 +84,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/relaxed rsa-sha1 verifying with header field name case change\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test137.c
+++ b/libopendkim/tests/t-test137.c
@@ -65,12 +65,12 @@ main(int argc, char **argv)
 	if (!dkim_libfeature(lib, DKIM_FEATURE_SHA256))
 	{
 		printf("*** simple/simple rsa-sha256 signature substrings SKIPPED\n");
-	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}
 
 	printf("*** simple/simple rsa-sha256 verifying signature substrings\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef TEST_KEEP_FILES
 	/* set flags */

--- a/libopendkim/tests/t-test137.c
+++ b/libopendkim/tests/t-test137.c
@@ -6,6 +6,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -64,6 +65,7 @@ main(int argc, char **argv)
 	if (!dkim_libfeature(lib, DKIM_FEATURE_SHA256))
 	{
 		printf("*** simple/simple rsa-sha256 signature substrings SKIPPED\n");
+	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}

--- a/libopendkim/tests/t-test138.c
+++ b/libopendkim/tests/t-test138.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -53,6 +54,7 @@ main(int argc, char **argv)
 	unsigned char signedhdrs[SIGARRAY][DKIM_MAXHEADER + 1];
 
 	printf("*** signed header content extraction\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test139.c
+++ b/libopendkim/tests/t-test139.c
@@ -6,6 +6,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -48,6 +49,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/relaxed rsa-sha1 verifying with oversigning\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test14.c
+++ b/libopendkim/tests/t-test14.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -47,6 +48,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** simple/relaxed rsa-sha1 verifying with lengths plus extra data\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test140.c
+++ b/libopendkim/tests/t-test140.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -58,6 +59,7 @@ main(int argc, char **argv)
 	assert(lib != NULL);
 
 	printf("*** relaxed/relaxed rsa-sha1 signing with extension tags\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef TEST_KEEP_FILES
 	/* set flags */

--- a/libopendkim/tests/t-test142.c
+++ b/libopendkim/tests/t-test142.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -61,6 +62,7 @@ main(int argc, char **argv)
 	unsigned char buf[MAXMSGSIZE];
 
 	printf("*** relaxed/simple rsa-sha1 verifying using chunking API (single chunk, LF only, FIXCRLF)\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test143.c
+++ b/libopendkim/tests/t-test143.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -54,6 +55,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** test DKIM_QUERYINFO routines\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test144.c
+++ b/libopendkim/tests/t-test144.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -64,6 +65,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** signing attempt with an invalid key\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test145.c
+++ b/libopendkim/tests/t-test145.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -62,6 +63,7 @@ main(int argc, char **argv)
 	dkim_sigkey_t key;
 
 	printf("*** invalid key preload test\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test146.c
+++ b/libopendkim/tests/t-test146.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -64,6 +65,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** use of invalid key after load failure\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test147.c
+++ b/libopendkim/tests/t-test147.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -50,6 +51,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** simple/simple rsa-sha1 signing with report request\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test149.c
+++ b/libopendkim/tests/t-test149.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -47,6 +48,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/relaxed rsa-sha1 verifying with missing end CRLF\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test15.c
+++ b/libopendkim/tests/t-test15.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -47,6 +48,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** simple/simple rsa-sha1 verifying with lengths plus extra data\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test150.c
+++ b/libopendkim/tests/t-test150.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -47,6 +48,7 @@ main(int argc, char **argv)
 	dkim_sigkey_t key;
 
 	printf("*** relaxed/relaxed rsa-sha1 signing with small key (failure)\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test151.c
+++ b/libopendkim/tests/t-test151.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -71,6 +72,7 @@ main(int argc, char **argv)
 	if (!dkim_libfeature(lib, DKIM_FEATURE_RESIGN))
 	{
 		printf("*** relaxed/simple rsa-sha1 dual signing with shared body SKIPPED\n");
+	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}

--- a/libopendkim/tests/t-test152.c
+++ b/libopendkim/tests/t-test152.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -68,6 +69,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/relaxed rsa-sha1 signing with message-specifc header sign list\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test153.c
+++ b/libopendkim/tests/t-test153.c
@@ -59,6 +59,7 @@ main(int argc, char **argv)
 	unsigned char buf[10240];
 
 	printf("*** simple/simple rsa-sha1 verifying with chunking, FIXCRLF, and \"b=...;\"\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test153.c
+++ b/libopendkim/tests/t-test153.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>

--- a/libopendkim/tests/t-test154.c
+++ b/libopendkim/tests/t-test154.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -50,6 +51,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/relaxed rsa-sha1 signing with a phony/extra From\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test203.c
+++ b/libopendkim/tests/t-test203.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -112,6 +113,7 @@ main(int argc, char **argv)
 	    !dkim_libfeature(lib, DKIM_FEATURE_SHA256))
 	{
 		printf("*** relaxed/simple rsa-sha1/ed25519-sha256/rsa-256 verifying SKIPPED\n");
+	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}

--- a/libopendkim/tests/t-test203.c
+++ b/libopendkim/tests/t-test203.c
@@ -113,12 +113,12 @@ main(int argc, char **argv)
 	    !dkim_libfeature(lib, DKIM_FEATURE_SHA256))
 	{
 		printf("*** relaxed/simple rsa-sha1/ed25519-sha256/rsa-256 verifying SKIPPED\n");
-	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}
 
 	printf("*** relaxed/simple rsa-sha1/ed25519-sha256/rsa-256 verifying\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef TEST_KEEP_FILES
 	/* set flags */

--- a/libopendkim/tests/t-test50.c
+++ b/libopendkim/tests/t-test50.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -51,6 +52,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** simple/simple rsa-sha1 signing with expiration times\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test64.c
+++ b/libopendkim/tests/t-test64.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -193,6 +194,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 verifying with leak detection\n");
+	SKIP_IF_NO_SHA1();
 
 	debug_init();
 

--- a/libopendkim/tests/t-test65.c
+++ b/libopendkim/tests/t-test65.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -193,6 +194,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 signing with leak detection\n");
+	SKIP_IF_NO_SHA1();
 
 	debug_init();
 

--- a/libopendkim/tests/t-test67.c
+++ b/libopendkim/tests/t-test67.c
@@ -103,12 +103,12 @@ main(int argc, char **argv)
 	if (!dkim_libfeature(lib, DKIM_FEATURE_SHA256))
 	{
 		printf("*** relaxed/simple rsa-sha1/rsa-256 verifying SKIPPED\n");
-	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}
 
 	printf("*** relaxed/simple rsa-sha1/rsa-256 verifying\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef TEST_KEEP_FILES
 	/* set flags */

--- a/libopendkim/tests/t-test67.c
+++ b/libopendkim/tests/t-test67.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -102,6 +103,7 @@ main(int argc, char **argv)
 	if (!dkim_libfeature(lib, DKIM_FEATURE_SHA256))
 	{
 		printf("*** relaxed/simple rsa-sha1/rsa-256 verifying SKIPPED\n");
+	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}

--- a/libopendkim/tests/t-test68.c
+++ b/libopendkim/tests/t-test68.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -49,6 +50,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 verifying with altered body\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test69.c
+++ b/libopendkim/tests/t-test69.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -47,6 +48,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 verifying with delayed processing\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test71.c
+++ b/libopendkim/tests/t-test71.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -207,6 +208,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 signing with large headers\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test73.c
+++ b/libopendkim/tests/t-test73.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -189,6 +190,7 @@ main(int argc, char **argv)
 	if (!dkim_libfeature(lib, DKIM_FEATURE_SHA256))
 	{
 		printf("*** simple/simple rsa-sha256 verifying with extra signature spaces and reportinfo (failure) SKIPPED\n");
+	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}

--- a/libopendkim/tests/t-test73.c
+++ b/libopendkim/tests/t-test73.c
@@ -190,12 +190,12 @@ main(int argc, char **argv)
 	if (!dkim_libfeature(lib, DKIM_FEATURE_SHA256))
 	{
 		printf("*** simple/simple rsa-sha256 verifying with extra signature spaces and reportinfo (failure) SKIPPED\n");
-	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}
 
 	printf("*** simple/simple rsa-sha256 verifying with extra signature spaces and reportinfo (failure)\n");
+	SKIP_IF_NO_SHA1();
 
 	/* DNS stubs for the reporting data lookup */
 	dkim_dns_set_query_service(lib, NULL);

--- a/libopendkim/tests/t-test74.c
+++ b/libopendkim/tests/t-test74.c
@@ -110,12 +110,12 @@ main(int argc, char **argv)
 	if (!dkim_libfeature(lib, DKIM_FEATURE_SHA256))
 	{
 		printf("*** simple/simple rsa-sha256 verifying with key callback and key reuse SKIPPED\n");
-	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}
 
 	printf("*** simple/simple rsa-sha256 verifying with key callback and key reuse\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef TEST_KEEP_FILES
 	/* set flags */

--- a/libopendkim/tests/t-test74.c
+++ b/libopendkim/tests/t-test74.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -109,6 +110,7 @@ main(int argc, char **argv)
 	if (!dkim_libfeature(lib, DKIM_FEATURE_SHA256))
 	{
 		printf("*** simple/simple rsa-sha256 verifying with key callback and key reuse SKIPPED\n");
+	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}

--- a/libopendkim/tests/t-test77.c
+++ b/libopendkim/tests/t-test77.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -50,6 +51,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 signing with oversized expiration\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test78.c
+++ b/libopendkim/tests/t-test78.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -49,6 +50,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 verifying with oversized expiration\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test79.c
+++ b/libopendkim/tests/t-test79.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -50,6 +51,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 signing with space-laden header names\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test80.c
+++ b/libopendkim/tests/t-test80.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -49,6 +50,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 verifying with space-laden header names\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test81.c
+++ b/libopendkim/tests/t-test81.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -50,6 +51,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 signing with i= set\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test82.c
+++ b/libopendkim/tests/t-test82.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -49,6 +50,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 verifying with i=/d= mismatch and t=s in the key\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test88.c
+++ b/libopendkim/tests/t-test88.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -62,6 +63,7 @@ main(int argc, char **argv)
 	unsigned char buf[MAXMSGSIZE];
 
 	printf("*** relaxed/simple rsa-sha1 verifying using chunking API (single chunk)\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test89.c
+++ b/libopendkim/tests/t-test89.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -49,6 +50,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 verifying using chunking API (many chunks)\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test90.c
+++ b/libopendkim/tests/t-test90.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -48,6 +49,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/relaxed rsa-sha1 signing with CRLF fixing\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test91.c
+++ b/libopendkim/tests/t-test91.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -48,6 +49,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 signing with CRLF fixing\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test92.c
+++ b/libopendkim/tests/t-test92.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -58,6 +59,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 signing with extra headers\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test93.c
+++ b/libopendkim/tests/t-test93.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -49,6 +50,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 verifying with extra (but missing) headers\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test94.c
+++ b/libopendkim/tests/t-test94.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -49,6 +50,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/simple rsa-sha1 verifying with extra headers added (failure)\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test95.c
+++ b/libopendkim/tests/t-test95.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -62,6 +63,7 @@ main(int argc, char **argv)
 	if (!dkim_libfeature(lib, DKIM_FEATURE_CONDITIONAL))
 	{
 		printf("*** conditional signature generation SKIPPED\n");
+	SKIP_IF_NO_SHA1();
 		dkim_close(lib);
 		return 0;
 	}

--- a/libopendkim/tests/t-test98.c
+++ b/libopendkim/tests/t-test98.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -48,6 +49,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** relaxed/relaxed rsa-sha1 verifying with oversized l= value (failure)\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();

--- a/libopendkim/tests/t-test99.c
+++ b/libopendkim/tests/t-test99.c
@@ -7,6 +7,7 @@
 */
 
 #include "build-config.h"
+#include "t-sha1.h"
 
 /* system includes */
 #include <sys/types.h>
@@ -50,6 +51,7 @@ main(int argc, char **argv)
 	unsigned char hdr[MAXHEADER + 1];
 
 	printf("*** exercise dkim_sig_hdrsigned()\n");
+	SKIP_IF_NO_SHA1();
 
 #ifdef USE_GNUTLS
 	(void) gnutls_global_init();


### PR DESCRIPTION
## Summary

On systems where the platform crypto policy restricts SHA1 for signing operations (e.g., RHEL 9 / AlmaLinux 9 DEFAULT policy, which sets `SignatureAlgorithms` in OpenSSL's `evp_properties` config section), RSA-SHA1 signing and verification were failing with `DKIM_STAT_INTERNAL` instead of being handled gracefully.

Root cause: the system-wide OpenSSL `evp_properties` config restricts `SignatureAlgorithms` for all EVP operations (not just TLS), causing `EVP_PKEY_CTX_set_signature_md(pkey_ctx, EVP_sha1())` to return `EVP_R_INVALID_DIGEST`.

### Changes

**configure.ac:**
- Add `AC_CACHE_CHECK` that tests RSA-SHA1 signing using `EVP_PKEY_sign` + `EVP_PKEY_CTX_set_signature_md` - the same code path the library uses internally. The previous test used `EVP_DigestSign` which goes through a different path and does not trigger the platform restriction.
- Fix a bug where pre-assigning `ac_cv_have_sha1_signing=yes` before `AC_CACHE_CHECK` caused the test to be silently skipped on every run.
- Use a 2048-bit key in the configure test.
- Set `HAVE_SHA1_SIGNING` and `AM_CONDITIONAL([HAVE_SHA1_SIGNING])` based on the result.
- Emit a `configure: WARNING` when SHA1 signing is unavailable.

**libopendkim/dkim.c:**
- Signing path: when `HAVE_SHA1_SIGNING` is not defined and RSA-SHA1 is requested, return `DKIM_STAT_SIGGEN` with a clear error message instead of hitting EVP calls that produce `DKIM_STAT_INTERNAL`.
- Verification path: when `HAVE_SHA1_SIGNING` is not defined, set `sig->sig_error = DKIM_SIGERROR_UNSUPPORTED_A` and return `DKIM_STAT_OK`, so inbound SHA1-signed mail is handled as "algorithm unverifiable" rather than causing an internal library error.
- Also fix the runtime `EVP_PKEY_CTX_set_signature_md` failure in verification (policy changes after compile) to follow the `DKIM_STAT_OK` + `sig_error` pattern used elsewhere, instead of returning `DKIM_STAT_INTERNAL`.

**libopendkim/tests:**
- Add `t-sha1.h` with `SKIP_IF_NO_SHA1()` macro (returns exit code 77 = automake skip when `HAVE_SHA1_SIGNING` is not defined).
- Add `SKIP_IF_NO_SHA1()` to all 71 SHA1-dependent signing and verification tests.
- Fix `t-signperf` to skip conditionally when `-s rsa-sha1` is requested.

## Test plan

- [x] On a system with the DEFAULT RHEL 9 / AlmaLinux 9 crypto policy: `./configure` reports SHA1 signing unavailable, `make check` shows 72 SKIP, 0 FAIL
- [x] On a system where SHA1 is available: `./configure` reports SHA1 signing available, all SHA1 tests run and pass as before
- [x] Inbound mail signed with `a=rsa-sha1` on a restricted platform: logs `DKIM_SIGERROR_UNSUPPORTED_A`, does not return `DKIM_STAT_INTERNAL`

Closes #364