### PR TITLE
Embed git hash in version string for development builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,9 +46,26 @@ AC_CONFIG_MACRO_DIR([m4])
 
 #
 # Hexadecimal version, for use in generating dkim.h
-# 
+#
 HEX_VERSION=$(printf %08x $(( ((VERSION_RELEASE << 8 | VERSION_MAJOR_REV) << 8 | VERSION_MINOR_REV) << 8| VERSION_PATCH )))
 AC_SUBST([HEX_VERSION])
+
+#
+# Version string for the software header; includes git hash for development builds
+#
+AC_CHECK_PROG([GIT], [git], [git])
+AC_MSG_CHECKING([build version string])
+DKIMF_VERSION=$PACKAGE_VERSION
+if test -n "$GIT" && $GIT describe --tags --dirty >/dev/null 2>&1; then
+    _git_ver=$($GIT describe --tags --dirty)
+    _git_ver=${_git_ver#v}
+    if test "$_git_ver" != "$PACKAGE_VERSION"; then
+        DKIMF_VERSION=$_git_ver
+    fi
+fi
+AC_MSG_RESULT([$DKIMF_VERSION])
+AC_DEFINE_UNQUOTED([DKIMF_VERSION], ["$DKIMF_VERSION"],
+                   [Version string for software header, including git hash on development builds])
 
 #
 # library version, passed to libtool

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -10434,7 +10434,7 @@ dkimf_sigreport(connctx cc, struct dkimf_config *conf, char *hostname)
 	fprintf(out, "--dkimreport/%s/%s\n", hostname, dfc->mctx_jobid);
 	fprintf(out, "Content-Type: message/feedback-report\n");
 	fprintf(out, "\n");
-	fprintf(out, "User-Agent: %s/%s\n", DKIMF_PRODUCTNS, VERSION);
+	fprintf(out, "User-Agent: %s/%s\n", DKIMF_PRODUCTNS, DKIMF_VERSION);
 	fprintf(out, "Version: %s\n", ARF_VERSION);
 	fprintf(out, "Original-Envelope-Id: %s\n", dfc->mctx_jobid);
 	fprintf(out, "Original-Mail-From: %s\n", dfc->mctx_envfrom);
@@ -15223,7 +15223,7 @@ mlfi_eom(SMFICTX *ctx)
 
 		snprintf(xfhdr, DKIM_MAXHEADER, "%s%s v%s %s %s",
 		         cc->cctx_noleadspc ? " " : "",
-		         DKIMF_PRODUCT, VERSION, hostname,
+		         DKIMF_PRODUCT, DKIMF_VERSION, hostname,
 		         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
 		                                 : (u_char *) JOBIDUNKNOWN);
 
@@ -15767,7 +15767,7 @@ main(int argc, char **argv)
 			}
 
 			printf("%s: %s v%s\n", progname, DKIMF_PRODUCT,
-			       VERSION);
+			       DKIMF_VERSION);
 #ifdef USE_GNUTLS
 			printf("\tCompiled with GnuTLS %s\n", GNUTLS_VERSION);
 #else /* USE_GNUTLS */
@@ -17095,7 +17095,7 @@ main(int argc, char **argv)
 		_Bool noargs = strlen(argstr) == 0;
 
 		dkimf_log(curconf, LOG_INFO, "%s v%s starting%s%s%s", DKIMF_PRODUCT,
-		          VERSION,
+		          DKIMF_VERSION,
 		          noargs ? "" : " (",
 		          argstr,
 		          noargs ? "" : ")");
@@ -17131,7 +17131,7 @@ main(int argc, char **argv)
 
 	dkimf_log(curconf, LOG_INFO,
 		  "%s v%s terminating with status %d, errno = %d",
-		  DKIMF_PRODUCT, VERSION, status, errno);
+		  DKIMF_PRODUCT, DKIMF_VERSION, status, errno);
 
 #ifdef POPAUTH
 	if (popdb != NULL)


### PR DESCRIPTION
## Summary

- Adds `AC_CHECK_PROG` detection for `git` in `configure.ac`
- If git is available and `git describe --tags --dirty` produces output that differs from `PACKAGE_VERSION`, that string becomes `DKIMF_VERSION` (e.g. `2.11.0-alpha-5-gabcdef7`); tagged release builds and no-git environments fall back to the plain version number
- Replaces all `VERSION` references in user-visible output in `opendkim.c` with `DKIMF_VERSION`: `DKIM-Filter` software header, `--version` output, startup/shutdown log messages, and feedback report `User-Agent`

Closes #350

## Test plan

- [ ] `autoreconf -fiv && ./configure` on a development checkout shows the git hash in the version string during configure output
- [ ] `autoreconf -fiv && ./configure` on a tagged commit shows the plain version number
- [ ] Build succeeds without git installed (fallback to `PACKAGE_VERSION`)
- [ ] `opendkim --version` shows the git-derived string on a dev build