### PR TITLE
docs: clarify OversignHeaders with RFC reference and rationale

### DIFF
--- a/opendkim/opendkim.conf.5.in
+++ b/opendkim/opendkim.conf.5.in
@@ -778,10 +778,16 @@ purpose of this, and especially of listing an absent header field, is to
 prevent the addition of important fields between the signer and the verifier.
 Since the verifier would include that header field when performing verification
 if it had been added by an intermediary, the signed message and the verified
-message were different and the verification would fail.  Note that listing
+message were different and the verification would fail.  Listing a header
+field name once more than it appears is sufficient to block any number of
+later additions; it is not necessary to list it more times than that.
+Note that this technique is useful even for header fields that RFC5322
+permits only once (such as From), since not all mail-handling software
+enforces RFC5322 header field count restrictions.  Note also that listing
 a field name here and not listing it in the
 .I SignHeaders
-list is likely to generate invalid signatures.
+list is likely to generate invalid signatures.  See RFC6376, Section 5.4
+for further discussion.
 
 .TP
 .I PeerList (dataset)

--- a/opendkim/opendkim.conf.sample
+++ b/opendkim/opendkim.conf.sample
@@ -421,10 +421,19 @@ KeyFile			/var/db/dkim/example.private
 ##
 ##  Specifies a set of header fields that should be included in all signature
 ##  header lists (the "h=" tag) once more than the number of times they were
-##  actually present in the signed message.  See opendkim.conf(5) for more
-##  information.
+##  actually present in the signed message.  The purpose is to prevent
+##  injection of additional instances of those fields after signing; a
+##  verifier that finds more copies than the signer recorded will fail
+##  verification.  Listing a field name once more than it appears in the
+##  message is sufficient regardless of how many copies an attacker might
+##  later add.  This is useful even for header fields that RFC5322 restricts
+##  to a single occurrence (such as From), because not all mail-handling
+##  software enforces those restrictions.  See RFC6376, Section 5.4 and
+##  opendkim.conf(5) for more information.
+##
+##  Oversigning From is a common and recommended practice:
 
-# OverSignHeaders	header1,header2,...
+# OversignHeaders	From
 
 ##  PeerList dataset
 ##  	default (none)


### PR DESCRIPTION
## Summary

- Adds RFC6376 Section 5.4 citation to the `OversignHeaders` manpage entry
- Explains why listing a header field once more than it appears in the message is sufficient to block any number of later injections
- Notes why oversigning is still worthwhile for RFC5322 singular headers (like `From`) whose uniqueness is not universally enforced by downstream software
- Expands the sample config comment with the same rationale, adds a recommended `OversignHeaders From` example, and fixes a capitalization typo in the directive name (`OverSignHeaders` -> `OversignHeaders`)

Prompted by the discussion in #131 (specifically the suggestion by @ghen2 to oversign `From` by default).

## Test plan

- [ ] Review manpage diff for accuracy and nroff formatting
- [ ] Review sample config diff for clarity