### PR TITLE
SoftwareHeader: include milter hostname when different from MTA hostname

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -15221,11 +15221,23 @@ mlfi_eom(SMFICTX *ctx)
 
 		memset(xfhdr, '\0', sizeof xfhdr);
 
-		snprintf(xfhdr, DKIM_MAXHEADER, "%s%s v%s %s %s",
-		         cc->cctx_noleadspc ? " " : "",
-		         DKIMF_PRODUCT, DKIMF_VERSION, hostname,
-		         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
-		                                 : (u_char *) JOBIDUNKNOWN);
+		if (strcasecmp(hostname, myhostname) == 0)
+		{
+			snprintf(xfhdr, DKIM_MAXHEADER, "%s%s v%s %s %s",
+			         cc->cctx_noleadspc ? " " : "",
+			         DKIMF_PRODUCT, DKIMF_VERSION, hostname,
+			         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
+			                                 : (u_char *) JOBIDUNKNOWN);
+		}
+		else
+		{
+			snprintf(xfhdr, DKIM_MAXHEADER, "%s%s v%s %s via %s %s",
+			         cc->cctx_noleadspc ? " " : "",
+			         DKIMF_PRODUCT, DKIMF_VERSION, hostname,
+			         myhostname,
+			         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
+			                                 : (u_char *) JOBIDUNKNOWN);
+		}
 
 		if (dkimf_insheader(ctx, 0, SWHEADERNAME, xfhdr) != MI_SUCCESS)
 		{


### PR DESCRIPTION
## Summary

When `SoftwareHeader yes` is configured and the milter runs on the same host as the MTA, the header is unchanged:

```
DKIM-Filter: OpenDKIM Filter v2.10.3 mail.example.com AB12CD3E
```

When the milter runs on a different host (e.g. a milter pool behind a load balancer), the milter's own hostname is appended:

```
DKIM-Filter: OpenDKIM Filter v2.10.3 mail.example.com via milter1.internal AB12CD3E
```

Comparison between the MTA hostname (`{j}` macro) and the milter hostname (`gethostname()`) is case-insensitive. No config changes required.

Closes #349

## Test plan

- [ ] Single-host deployment: header format unchanged from current behavior
- [ ] Milter running on separate host from MTA: `via <myhostname>` appears between MTA hostname and job ID
- [ ] `SoftwareHeader no` (default): no change in behavior