### PR TITLE
chore: fix mandoc -T lint warnings and style issues in manpages

### DIFF
--- a/opendkim/opendkim-atpszone.8.in
+++ b/opendkim/opendkim-atpszone.8.in
@@ -111,7 +111,7 @@ as the default record TTL time.  The default is 86400.
 .I \-u domain
 Produce output suitable for use as input to
 .B nsupdate(8)
-to add ATPS records to the named 
+to add ATPS records to the named
 .I domain.
 .TP
 .I \-v

--- a/opendkim/opendkim-genzone.8.in
+++ b/opendkim/opendkim-genzone.8.in
@@ -72,7 +72,8 @@ below), use
 as the default record expiration time.  The default is 604800.
 .TP
 .I \-F
-Adds a "._domainkey" suffix and the domainname to selector names in the zone file.
+Adds a "._domainkey" suffix and the domainname to selector names in the
+zone file.
 .TP
 .I \-N nslist
 Specifies a comma-separated list of nameservers, which will be output in

--- a/opendkim/opendkim-lua.3.in
+++ b/opendkim/opendkim-lua.3.in
@@ -6,7 +6,7 @@
 The OpenDKIM filter has hooks to run user-provided scripts for making policy
 decisions regarding signatures to add on outbound messages or verification and
 acceptance of messages inbound.  The hooks take the form of multiple Lua
-scripts which, if defined, are run at important points during processing of 
+scripts which, if defined, are run at important points during processing of
 a message.
 
 For a full description of the Lua language, consult Lua programming references
@@ -110,7 +110,7 @@ have a name associated with it.
 .TP
 .B odkim.get_clientip(ctx)
 Returns the IP address of the client on the other end of the SMTP connection
-sending the current message as a string.  Both IPv4 and IPv6 addresses are 
+sending the current message as a string.  Both IPv4 and IPv6 addresses are
 supported.
 .TP
 .B odkim.get_dbhandle(ctx, db)
@@ -524,7 +524,7 @@ the signature handled specified by
 .I sig,
 previously returned by a call to
 .B odkim.get_sighandle().
-Valid values are the DKIM_SIGBH_* constants defined in the 
+Valid values are the DKIM_SIGBH_* constants defined in the
 .B libopendkim
 header file
 .I dkim.h.

--- a/opendkim/opendkim-spam.1.in
+++ b/opendkim/opendkim-spam.1.in
@@ -14,7 +14,7 @@ with an indiciation that a user believes the input message is spam or
 otherwise abusive.  This feedback is important input toward developing
 DKIM-based domain reputation systems.
 
-The tool is intended to be used directly from within shell-based mail readers 
+The tool is intended to be used directly from within shell-based mail readers
 such as
 .I alpine(1)
 or

--- a/opendkim/opendkim-testmsg.8.in
+++ b/opendkim/opendkim-testmsg.8.in
@@ -7,7 +7,7 @@
 [\-C] [\-d domain] [\-K] [\-k keypath] [\-s selector] [\-t path]
 .SH DESCRIPTION
 .B opendkim-testmsg
-signs or verifies an input message.  This is similar to the test mode for 
+signs or verifies an input message.  This is similar to the test mode for
 .I opendkim(8)
 except that it does not use the same configuration system or milter interface.
 Rather, it is a direct access to the DKIM library with those functions

--- a/opendkim/opendkim.8.in
+++ b/opendkim/opendkim.8.in
@@ -35,7 +35,7 @@
 [\-X]
 .SH DESCRIPTION
 .B opendkim
-implements the 
+implements the
 .B DKIM
 standard for signing and verifying e-mail messages on a per-domain basis.
 
@@ -121,9 +121,7 @@ the name of the table, the name of the column to consider as the key, and the
 name(s) of the column(s) to be considered as the values (separated by
 commas).  For example (all in one line):
 
-mysql:://dbuser:dbpass@3306+dbhost/odkim/table=macros
-.br
-         ?keycol=host?datacol=v1,v2
+mysql:://dbuser:dbpass@3306+dbhost/odkim/table=macros?keycol=host?datacol=v1,v2
 
 defines a MySQL database listening at port 3306 on host "dbhost"; the userid
 "dbuser" and password "dbpass" should be used to access the database; the
@@ -131,8 +129,9 @@ database name is "odkim", and the data are in columns "host" (the keys)
 and "v1" and "v2" (the values) inside table "macros".  This example would
 thus return two values when a match is found.
 
