### PR TITLE
feat: warn on RSA signing keys shorter than 2048 bits (fixes #394)

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -257,6 +257,7 @@ struct dkimf_config
 	_Bool		conf_noheaderb;		/* suppress "header.b" */
 	_Bool		conf_singleauthres;	/* single Auth-Results */
 	_Bool		conf_safekeys;		/* check key permissions */
+	_Bool		conf_weakkey_warned;	/* already warned about weak key */
 	_Bool		conf_checksigningtable; /* check keys on dkimf_config_load */
 #ifdef _FFR_RESIGN
 	_Bool		conf_resignall;		/* resign unverified mail */
@@ -5026,6 +5027,73 @@ dkimf_add_signrequest(struct msgctx *dfc, DKIMF_DB keytable, char *keyname,
 			return 2;
 		}
 
+		if (!curconf->conf_weakkey_warned)
+		{
+#ifdef USE_GNUTLS
+			gnutls_privkey_t pk;
+
+			if (gnutls_privkey_init(&pk) == GNUTLS_E_SUCCESS)
+			{
+				gnutls_datum_t d;
+				unsigned int bits = 0;
+
+				d.data = (unsigned char *) dbd[2].dbdata_buffer;
+				d.size = keydatasz;
+
+				if (gnutls_privkey_import_x509_raw(pk, &d,
+				    GNUTLS_X509_FMT_PEM, NULL,
+				    0) == GNUTLS_E_SUCCESS &&
+				    gnutls_privkey_get_pk_algorithm(pk,
+				    &bits) == GNUTLS_PK_RSA &&
+				    bits < 2048)
+				{
+					dkimf_log(curconf, LOG_WARNING,
+					          "%s: %u-bit RSA signing key"
+					          " is below the 2048-bit"
+					          " minimum recommended by"
+					          " RFC 8301; major mail"
+					          " providers may reject"
+					          " signatures",
+					          keyname, bits);
+					curconf->conf_weakkey_warned = TRUE;
+				}
+
+				gnutls_privkey_deinit(pk);
+			}
+#else /* USE_GNUTLS */
+			BIO *keybio;
+			EVP_PKEY *pkey = NULL;
+
+			keybio = BIO_new_mem_buf(dbd[2].dbdata_buffer,
+			                         keydatasz);
+			if (keybio != NULL)
+			{
+				pkey = PEM_read_bio_PrivateKey(keybio, NULL,
+				                               NULL, NULL);
+				BIO_free(keybio);
+			}
+
+			if (pkey != NULL)
+			{
+				if (EVP_PKEY_base_id(pkey) == EVP_PKEY_RSA &&
+				    EVP_PKEY_bits(pkey) < 2048)
+				{
+					dkimf_log(curconf, LOG_WARNING,
+					          "%s: %d-bit RSA signing key"
+					          " is below the 2048-bit"
+					          " minimum recommended by"
+					          " RFC 8301; major mail"
+					          " providers may reject"
+					          " signatures",
+					          keyname,
+					          EVP_PKEY_bits(pkey));
+					curconf->conf_weakkey_warned = TRUE;
+				}
+				EVP_PKEY_free(pkey);
+			}
+#endif /* USE_GNUTLS */
+		}
+
 		if (insecure)
 		{
 			if (dolog)
@@ -8345,10 +8413,29 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 				if (gnutls_privkey_import_x509_raw(pk, &d,
 				    GNUTLS_X509_FMT_PEM, NULL, 0) == GNUTLS_E_SUCCESS)
 				{
-					if (gnutls_privkey_get_pk_algorithm(pk,
-					    &bits) == GNUTLS_PK_EDDSA_ED25519)
+					int algo;
+
+					algo = gnutls_privkey_get_pk_algorithm(
+					           pk, &bits);
+					if (algo == GNUTLS_PK_EDDSA_ED25519)
 						conf->conf_signalg =
 						    DKIM_SIGN_ED25519SHA256;
+					else if (algo == GNUTLS_PK_RSA &&
+					         bits < 2048 &&
+					         !conf->conf_weakkey_warned)
+					{
+						dkimf_log(conf, LOG_WARNING,
+						          "%s: %u-bit RSA signing"
+						          " key is below the"
+						          " 2048-bit minimum"
+						          " recommended by"
+						          " RFC 8301; major mail"
+						          " providers may reject"
+						          " signatures",
+						          conf->conf_keyfile,
+						          bits);
+						conf->conf_weakkey_warned = TRUE;
+					}
 				}
 
 				gnutls_privkey_deinit(pk);
@@ -8370,6 +8457,21 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 				if (EVP_PKEY_base_id(pkey) == EVP_PKEY_ED25519)
 					conf->conf_signalg =
 					    DKIM_SIGN_ED25519SHA256;
+				else if (EVP_PKEY_base_id(pkey) == EVP_PKEY_RSA &&
+				         EVP_PKEY_bits(pkey) < 2048 &&
+				         !conf->conf_weakkey_warned)
+				{
+					dkimf_log(conf, LOG_WARNING,
+					          "%s: %d-bit RSA signing key"
+					          " is below the 2048-bit"
+					          " minimum recommended by"
+					          " RFC 8301; major mail"
+					          " providers may reject"
+					          " signatures",
+					          conf->conf_keyfile,
+					          EVP_PKEY_bits(pkey));
+					conf->conf_weakkey_warned = TRUE;
+				}
 				EVP_PKEY_free(pkey);
 			}
 #endif /* USE_GNUTLS */

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -5051,9 +5051,7 @@ dkimf_add_signrequest(struct msgctx *dfc, DKIMF_DB keytable, char *keyname,
 					          "%s: %u-bit RSA signing key"
 					          " is below the 2048-bit"
 					          " minimum recommended by"
-					          " RFC 8301; major mail"
-					          " providers may reject"
-					          " signatures",
+					          " RFC 8301",
 					          keyname, bits);
 					curconf->conf_weakkey_warned = TRUE;
 				}
