### PR TITLE
opendkim-dns.c: fix socket leak when libunbound returns bogus DNSSEC result

### DIFF
--- a/opendkim/opendkim-dns.c
+++ b/opendkim/opendkim-dns.c
@@ -179,7 +179,6 @@ dkimf_unbound_cb(void *mydata, int err, struct ub_result *result)
 		return;
 	}
 
-	ubdata->ubd_done = FALSE;
 	ubdata->ubd_stat = DKIM_STAT_NOKEY;
 	ubdata->ubd_rcode = result->rcode;
 	memcpy(ubdata->ubd_buf, result->answer_packet,
@@ -192,22 +191,14 @@ dkimf_unbound_cb(void *mydata, int err, struct ub_result *result)
 	*/
 
 	if (result->secure)
-	{
 		ubdata->ubd_result = DKIM_DNSSEC_SECURE;
-	}
 	else if (result->bogus)
-	{
-		/* result was bogus */
 		ubdata->ubd_result = DKIM_DNSSEC_BOGUS;
-		ub_resolve_free(result);
-		return;
-	}
 	else
-	{ 
 		ubdata->ubd_result = DKIM_DNSSEC_INSECURE;
-	}
 
-	if (result->havedata && !result->nxdomain && result->rcode == NOERROR)
+	if (!result->bogus && result->havedata && !result->nxdomain &&
+	    result->rcode == NOERROR)
 		ubdata->ubd_stat = DKIM_STAT_OK;
 
 	ub_resolve_free(result);


### PR DESCRIPTION
## Problem

`dkimf_unbound_cb()` has an early return in the bogus-DNSSEC branch that never sets `ubdata->ubd_done = TRUE`:

```c
else if (result->bogus)
{
    ubdata->ubd_result = DKIM_DNSSEC_BOGUS;
    ub_resolve_free(result);
    return;   /* ubd_done stays FALSE forever */
}
```

The waiting thread in `dkimf_unbound_wait()` blocks on `!ubdata->ubd_done`.  When the callback returns without setting that flag:

- the waiting thread hangs indefinitely
- `ub_cancel()` is never called for the query
- the file descriptor opened by libunbound for that query is never closed

This is a guaranteed socket leak for any domain whose DNSSEC validation returns a bogus result.  It is the likely root cause of the accumulation described in issue #149.

## Fix

Remove the early return; all paths fall through to the common `ub_resolve_free()` + `ubd_done = TRUE` tail.  The `DKIM_STAT_OK` assignment is guarded with `!result->bogus` so a bogus result keeps `DKIM_STAT_NOKEY` as the original intent.

The redundant `ubd_done = FALSE` mid-function is also removed - `ubd_done` is already initialized to `FALSE` in `dkimf_unbound_queue()` before the async query is submitted.

Found while diagnosing #149, but probably not the ultimate fix.