-The key may also include a "filter" value which will be included in all generated
-SQL as an AND clause after the WHERE clause that declares the search criteria.
+The key may also include a "filter" value which will be included in all
+generated SQL as an AND clause after the WHERE clause that declares the
+search criteria.
 For example, given the above DSN specification with an additional "filter" value
 of "ID > 1000", the generated SQL for a query for "foo" would look like so:
 
@@ -209,9 +208,7 @@ is the name of the Erlang module where the function to be called resides,
 is the name of the Erlang function to be called. For example, (all in one
 line):
 
-erlang:mynode@myhost,myothernode@myotherhost:
-.br
-       chocolate:dkim:lookup
+erlang:mynode@myhost,myothernode@myotherhost:chocolate:dkim:lookup
 
 will join the distributed Erlang setup connecting to either "mynode@myhost"
 or "myothernode@myotherhost" (connections to nodes are tried in order) using
@@ -461,14 +458,15 @@ The default is to read a configuration file from
 if one exists, or otherwise to apply defaults to all values.
 .TP
 .I \-X
-Tolerates configuration file items that have been internally marked as "deprecated".
-Normally when a configuration file item is removed from the package, it is flagged
-in this way for at least one full release cycle.  The presence of a deprecated
-configuration file item typically causes the filter to return an error and refuse to
-start.  Setting this flag will allow the filter to start and a warning is logged.
-In some future release when the item is removed completely, a different error
-results, and it will not be possible to start the filter.  Use of this flag is
-NOT RECOMMENDED; it could effectively hide a major configuration change with serious
+Tolerates configuration file items that have been internally marked as
+"deprecated".  Normally when a configuration file item is removed from the
+package, it is flagged in this way for at least one full release cycle.
+The presence of a deprecated configuration file item typically causes the
+filter to return an error and refuse to start.  Setting this flag will
+allow the filter to start and a warning is logged.  In some future release
+when the item is removed completely, a different error results, and it will
+not be possible to start the filter.  Use of this flag is NOT RECOMMENDED;
+it could effectively hide a major configuration change with serious
 security implications.
 .SH OPERATION
 A message will be verified unless it conforms to the signing criteria,

--- a/opendkim/opendkim.conf.5.in
+++ b/opendkim/opendkim.conf.5.in
@@ -34,7 +34,7 @@ so the complete set of options is available here, and thus use of the
 configuration file is encouraged.  In some future release, the
 set of available command line options is likely to get trimmed.
 
-See the 
+See the
 .I opendkim(8)
 man page for details about how and when the configuration file contents
 are reloaded.
@@ -260,7 +260,7 @@ Specifies a set of domains, mail from which should be ignored entirely
 by the filter.  This is similar to the
 .I PeerList
 setting except that it bases its decision on the sender of the message
-as identified from the header fields or other message data, not the 
+as identified from the header fields or other message data, not the
 identity of the SMTP client sending the message.
 
 .TP
@@ -439,30 +439,30 @@ Names the authentication mechanism to use when connecting to an LDAP
 server.  The default is the empty string, meaning "simple" authentication
 should be done.
 
-.TP 
+.TP
 .I LDAPAuthName (string)
 Specifies the authenticating name to use when using SASL to authenticate to
 an LDAP server.  Requires SASL support be installed on the local system.
 There is no default.
 
-.TP 
+.TP
 .I LDAPAuthRealm (string)
 Specifies the authentication realm to use when using SASL to authenticate to
 an LDAP server.  Requires SASL support be installed on the local system.
 There is no default.
 
-.TP 
+.TP
 .I LDAPAuthUser (string)
 Specifies the authenticating user to use when using SASL to authenticate to an
 LDAP server.  Requires SASL support be installed on the local system.
 There is no default.
 
-.TP 
+.TP
 .I LDAPBindPassword (string)
 Specifies the password to use when conducting an LDAP "bind" operation.
 There is no default.
 
-.TP 
+.TP
 .I LDAPBindUser (string)
 Specifies the user ID to use when conducting an LDAP "bind" operation.
 There is no default.
@@ -492,7 +492,7 @@ the connection.  If not specified, the LDAP library default is used.
 Sets the time in seconds after which an LDAP operation should be abandoned.
 The default is 5.
 