@@ -5082,9 +5080,7 @@ dkimf_add_signrequest(struct msgctx *dfc, DKIMF_DB keytable, char *keyname,
 					          "%s: %d-bit RSA signing key"
 					          " is below the 2048-bit"
 					          " minimum recommended by"
-					          " RFC 8301; major mail"
-					          " providers may reject"
-					          " signatures",
+					          " RFC 8301",
 					          keyname,
 					          EVP_PKEY_bits(pkey));
 					curconf->conf_weakkey_warned = TRUE;
@@ -8429,9 +8425,7 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 						          " key is below the"
 						          " 2048-bit minimum"
 						          " recommended by"
-						          " RFC 8301; major mail"
-						          " providers may reject"
-						          " signatures",
+						          " RFC 8301",
 						          conf->conf_keyfile,
 						          bits);
 						conf->conf_weakkey_warned = TRUE;
@@ -8465,9 +8459,7 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 					          "%s: %d-bit RSA signing key"
 					          " is below the 2048-bit"
 					          " minimum recommended by"
-					          " RFC 8301; major mail"
-					          " providers may reject"
-					          " signatures",
+					          " RFC 8301",
 					          conf->conf_keyfile,
 					          EVP_PKEY_bits(pkey));
 					conf->conf_weakkey_warned = TRUE;


### PR DESCRIPTION
## Summary

Closes #394.

Logs a `LOG_WARNING` when opendkim loads an RSA signing key shorter than 2048 bits, citing RFC 8301's recommendation. A single flag on the config struct (`conf_weakkey_warned`) prevents repeat warnings after the first; the flag resets on config reload so a freshly-rotated key that is still too short will warn again.

- **KeyFile path**: check fires at startup / config reload, where the key is already parsed into an `EVP_PKEY` for algorithm auto-detection
- **KeyTable path**: check fires on first use of a weak key (keys load lazily per message)
- Covers both OpenSSL and GnuTLS build paths

## Test plan

- [ ] Generate a 1024-bit key (`openssl genrsa 1024`) and configure it as `KeyFile`; start opendkim with `Syslog yes` — confirm warning appears in syslog
- [ ] Replace with a 2048-bit key — confirm no warning
- [ ] Confirm warning appears only once per config load, not once per message (KeyTable case)