### PR TITLE
chore: restore AC_PREREQ to 2.71 and document autoconf 2.72 release requirement

### DIFF
--- a/HowToRelease
+++ b/HowToRelease
@@ -11,6 +11,12 @@ Release procedures for OpenDKIM
 
 3) In the root build directory, build and test the release tarball:
 
+   autoconf 2.72 or later is required to generate a correct ./configure
+   script for projects built with GCC 15+ (which defaults to C23).  Earlier
+   versions silently produce false negatives in feature tests.  Verify with:
+
+	% autoconf --version
+
 	% make distclean
 	% autoreconf -fvi
 	% ./configure

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@
 #
 # Setup
 #
-AC_PREREQ([2.69])
+AC_PREREQ([2.71])
 
 #
 # Package version


### PR DESCRIPTION
## Summary

Reverts e0d1beec (merged without a backing issue) which downgraded `AC_PREREQ` from 2.71 to 2.69.

- `AC_PREREQ` restored to 2.71 — the floor for all current supported developer platforms (Debian 12, Ubuntu 22.04 LTS, RHEL/AlmaLinux 9)
- `HowToRelease` updated to document that autoconf 2.72+ is required at release time, since pre-2.72 versions silently produce false-negative feature tests when building with GCC 15/16 (which default to C23)

The 2.72 requirement is enforced via documentation and CI rather than `AC_PREREQ`, since 2.72 is not yet available on several current actively-supported platforms.

Discussed in #396.