-.TP 
+.TP
 .I LDAPUseTLS (Boolean)
 Indicates whether or not a TLS connection should be established when
 contacting an LDAP server.  The default is "False".
@@ -941,7 +941,7 @@ should be signed (if set) versus only verified mail being signed (if not set).
 Checks each message recipient against the specified dataset for a matching
 record.  The full address is checked in each case, then the hostname, then
 each domain preceded by ".".  If there is a match, the value returned is
-presumed to be the name of a key in the 
+presumed to be the name of a key in the
 .I KeyTable
 (if defined) to be used to re-sign the message in addition to verifying it.
 If there is a match without a
@@ -1051,9 +1051,10 @@ If not set, no expiration time is added to signatures.
 
 .TP
 .I SignHeaders (dataset)
-Specifies the comma-separated set of header fields that should be included when
-generating signatures.  If the list omits any header field that is mandated by the
-DKIM specification, those fields are implicitly added.  A set of header fields is
+Specifies the comma-separated set of header fields that should be included
+when generating signatures.  If the list omits any header field that is
+mandated by the DKIM specification, those fields are implicitly added.
+A set of header fields is
 listed in the DKIM specification as "Common examples" to be signed (RFC6376,
 Section 5.4.1); the default list for this parameter contains those fields (From,
 Reply-To, Subject, Date, To, Cc, Resent-Date, Resent-From, Resent-Sender,
@@ -1137,7 +1138,7 @@ listening on all interfaces.  A literal IP address must be enclosed in
 square brackets.  This option is mandatory either in the configuration file or
 on the command line.
 
-.TP 
+.TP
 .I SoftStart (Boolean)
 If set, the inability to connect and authenticate to an LDAP or SQL server will
 not prevent the filter from starting, and reconnections will be attempted for
@@ -1334,7 +1335,7 @@ prior to sending them.
 
 .TP
 .I VBR-TrustedCertifiers (string)
-A colon or comma sparated list of trusted certifiers to accept when 
+A colon or comma sparated list of trusted certifiers to accept when
 verifying VBR-Info header field.
 @VBR_MANNOTICE@
 
@@ -1369,9 +1370,9 @@ a reply from the filter, which in turn is still waiting for a DNS reply.
 
 Features that involve specification of IPv4 addresses or CIDR blocks
 will use the
-.I inet_addr(3) 
+.I inet_addr(3)
 function to parse that information.  Users should be familiar with the
-way that function handles the non-trivial cases (for example, "192.0.2/24"    
+way that function handles the non-trivial cases (for example, "192.0.2/24"
 and "192.0.2.0/24" are not the same thing).
 .SH FILES
 .TP

--- a/reprrd/opendkim-reprrdimport.8.in
+++ b/reprrd/opendkim-reprrdimport.8.in
@@ -10,7 +10,7 @@
 collates data accumulated by the OpenDKIM statistics feature and stores them
 into RRD tables for forecasting analysis.
 
-See 
+See
 .B rrdtool(1)
 for information about RRD tables.
 .SH OPTIONS
@@ -50,7 +50,7 @@ can also refer to a file from which domain names should be read.
 Prints a usage message and exits.
 .TP
 .I --interval=n
-Retrieves records for the previous 
+Retrieves records for the previous
 .I n
 days.  The default is 1.  A value of 0 retrieves data for all dates.
 .TP


### PR DESCRIPTION
## Summary

Cleans up all issues flagged by `mandoc -T lint` across the manpage source files (excluding the two universal patterns that affect every file by design: lowercase titles and the project name in the date slot of `.TH`).

- **opendkim.8.in**: Fix two instances where `.br` preceded a line with leading whitespace — mandoc silently skipped the macro, dropping the line break in rendered output. Fixed by joining each split example string onto a single line (both fit within 80 bytes). Also reflow several lines over 80 bytes.
- **opendkim-genzone.8.in**: Reflow one line over 80 bytes.
- **opendkim.conf.5.in**: Reflow two lines over 80 bytes.
- **Trailing whitespace**: Strip from `opendkim-atpszone.8.in`, `opendkim-lua.3.in`, `opendkim-spam.1.in`, `opendkim-testmsg.8.in`, `opendkim.8.in`, `opendkim.conf.5.in`, `opendkim-reprrdimport.8.in`.

## Test plan

- [ ] `mandoc -T lint` on all changed files produces no warnings (only the two known universal style notes)