### PR TITLE
Fix DSN special character handling for SQL credentials

### DIFF
--- a/opendkim/README.SQL
+++ b/opendkim/README.SQL
@@ -14,6 +14,23 @@ single query.  The KeyTable is a common example of this.  Configuring these
 for SQL or LDAP backends can be tricky.  This document explains them in some
 detail and provides a few example configurations.
 
+SPECIAL CHARACTERS IN DSN FIELDS
+=================================
+
+If your database username, password, hostname, port, or database name contains
+any of the characters that the DSN parser uses as delimiters (':', '/', '@',
+'+', '?', or '='), you must encode them using the escape sequence =XY where XY
+is the two-digit uppercase hexadecimal value of the character.  For example, a
+password of "p@ss=word" would be written as "p=40ss=3Dword" in the DSN.
+
+Common encodings:
+  :  =3A
+  /  =2F
+  @  =40
+  +  =2B
+  ?  =3F
+  =  =3D
+
 The SigningTable lookup will use a signing pattern based on the message sender
 to perform a lookup and must return an arbitrary "label", which can be any
 string or number you wish to use.

--- a/opendkim/opendkim-db.c
+++ b/opendkim/opendkim-db.c
@@ -724,9 +724,31 @@ dkimf_db_hexdigit(int c)
 	else if (c >= 'A' && c <= 'F')
 		return c - 'A' + 10;
 	else if (c >= 'a' && c <= 'f')
-		return c - 'f' + 10;
+		return c - 'a' + 10;
 	else
 		return 0;
+}
+
+static void
+dkimf_db_dsn_decode(char *str)
+{
+	char *r;
+	char *w;
+
+	for (r = w = str; *r != '\0'; r++, w++)
+	{
+		if (*r == '=' && isxdigit(*(r + 1)) && isxdigit(*(r + 2)))
+		{
+			*w = 16 * dkimf_db_hexdigit(*(r + 1)) +
+			         dkimf_db_hexdigit(*(r + 2));
+			r += 2;
+		}
+		else
+		{
+			*w = *r;
+		}
+	}
+	*w = '\0';
 }
 #endif /* USE_ODBX */
 
@@ -2666,6 +2688,12 @@ dkimf_db_open(DKIMF_DB *db, char *name, u_int flags, pthread_mutex_t *lock,
 			free(new);
 			return -1;
 		}
+
+		dkimf_db_dsn_decode(dsn->dsn_user);
+		dkimf_db_dsn_decode(dsn->dsn_password);
+		dkimf_db_dsn_decode(dsn->dsn_host);
+		dkimf_db_dsn_decode(dsn->dsn_port);
+		dkimf_db_dsn_decode(dsn->dsn_dbase);
 
 		for (p = strtok_r(q, "?", &r);
 		     p != NULL;


### PR DESCRIPTION
## Summary

- `dkimf_db_hexdigit()` had a typo (`'f'` instead of `'a'`) causing incorrect decoding of lowercase hex digits `a`-`e`
- The `=XY` escape mechanism in DSN strings was never applied when storing credential fields (user, password, host, port, database) after parsing - so there was no working way to include special characters (e.g. `@`, `:`, `/`) in a MySQL/SQL password even though the DSN format was designed to support it
- Added `dkimf_db_dsn_decode()` and applied it to all credential fields; the existing inline decode in the filter path now shares the same hex helper
- Documented the `=XY` escape syntax in `README.SQL`, which had no mention of it

Closes #248

## Test plan

- [ ] DSN with special characters in password (e.g. `=40` for `@`) connects successfully
- [ ] Lowercase hex escape sequences (e.g. `=2f` for `/`) decode correctly
- [ ] Uppercase hex escape sequences continue to work
- [ ] DSN without any escapes is unaffected