### PR TITLE
docs: SignatureAlgorithm is auto-detected for ed25519 KeyFile (issue #107)

### DIFF
--- a/opendkim/opendkim.conf.5.in
+++ b/opendkim/opendkim.conf.5.in
@@ -346,11 +346,13 @@ Gives the location of a PEM-formatted private key to be used for signing
 all messages.  Ignored if a
 .I KeyTable
 is defined.
-If the key is an Ed25519 key, you must also set
+If the key is an Ed25519 key,
 .I SignatureAlgorithm
-to
-.I ed25519-sha256;
-the algorithm is not auto-detected from the key type.
+is automatically set to
+.I ed25519-sha256.
+An explicit
+.I SignatureAlgorithm
+setting is not required.
 
 .TP
 .I KeyTable (dataset)


### PR DESCRIPTION
## Summary

- Updates the `KeyFile` entry in `opendkim.conf(5)` to reflect that `SignatureAlgorithm` is now auto-detected when the key is ed25519 (implemented in #370).
- The previous text said "you must also set `SignatureAlgorithm` to `ed25519-sha256`; the algorithm is not auto-detected from the key type." That is no longer true.

## Test plan

- [ ] Verify man page renders correctly (`nroff -man opendkim/opendkim.conf.5.in | less`)
- [ ] Confirm an ed25519 `KeyFile` deployment works without an explicit `SignatureAlgorithm` line in config