### PR TITLE
ci: skip workflow for markdown and doc-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [ develop ]
+    paths-ignore:
+      - '**.md'
+      - 'doc/**'
+      - 'contrib/**'
   pull_request:
     branches: [ develop ]
+    paths-ignore:
+      - '**.md'
+      - 'doc/**'
+      - 'contrib/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Add `paths-ignore` to the `push` and `pull_request` triggers so CI does not run when only documentation files are changed:

- `**.md` — changelog, readme, any other markdown
- `doc/**` — man pages and other docs
- `contrib/**` — scripts and tooling not part of the build

`workflow_dispatch` is unaffected — manual triggers always run regardless of `paths-ignore`.