### PR TITLE
Makefile.am: fix HEX_VERSION substitution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -59,7 +59,7 @@ push: $(DIST_ARCHIVES) $(DIST_ARCHIVES).sha1 $(DIST_ARCHIVES).md5 $(DIST_ARCHIVE
 
 dist-hook:
 	[ -f $(distdir)/libopendkim/dkim.h ] && rm -f $(distdir)/libopendkim/dkim.h
-	sed -e '/OPENDKIM_LIB_VERSION/s/0x[0-9]*/0x@HEX_VERSION@/' < $(srcdir)/libopendkim/dkim.h > $(distdir)/libopendkim/dkim.h
+	sed -e '/OPENDKIM_LIB_VERSION/s/0x[0-9abcdefABCDEF]*/0x@HEX_VERSION@/' < $(srcdir)/libopendkim/dkim.h > $(distdir)/libopendkim/dkim.h
 	echo "looking to see if @VERSION@ is in the RELEASE_NOTES"
 	fgrep @VERSION@ $(srcdir)/RELEASE_NOTES
 	sed -e 's|\(@VERSION@[ \t]*\)[0-9?]\{4\}\(/[0-9?]\{2\}\)\{2\}|\1'`date +%Y/%m/%d`'|' < $(srcdir)/RELEASE_NOTES > $(distdir)/RELEASE_NOTES


### PR DESCRIPTION
Include A-F in the regular expression for a hexadecimal number. Without this, the version gets substituted incorrectly during distcheck.

(listing the digits explicitly avoids having "A-F" depend on the locale)
