### PR TITLE
opendkim-db: treat leading '[' as bracketed IPv6, not a type prefix

### DIFF
--- a/opendkim/opendkim-db.c
+++ b/opendkim/opendkim-db.c
@@ -1847,7 +1847,11 @@ dkimf_db_open(DKIMF_DB *db, char *name, u_int flags, pthread_mutex_t *lock,
 	new->db_flags = (flags | gflags);
 	new->db_type = DKIMF_DB_TYPE_UNKNOWN;
 
-	p = strchr(name, ':');
+	/* a leading '[' means a bracketed IPv6 address, not a type: prefix */
+	if (name[0] == '[')
+		p = NULL;
+	else
+		p = strchr(name, ':');
 	comma = strchr(name, ',');
 
 	/* catch a CSL that contains colons not in the first entry */


### PR DESCRIPTION
## Summary

`dkimf_db_open()` used `strchr(name, ':')` to detect a `type:` prefix (e.g. `file:`, `ldap:`). A bracketed IPv6 address like `[fd00:368::]/40` contains colons, causing the parser to treat `[fd00` as the type string and return "Unknown database type".

Fix: skip the colon search when the value starts with `[`, letting it fall through to CSL type detection. The CSL tokenizer splits on commas only, so colons inside a bracketed IPv6 entry are irrelevant. The matching side (`dkimf_checkip()` in `util.c`) already probes both bare and bracketed forms with and without CIDR prefix.

This enables inline IPv6 CIDR notation without requiring a file reference:
\`\`\`
PeerList [fd00:368::]/40
InternalHosts 10.0.0.0/8,[fd00:368::]/40
\`\`\`

The file workaround (`PeerList file:/etc/opendkim/peerlist.txt`) continues to work unchanged.

Closes #319

## Test plan

- [ ] `PeerList [fd00:368::]/40` loads without "Unknown database type" error
- [ ] Connection from an IPv6 address in the configured CIDR is correctly matched
- [ ] Connection from an IPv6 address outside the CIDR is not matched
- [ ] Existing `file:` and plain IPv4 CIDR entries unaffected