### PR TITLE
libopendkim/dkim-dns.c: serialize res_nquery() with a mutex to fix socket leak

### DIFF
--- a/libopendkim/dkim-dns.c
+++ b/libopendkim/dkim-dns.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
+#include <pthread.h>
 
 /* libopendkim includes */
 #include "dkim.h"
@@ -43,6 +44,20 @@ struct dkim_res_qh
 	size_t		rq_buflen;
 };
 
+#ifdef HAVE_RES_NINIT
+/*
+**  Wrapper around __res_state that serializes concurrent access.
+**  res_nquery() is not thread-safe on a shared __res_state: glibc keeps
+**  UDP sockets open in EXT(statp).nssocks[] between queries, and concurrent
+**  threads race on that array, orphaning file descriptors.
+*/
+struct dkim_res_svc
+{
+	struct __res_state	rs_state;
+	pthread_mutex_t		rs_lock;
+};
+#endif /* HAVE_RES_NINIT */
+
 /*
 **  DKIM_RES_INIT -- initialize the resolver
 **
@@ -57,24 +72,26 @@ int
 dkim_res_init(void **srv)
 {
 #ifdef HAVE_RES_NINIT
-	struct __res_state *res;
+	struct dkim_res_svc *svc;
 
-	res = malloc(sizeof(struct __res_state));
-	if (res == NULL)
+	svc = malloc(sizeof(struct dkim_res_svc));
+	if (svc == NULL)
 		return -1;
 
-	memset(res, '\0', sizeof(struct __res_state));
+	memset(&svc->rs_state, '\0', sizeof(svc->rs_state));
 
-	if (res_ninit(res) != 0)
+	if (res_ninit(&svc->rs_state) != 0)
 	{
-		free(res);
+		free(svc);
 		return -1;
 	}
 #ifdef RES_USE_DNSSEC
-	res->options |= RES_USE_DNSSEC;
+	svc->rs_state.options |= RES_USE_DNSSEC;
 #endif
 
-	*srv = res;
+	pthread_mutex_init(&svc->rs_lock, NULL);
+
+	*srv = svc;
 
 	return 0;
 #else /* HAVE_RES_NINIT */
@@ -107,14 +124,15 @@ void
 dkim_res_close(void *srv)
 {
 #ifdef HAVE_RES_NINIT
-	struct __res_state *res;
+	struct dkim_res_svc *svc;
 
-	res = srv;
+	svc = srv;
 
-	if (res != NULL)
+	if (svc != NULL)
 	{
-		res_nclose(res);
-		free(res);
+		res_nclose(&svc->rs_state);
+		pthread_mutex_destroy(&svc->rs_lock);
+		free(svc);
 	}
 #endif /* HAVE_RES_NINIT */
 }
@@ -172,13 +190,16 @@ dkim_res_query(void *srv, int type, unsigned char *query, unsigned char *buf,
 	int ret;
 	struct dkim_res_qh *rq;
 #ifdef HAVE_RES_NINIT
-	struct __res_state *statp;
+	struct dkim_res_svc *svc;
 #endif /* HAVE_RES_NINIT */
 	HEADER *hdr;
 
 #ifdef HAVE_RES_NINIT
-	statp = srv;
-	ret = res_nquery(statp, (char *) query, C_IN, type, buf, buflen);
+	svc = srv;
+	pthread_mutex_lock(&svc->rs_lock);
+	ret = res_nquery(&svc->rs_state, (char *) query, C_IN, type, buf,
+	                 buflen);
+	pthread_mutex_unlock(&svc->rs_lock);
 #else /* HAVE_RES_NINIT */
 	ret = res_query((char *) query, C_IN, type, buf, buflen);
 #endif /* HAVE_RES_NINIT */
@@ -287,7 +308,7 @@ dkim_res_nslist(void *srv, const char *nslist)
 # ifdef AF_INET6
 	struct sockaddr_in6 in6;
 # endif /* AF_INET6 */
-	struct __res_state *res;
+	struct dkim_res_svc *svc;
 	union res_sockaddr_union nses[MAXNS];
 
 	assert(srv != NULL);
@@ -336,8 +357,8 @@ dkim_res_nslist(void *srv, const char *nslist)
 		}
 	}
 
-	res = srv;
-	res_setservers(res, nses, nscount);
+	svc = srv;
+	res_setservers(&svc->rs_state, nses, nscount);
 
 	free(tmp);
 #endif /* HAVE_RES_SETSERVERS */


### PR DESCRIPTION
## Problem

The DKIM library holds a single `__res_state` (initialized by `res_ninit()` in `dkim_res_init()`), stored in `lib->dkiml_dns_service`.  libmilter spawns one thread per incoming connection.  All those threads share the same `DKIM_LIB` and call `dkim_res_query()` - and therefore `res_nquery(statp, ...)` - on the same `statp` concurrently with no locking.

`res_nquery()` is not thread-safe on a shared `__res_state`.  glibc keeps UDP sockets open between queries in `EXT(statp).nssocks[ns]` for performance (rather than opening/closing per query).  The pattern in glibc's `send_dg()`:

```c
if (EXT(statp).nssocks[ns] == -1) {
    s = socket(...);
    EXT(statp).nssocks[ns] = s;   /* store */
}
s = EXT(statp).nssocks[ns];
/* send and receive */
```

Under concurrent load, two threads can both read `nssocks[0] == -1`, both call `socket()`, and whichever stores last silently overwrites the other's fd.  The first fd is now orphaned - open in the kernel, tracked nowhere - and will never be closed.  Each race cycle leaks one socket.  Under sustained mail volume this accumulates until the process hits `EMFILE` ("socket() failed to open socket, insufficient resources").

This is the root cause of the socket accumulation reported in issue #149.  Confirmed by a reporter who built without `--with-unbound` (`#undef USE_UNBOUND`) and still observed the problem, ruling out the libunbound path.

## Fix

Wrap `__res_state` in a new `struct dkim_res_svc` that also carries a `pthread_mutex_t`.  `dkim_res_query()` holds the mutex for the duration of `res_nquery()`.

Serializing DNS lookups per library is acceptable: `res_nquery()` is already blocking network I/O, and the concurrency lost is small relative to the per-query latency.

## Testing

Built and restarted against this patch on an AlmaLinux 9.7 test instance that has been running in verify mode since 2026-05-25.  Zero socket accumulation observed (baseline was also zero at that load level; the race requires concurrent threads to manifest).

Fixes #149.  The libunbound bogus-DNSSEC path has a related but separate fix in PR #380.