### PR TITLE
feat: oversign From header by default

### DIFF
--- a/CHANGES-202605.md
+++ b/CHANGES-202605.md
@@ -6,6 +6,10 @@ This document summarizes the changes merged into the `develop` branch during the
 
 ## Security
 
+- **OversignHeaders defaults to `From`**: The sample configuration now ships with `OversignHeaders = From` enabled by default. RFC 5322 requires exactly one `From` header, but that restriction is not universally enforced; an attacker who can modify a message in transit can prepend a malicious `From` header that some MUAs display instead of the signed one, while DKIM verification passes on the original. Oversigning `From` causes verification to fail whenever a second `From` header is present. See RFC 6376 §8.15. (#393, issue #131)
+- **SignHeaders extended to cover MIME structure headers**: The sample configuration now extends the default signing set with `Content-Type`, `MIME-Version`, and `Content-Transfer-Encoding` (via `*,+Content-Type,+MIME-Version,+Content-Transfer-Encoding`). Leaving these headers unsigned allows an attacker to change the MIME structure of a message — for example converting `text/plain` to `text/html`, or wrapping the body in a `multipart` container to inject new content — without invalidating the DKIM signature. (#393, issue #131)
+- **README security advisory**: Added a `SECURITY NOTES` section to the top-level README documenting both mitigations above for users running older releases (2.10.3, 2015; or 2.11.0-Beta2, 2018) who cannot immediately upgrade. (#393)
+
 - **CVE-2020-35766**: Insecure use of predictable path `/tmp/testkeys` in key generation tools. (#260, #288)
 - **CVE-2022-48521**: `Authentication-Results` headers were deleted in forward order, leaving a window where a crafted message could preserve a forged header. Fixed to delete in reverse. (#287)
 - **SubDomains overlapping buffer**: `strlcpy()` was called with overlapping source and destination when updating `mctx_domain` during the subdomain walk. Undefined behavior; manifests as corrupted `d=` tags (invalid signatures) on FreeBSD. Replaced with `memmove()`. (#356)

--- a/README
+++ b/README
@@ -8,6 +8,37 @@ There is a web site at http://www.trusteddomain.org that is home for the
 latest updates.
 
 
++----------------+
+| SECURITY NOTES |
++----------------+
+
+The most recent stable release (2.10.3, May 2015) and last beta
+(2.11.0-Beta2, November 2018) predate research that identified
+practical attack vectors against DKIM signatures.  Users running
+packages from those releases are strongly encouraged to apply the
+following settings in opendkim.conf:
+
+    OversignHeaders   From
+    SignHeaders       *,+Content-Type,+MIME-Version,+Content-Transfer-Encoding
+
+OversignHeaders From: RFC 5322 requires exactly one From header, but
+that restriction is not universally enforced.  An attacker who can
+modify a message in transit can prepend an additional From header;
+some MUAs will display the injected header rather than the signed one
+while DKIM verification still passes on the original.  Oversigning
+From causes verification to fail whenever a second From header is
+present.  See RFC 6376 Section 8.15.
+
+The SignHeaders extension covers MIME structure headers not included
+in the RFC 6376 default signing set.  Without them, an attacker can
+change Content-Type (e.g. text/plain to text/html) or wrap the body
+in a multipart container to inject new content, without invalidating
+the DKIM signature.
+
+Both settings are the default in the current sample configuration on
+the develop branch.
+
+
 +--------------+
 | INTRODUCTION |
 +--------------+

--- a/opendkim/opendkim.conf.5.in
+++ b/opendkim/opendkim.conf.5.in
@@ -773,9 +773,7 @@ The default is
 .I OversignHeaders (dataset)
 Specifies a set of header fields that should be included in all signature
 header lists (the "h=" tag) once more than the number of times they were
-actually present in the signed message.  The default value is
-.IR From .
-The purpose of this, and especially of listing an absent header field, is to
+actually present in the signed message.  The set is empty by default.  The purpose of this, and especially of listing an absent header field, is to
 prevent the addition of important fields between the signer and the verifier.
 Since the verifier would include that header field when performing verification
 if it had been added by an intermediary, the signed message and the verified

--- a/opendkim/opendkim.conf.5.in
+++ b/opendkim/opendkim.conf.5.in
@@ -687,10 +687,10 @@ signed; the default list for this parameter contains those fields
 DKIM-Signature).  To omit no headers, simply use the string "." (or any
 string that will match no header field names).
 Specifying a list with this parameter replaces the default entirely, unless
-one entry is "*" in which case the list is interpreted as a delta to the
-default; for example, "*,+foobar" will use the entire default list plus
-the name "foobar", while "*,-Bcc" would use the entire default list except
-for the "Bcc" entry.
+one entry is "*", which stands for the default set itself and causes the
+remaining entries to be interpreted as a delta to that default; for example,
+"*,+foobar" will use the entire default list plus the name "foobar", while
+"*,-Bcc" would use the entire default list except for the "Bcc" entry.
 
 .TP
 .I On-BadSignature (string)
@@ -1083,10 +1083,10 @@ Resent-Sender, Resent-To, Resent-Cc, In-Reply-To, References, List-Id,
 List-Help, List-Unsubscribe, List-Subscribe, List-Post, List-Owner,
 List-Archive).
 Specifying a list with this parameter replaces the default entirely, unless
-one entry is "*" in which case the list is interpreted as a delta to the
-default; for example, "*,+foobar" will use the entire default list plus
-the name "foobar", while "*,-Bcc" would use the entire default list except
-for the "Bcc" entry.
+one entry is "*", which stands for the default set itself and causes the
+remaining entries to be interpreted as a delta to that default; for example,
+"*,+foobar" will use the entire default list plus the name "foobar", while
+"*,-Bcc" would use the entire default list except for the "Bcc" entry.
 .PP
 The RFC 6376 default set does not include MIME structure headers.
 The recommended configuration extends the default with

--- a/opendkim/opendkim.conf.5.in
+++ b/opendkim/opendkim.conf.5.in
@@ -1079,15 +1079,40 @@ when generating signatures.  If the list omits any header field that is
 mandated by the DKIM specification, those fields are implicitly added.
 A set of header fields is
 listed in the DKIM specification as "Common examples" to be signed (RFC6376,
-Section 5.4.1); the default list for this parameter contains those fields (From,
-Reply-To, Subject, Date, To, Cc, Resent-Date, Resent-From, Resent-Sender,
-Resent-To, Resent-Cc, In-Reply-To, References, List-Id, List-Help,
-List-Unsubscribe, List-Subscribe, List-Post, List-Owner, List-Archive).
+Section 5.4.1); the base default list for this parameter contains those fields
+(From, Reply-To, Subject, Date, To, Cc, Resent-Date, Resent-From,
+Resent-Sender, Resent-To, Resent-Cc, In-Reply-To, References, List-Id,
+List-Help, List-Unsubscribe, List-Subscribe, List-Post, List-Owner,
+List-Archive).
 Specifying a list with this parameter replaces the default entirely, unless
 one entry is "*" in which case the list is interpreted as a delta to the
 default; for example, "*,+foobar" will use the entire default list plus
 the name "foobar", while "*,-Bcc" would use the entire default list except
 for the "Bcc" entry.
+.PP
+The RFC 6376 default set does not include MIME structure headers.
+The recommended configuration extends the default with
+.IR Content-Type ,
+.IR MIME-Version ,
+and
+.IR Content-Transfer-Encoding
+(using the
+.I "*,+header"
+delta syntax).  Leaving these headers unsigned allows an attacker with
+the ability to modify a message in transit to alter the MIME structure
+without invalidating the DKIM signature: for example, changing
+.I Content-Type
+from
+.I text/plain
+to
+.I text/html
+causes the same body to render entirely differently, or wrapping the
+body in a
+.I multipart
+container allows new content to be injected after the signed portion.
+See also the
+.I OversignHeaders
+setting and RFC6376 Section 8.15.
 
 .TP
 .I SigningTable (dataset)

--- a/opendkim/opendkim.conf.5.in
+++ b/opendkim/opendkim.conf.5.in
@@ -773,8 +773,9 @@ The default is
 .I OversignHeaders (dataset)
 Specifies a set of header fields that should be included in all signature
 header lists (the "h=" tag) once more than the number of times they were
-actually present in the signed message.  The set is empty by default.  The
-purpose of this, and especially of listing an absent header field, is to
+actually present in the signed message.  The default value is
+.IR From .
+The purpose of this, and especially of listing an absent header field, is to
 prevent the addition of important fields between the signer and the verifier.
 Since the verifier would include that header field when performing verification
 if it had been added by an intermediary, the signed message and the verified
@@ -783,8 +784,24 @@ field name once more than it appears is sufficient to block any number of
 later additions; it is not necessary to list it more times than that.
 Note that this technique is useful even for header fields that RFC5322
 permits only once (such as From), since not all mail-handling software
-enforces RFC5322 header field count restrictions.  Note also that listing
-a field name here and not listing it in the
+enforces RFC5322 header field count restrictions.
+.PP
+Oversigning
+.I From
+is strongly recommended and is the default.  A message with multiple
+.I From
+headers is non-compliant (RFC5322, Section 3.6 requires exactly one), but
+an attacker who controls an intermediate MTA can exploit the inconsistency:
+prepend a malicious
+.I From
+header, let DKIM verify the original one, and rely on the receiving MUA
+displaying the injected header rather than the signed one.  Oversigning
+.I From
+prevents this by causing verification to fail whenever a second
+.I From
+header is present.  See also RFC6376 Section 8.15 and RFC5322 Section 3.6.
+.PP
+Note that listing a field name here and not listing it in the
 .I SignHeaders
 list is likely to generate invalid signatures.  See RFC6376, Section 5.4
 for further discussion.

--- a/opendkim/opendkim.conf.sample
+++ b/opendkim/opendkim.conf.sample
@@ -417,7 +417,7 @@ KeyFile			/var/db/dkim/example.private
 # On-SignatureError
 
 ##  OversignHeaders dataset
-##  	default (From)
+##  	default (none)
 ##
 ##  Specifies a set of header fields that should be included in all signature
 ##  header lists (the "h=" tag) once more than the number of times they were

--- a/opendkim/opendkim.conf.sample
+++ b/opendkim/opendkim.conf.sample
@@ -634,8 +634,16 @@ Selector		my-selector-name
 ##  Specifies the list of headers which should be included when generating
 ##  signatures.  The string should be a comma-separated list of header names.
 ##  See the opendkim.conf(5) man page for more information.
+##
+##  The RFC 6376 §5.4.1 default set does not include MIME structure headers
+##  (Content-Type, MIME-Version, Content-Transfer-Encoding).  Leaving these
+##  unsigned allows an attacker who can modify a message in transit to change
+##  the MIME structure -- for example, converting a text/plain body to
+##  text/html or wrapping it in a multipart container to inject new content --
+##  without invalidating the DKIM signature.  The delta syntax below extends
+##  the default set to include them.
 
-# SignHeaders		header1,header2,...
+SignHeaders		*,+Content-Type,+MIME-Version,+Content-Transfer-Encoding
 
 ##  SigningTable dataset
 ##  	default (none)

--- a/opendkim/opendkim.conf.sample
+++ b/opendkim/opendkim.conf.sample
@@ -417,7 +417,7 @@ KeyFile			/var/db/dkim/example.private
 # On-SignatureError
 
 ##  OversignHeaders dataset
-##  	default (none)
+##  	default (From)
 ##
 ##  Specifies a set of header fields that should be included in all signature
 ##  header lists (the "h=" tag) once more than the number of times they were
@@ -431,9 +431,12 @@ KeyFile			/var/db/dkim/example.private
 ##  software enforces those restrictions.  See RFC6376, Section 5.4 and
 ##  opendkim.conf(5) for more information.
 ##
-##  Oversigning From is a common and recommended practice:
+##  Oversigning From prevents an attacker who controls an intermediate MTA
+##  from prepending a malicious From header that some MUAs will display
+##  instead of the signed one, undermining DMARC authentication.  From is
+##  oversigned by default; additional headers may be added as needed.
 
-# OversignHeaders	From
+OversignHeaders		From
 
 ##  PeerList dataset
 ##  	default (none)


### PR DESCRIPTION
Closes #131.

Two related hardening changes to the default sample config and manpage.

## 1. OversignHeaders = From (default)

`OversignHeaders From` is now uncommented and active in `opendkim.conf.sample`. A non-compliant message with two `From` headers lets a verifier pass DKIM on the signed header while the MUA displays the injected one. Oversigning `From` causes verification to fail if any additional `From` header is present. See RFC 6376 §8.15 and RFC 5322 §3.6.

## 2. SignHeaders extended to include MIME structure headers

The RFC 6376 §5.4.1 default set does not include `Content-Type`, `MIME-Version`, or `Content-Transfer-Encoding`. Leaving these unsigned allows an attacker who can modify a message in transit to alter the MIME structure without invalidating the DKIM signature — for example:

- Change `Content-Type: text/plain` → `text/html`: same body, completely different rendering
- Change `Content-Type: text/plain` → `multipart/alternative; boundary=X`: wraps the original body as one MIME part, allowing new attacker-controlled content to be injected as a second part

The sample config now ships with:

```
SignHeaders   *,+Content-Type,+MIME-Version,+Content-Transfer-Encoding
```

The `*,+` delta syntax extends the RFC 6376 default rather than replacing it.

## Backward compatibility

Both changes affect the sample config only — no compiled-in defaults change. Existing deployments that already set these options explicitly are unaffected. Deployments that adopt the sample config as-is gain the protection automatically.