### PR TITLE
autotools: support @VARIABLE@ substitution from ./configure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,6 +39,39 @@ DISTCLEANFILES = opendkim-@VERSION@.tar.gz
 # though.
 DISTCHECK_CONFIGURE_FLAGS=--enable-vbr --with-lua --enable-stats --with-odbx --with-db --with-openssl=/usr/local --enable-atps --enable-replace_rules
 
+
+#
+# Handle scripts and configuration files that need @VARIABLE@
+# replacements here, so that we can share the rules (which are
+# identical) between all of the targets.
+#
+
+# We want to *build and install* these on the target machine.
+nodist_doc_DATA = opendkim/opendkim.conf.simple \
+                  opendkim/opendkim.conf.simple-verify
+
+# We want to *ship* these.
+EXTRA_DIST =  opendkim/opendkim.conf.simple.in \
+              opendkim/opendkim.conf.simple-verify.in
+
+# The next rule allow us to replace bindir, libdir, etc.  within
+# files. The example is taken from the autoconf documentation and can
+# be found in the "Installation Directory Variables" section.
+edit = sed -e 's|@DOMAIN[@]|$(DOMAIN)|g' \
+           -e 's|@RUNSTATEDIR[@]|$(runstatedir)|g'
+
+# This rule includes EVERY source/intermediate file as a dependency of
+# EVERY output file, which is clearly wrong, but it may be the best we
+# can do without duplication. At least it's the right kind of wrong,
+# and rebuilds too often rather than not often enough.
+$(nodist_doc_DATA): $(doc_DATA_intermediate) $(EXTRA_DIST) Makefile
+	rm -f $@ $@.tmp
+	srcdir=''; \
+	  test -f ./$@.in || srcdir=$(srcdir)/; \
+	  $(edit) $${srcdir}$@.in > $@.tmp
+	mv $@.tmp $@
+
+
 $(DIST_ARCHIVES): distcheck
 
 $(DIST_ARCHIVES).md5: $(DIST_ARCHIVES)

--- a/Makefile.am
+++ b/Makefile.am
@@ -58,6 +58,7 @@ EXTRA_DIST =  opendkim/opendkim.conf.simple.in \
 # files. The example is taken from the autoconf documentation and can
 # be found in the "Installation Directory Variables" section.
 edit = sed -e 's|@DOMAIN[@]|$(DOMAIN)|g' \
+           -e 's|@LOCALSTATEDIR[@]|$(localstatedir)|g' \
            -e 's|@RUNSTATEDIR[@]|$(runstatedir)|g'
 
 # This rule includes EVERY source/intermediate file as a dependency of

--- a/configure.ac
+++ b/configure.ac
@@ -2752,8 +2752,6 @@ AC_CONFIG_FILES([	Makefile
 			opendkim/opendkim-lua.3 
 			opendkim/opendkim-testkey.8 opendkim/opendkim-stats.8
 			opendkim/opendkim-testmsg.8 opendkim/opendkim.conf.5
-			opendkim/opendkim.conf.simple
-			opendkim/opendkim.conf.simple-verify
 			opendkim/opendkim-atpszone.8 opendkim/opendkim-spam.1
 		opendkim/tests/Makefile
 		stats/Makefile stats/opendkim-importstats.8

--- a/opendkim/Makefile.am
+++ b/opendkim/Makefile.am
@@ -17,8 +17,7 @@ sbin_PROGRAMS += opendkim-stats
 endif
 
 dist_sbin_SCRIPTS = opendkim-genkey
-dist_doc_DATA = opendkim.conf.sample opendkim.conf.simple \
-	opendkim.conf.simple-verify README.SQL
+dist_doc_DATA = opendkim.conf.sample README.SQL
 
 if BUILD_FILTER
 sbin_PROGRAMS += opendkim

--- a/opendkim/opendkim.conf.simple-verify.in
+++ b/opendkim/opendkim.conf.simple-verify.in
@@ -17,5 +17,5 @@ Mode			v
 
 # ADSPDiscard	no
 
-# PidFile		/var/run/opendkim/opendkim.pid
+# PidFile		@RUNSTATEDIR@/opendkim.pid
 

--- a/opendkim/opendkim.conf.simple.in
+++ b/opendkim/opendkim.conf.simple.in
@@ -8,7 +8,7 @@ Canonicalization	relaxed/simple
 
 Domain			@DOMAIN@
 Selector		default
-KeyFile			/var/db/dkim/@DOMAIN@.private
+KeyFile			@LOCALSTATEDIR@/dkim/@DOMAIN@.private
 
 Socket                  inet:8891@localhost
 

--- a/opendkim/opendkim.conf.simple.in
+++ b/opendkim/opendkim.conf.simple.in
@@ -12,6 +12,10 @@ KeyFile			/var/db/dkim/@DOMAIN@.private
 
 Socket                  inet:8891@localhost
 
+# To use a local socket instead, specify a path. The default path
+# (that the included service scripts use) is below.
+#Socket                 local:@RUNSTATEDIR@/opendkim/opendkim.sock
+
 ReportAddress           postmaster@@DOMAIN@
 SendReports             yes
 

--- a/opendkim/opendkim.conf.simple.in
+++ b/opendkim/opendkim.conf.simple.in
@@ -29,4 +29,4 @@ SendReports             yes
 #
 # PeerList		X.X.X.X
 
-# PidFile		/var/run/opendkim/opendkim.pid
+# PidFile		@RUNSTATEDIR@/opendkim.pid


### PR DESCRIPTION
I am resurrecting https://github.com/trusteddomainproject/OpenDKIM/pull/41 but will try to do it in a way that is not overwhelming. Ultimately the goal is to add a service script, and that script needs to be aware of opendkim's paths (where opendkim is installed, where its socket lives, where the PID file goes, et cetera).

As a prerequisite, we need to be able to substitute the value of `./configure --bindir` and other such flags into the source tree. Here I've chosen to do `--localstatedir`, `--with-domain`, and `--runstatedir`, the latter requiring autoconf >= 2.70. These we substitute into the sample configs, so that the samples more closely match reality. In one instance, this helps avoid a minor security issue, since the PID file should not be in the same (presumably writable) directory as the socket.

It's in one of the commit messages, but the reason for the sed charade is that `$bindir` and friends still have a level of indirection baked into them and therefore aren't suitable for direct substitution.
