### PR TITLE
reputation: fix strtoul/strtof endptr checks in dkimf_rep_check

### DIFF
--- a/CHANGES-202605.md
+++ b/CHANGES-202605.md
@@ -45,6 +45,7 @@ This document summarizes the changes merged into the `develop` branch during the
 - **`opendkim.c` NULL pointer comparison**: Fixed companion issue in `dkimf_add_signrequest`. (#244)
 - **SignHeaders/SkipHeaders regex buffer**: Fixed-size `BUFRSZ` limit on the regex buffer caused truncation with long header lists. Now dynamically sized. (#341, issue #120)
 - **Minimum signing percentage with empty body**: `Minimum` percentage checks incorrectly handled messages with an empty body. (#223, issue #222)
+- **`reputation.c` strtoul/strtof endptr checks**: `strtoul` and `strtof` always set their endptr argument to a non-NULL value; the existing `p != NULL` guards were redundant and masked the case where no conversion occurred at all. Three sites fixed in `dkimf_rep_check`: the limit parse, the modifier parse (missing no-conversion check could silently zero the limit on a bare operator like `"*"`), and the ratio parse. Also removes a pointless `p = NULL` initialization before `strtof`. Reported via futatuki/OpenDKIM PR #2 (Jared Mauch). (#383)
 - **Lua `del_header` index**: `odkim.del_header()` used an incorrect header index (off-by-one), deleting the wrong header. (#191)
 - **`KeepAuthResults` deleting wrong headers**: Could delete the wrong `Authentication-Results` header when multiple were present. (issue #148)
 - **`AuthservID` with job ID producing invalid header**: Quoting fix for job-ID-appended authserv-ids. (#308, issue #103)

--- a/opendkim/reputation.c
+++ b/opendkim/reputation.c
@@ -413,7 +413,7 @@ dkimf_rep_check(DKIMF_REP rep, DKIM_SIGINFO *sig, _Bool spam,
 			buf[req[fields - 1].dbdata_buflen] = '\0';
 
 			reps.reps_limit = (unsigned long) (ceil((double) strtoul(buf, &p, 10) / (double) rep->rep_factor) + 1.);
-			if (p != NULL && *p != '\0')
+			if (p == buf || *p != '\0')
 			{
 				if (errbuf != NULL)
 				{
@@ -452,7 +452,7 @@ dkimf_rep_check(DKIMF_REP rep, DKIM_SIGINFO *sig, _Bool spam,
 
 					buf[req[0].dbdata_buflen] = '\0';
 					mod = strtoul(&buf[1], &p, 10);
-					if (*p != '\0')
+					if (p == &buf[1] || *p != '\0')
 						buf[0] = '\0';
 
 					switch (buf[0])
@@ -540,9 +540,8 @@ dkimf_rep_check(DKIMF_REP rep, DKIM_SIGINFO *sig, _Bool spam,
 		}
 
 		buf[req[0].dbdata_buflen] = '\0';
-		p = NULL;
 		reps.reps_ratio = strtof(buf, &p);
-		if (p != NULL && *p != '\0')
+		if (p == buf || *p != '\0')
 		{
 			if (errbuf != NULL)
 			{


### PR DESCRIPTION
## Summary

- `strtoul` and `strtof` always set their endptr argument to a non-NULL value, making `p != NULL` checks redundant and masking the case where no conversion occurred at all (`p == buf`/`p == &buf[1]`)
- Three sites fixed in `dkimf_rep_check`:
  - **reps_limit parse**: `p != NULL && *p != '\0'` -> `p == buf || *p != '\0'`
  - **modifier parse**: `*p != '\0'` -> `p == &buf[1] || *p != '\0'` — a modifier string like `"*"` with no number would otherwise silently produce `mod = 0`, zeroing the limit
  - **reps_ratio parse** (`strtof`): same NULL check fix; also removes the pointless `p = NULL` initialization immediately overwritten by `strtof`

The first site was identified by Jared Mauch in futatuki/OpenDKIM PR #2; this applies the same fix pattern to all three sites in the function.