### PR TITLE
docs: clarify OversignHeaders/SignHeaders interaction and add startup warnings

### DIFF
--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -8994,6 +8994,76 @@ dkimf_config_setlib(struct dkimf_config *conf, char **err)
 		}
 	}
 
+	if (conf->conf_oversignhdrs != NULL)
+	{
+		int n;
+		int m;
+		_Bool found;
+		char **effective;
+
+		effective = (conf->conf_signhdrs != NULL)
+		            ? conf->conf_signhdrs
+		            : (char **) dkim_should_signhdrs;
+
+		for (n = 0; conf->conf_oversignhdrs[n] != NULL; n++)
+		{
+			if (conf->conf_oversignhdrs[n][0] == '\0')
+				continue;
+
+			found = FALSE;
+			for (m = 0; effective[m] != NULL; m++)
+			{
+				if (strcasecmp(conf->conf_oversignhdrs[n],
+				               effective[m]) == 0)
+				{
+					found = TRUE;
+					break;
+				}
+			}
+
+			if (!found)
+			{
+				dkimf_log(conf, LOG_WARNING,
+				          "OversignHeaders entry '%s' is not in the signing set; "
+				          "oversigning will have no effect for this header",
+				          conf->conf_oversignhdrs[n]);
+			}
+		}
+	}
+
+	{
+		int n;
+		int m;
+		char **effsign;
+		char **effomit;
+
+		effsign = (conf->conf_signhdrs != NULL)
+		          ? conf->conf_signhdrs
+		          : (char **) dkim_should_signhdrs;
+
+		effomit = (conf->conf_omithdrs != NULL)
+		          ? conf->conf_omithdrs
+		          : (char **) dkim_should_not_signhdrs;
+
+		for (n = 0; effsign[n] != NULL; n++)
+		{
+			if (effsign[n][0] == '\0')
+				continue;
+
+			for (m = 0; effomit[m] != NULL; m++)
+			{
+				if (strcasecmp(effsign[n], effomit[m]) == 0)
+				{
+					dkimf_log(conf, LOG_WARNING,
+					          "header '%s' appears in both SignHeaders and OmitHeaders; "
+					          "it will not be signed",
+					          effsign[n]);
+					break;
+				}
+			}
+		}
+	}
+
 	status = dkim_options(conf->conf_libopendkim, DKIM_OP_SETOPT,
 	                      DKIM_OPTS_TMPDIR,
 	                      (void *) conf->conf_tmpdir,

--- a/opendkim/opendkim.conf.5.in
+++ b/opendkim/opendkim.conf.5.in
@@ -691,6 +691,13 @@ one entry is "*", which stands for the default set itself and causes the
 remaining entries to be interpreted as a delta to that default; for example,
 "*,+foobar" will use the entire default list plus the name "foobar", while
 "*,-Bcc" would use the entire default list except for the "Bcc" entry.
+.PP
+Note that none of the headers in the default OmitHeaders list appear in the
+default
+.I SignHeaders
+list either.  This setting acts as a safety override: it prevents headers
+from being signed even if they are explicitly added to
+.IR SignHeaders .
 
 .TP
 .I On-BadSignature (string)
@@ -719,6 +726,16 @@ action.
 Selects the action to be taken when any verification or internal error of
 any kind is encountered.  This is processed before the other "On-" values
 so it can be used as a blanket setting followed by specific overrides.
+Possible values are the same as those for
+.IR On-BadSignature .
+.PP
+Use with caution in production: setting this to
+.I accept
+will cause the filter to pass messages through regardless of any verification
+error condition.  It is most useful during initial deployment or
+troubleshooting, combined with specific
+.I On-
+overrides for conditions you want to enforce.
 
 .TP
 .I On-DNSError (string)
@@ -773,7 +790,8 @@ The default is
 .I OversignHeaders (dataset)
 Specifies a set of header fields that should be included in all signature
 header lists (the "h=" tag) once more than the number of times they were
-actually present in the signed message.  The set is empty by default.  The purpose of this, and especially of listing an absent header field, is to
+actually present in the signed message.  The set is empty by default.  
+The purpose of this, and especially of listing an absent header field, is to
 prevent the addition of important fields between the signer and the verifier.
 Since the verifier would include that header field when performing verification
 if it had been added by an intermediary, the signed message and the verified
@@ -799,10 +817,31 @@ prevents this by causing verification to fail whenever a second
 .I From
 header is present.  See also RFC6376 Section 8.15 and RFC5322 Section 3.6.
 .PP
-Note that listing a field name here and not listing it in the
+The oversigning mechanism works by appending each listed field name an extra
+time to the signature's
+.I h=
+tag.  For this to provide any protection, the field must also be present in
+the set of headers actually being signed (via
 .I SignHeaders
-list is likely to generate invalid signatures.  See RFC6376, Section 5.4
-for further discussion.
+or the compiled-in default set).  If a field name appears here but not in
+the signing set, it will appear only once in
+.I h=
+as a phantom empty-header entry.  The resulting signature is technically
+valid, but the oversigning protection is silently absent: a verifier will
+accept a message that has had that header injected downstream.  Any field
+listed here must therefore also appear in
+.I SignHeaders
+(or be covered by the
+.I *
+default expansion).  See RFC6376, Section 5.4 for further discussion.
+.PP
+Unlike
+.I SignHeaders
+and
+.IR OmitHeaders ,
+this parameter does not support the
+.I *,+,-
+delta syntax, as there is no default set to expand.
 
 .TP
 .I PeerList (dataset)
@@ -1111,6 +1150,18 @@ container allows new content to be injected after the signed portion.
 See also the
 .I OversignHeaders
 setting and RFC6376 Section 8.15.
+.PP
+If you specify an explicit header list without
+.IR * ,
+be careful not to omit any field that is also listed in
+.IR OversignHeaders .
+Doing so removes it from the signing set, which silently disables the
+oversigning protection for that field: the signature will still verify, but
+a downstream injected copy of that header will no longer cause verification
+to fail.  Using the
+.I *
+delta syntax is the safest way to extend the default set without
+inadvertently dropping fields required by other settings.
 
 .TP
 .I SigningTable (dataset)

--- a/opendkim/opendkim.conf.sample
+++ b/opendkim/opendkim.conf.sample
@@ -1,4 +1,3 @@
-##
 ## opendkim.conf -- configuration file for OpenDKIM filter
 ##
 ## Copyright (c) 2010-2015, 2018, The Trusted Domain Project.
@@ -395,29 +394,53 @@ KeyFile			/var/db/dkim/example.private
 # NoHeaderB		no
 
 ##  OmitHeaders dataset
-##  	default (none)
+##  	default Return-Path, Received, Comments, Keywords, Bcc, Resent-Bcc, DKIM-Signature
+##
+##  NOTE: This option DOES support the *,+,- delta syntax
 ##
 ##  Specifies a list of headers that should always be omitted when signing.
 ##  Header names should be separated by commas.
+##  
+##  This can be either a static list, or a list starting with * (representing the default),
+##  then modified by adding and removing items with + and -.
+##  
+##  Note that none of the default items in this list are in the default SignHeaders list
+##  This really serves as an extra override (and as a complement to the list of excluded
+##  headers in RFC 6376 section 5.4.1)
 
 # OmitHeaders		header1,header2,...
 
 ##  On-...
 ##
-##  Specifies what to do when certain error conditions are encountered.
+##  Specifies possible overrides for the action taken when various signing and
+##  verification conditions are encountered.  Possible values are:
+##  accept, discard, quarantine, reject, tempfail
 ##
-##  See opendkim.conf(5) for more information.
-
-# On-Default
-# On-BadSignature
-# On-DNSError
-# On-InternalError
-# On-NoSignature
-# On-Security
-# On-SignatureError
+##  These settings are primarily useful during testing, initial deployment,
+##  or troubleshooting.  Changing them in production can silently disable
+##  enforcement; in particular, On-Default accept will cause the filter to
+##  pass messages through regardless of verification errors.
+##
+##  See opendkim.conf(5) for more information and definitions of each condition.
+##
+##  The following example rejects messages with bad signatures, accepts
+##  unsigned messages, and temp-fails on DNS errors.  Note that the code
+##  default for On-BadSignature is "accept"; this example is intentionally
+##  more aggressive:
+##
+# On-Default        accept
+# On-BadSignature   reject
+# On-DNSError       tempfail
+# On-NoSignature    accept
+# On-InternalError  tempfail
+# On-Security       tempfail
+# On-SignatureError reject
 
 ##  OversignHeaders dataset
 ##  	default (none)
+## 
+##  NOTE: Unlike Signheaders and OmitHeaders, this field does NOT support the
+##  *,+,- notation to modify the default set, because there is no default.
 ##
 ##  Specifies a set of header fields that should be included in all signature
 ##  header lists (the "h=" tag) once more than the number of times they were
@@ -435,6 +458,21 @@ KeyFile			/var/db/dkim/example.private
 ##  from prepending a malicious From header that some MUAs will display
 ##  instead of the signed one, undermining DMARC authentication.  From is
 ##  oversigned by default; additional headers may be added as needed.
+##
+##  IMPORTANT: every header listed here must also appear in the set of headers
+##  being signed (see SignHeaders below).  If a header is in OversignHeaders
+##  but not in the signing set, the signature will still verify, but the
+##  oversigning protection will be silently absent.  The SignHeaders line
+##  (later in this file) uses "*" which expands to the RFC 6376 default set; 
+##  that set includes From, so the default OversignHeaders value is safe as written.
+##  If you replace Signheaders "*" with an explicit list, ensure any OversignHeaders
+##  entries are included in that list as well.
+##  
+##  In Short:
+## 
+##  SignHeaders means "Sign these, if present"
+##  OversignHeaders means "Add an extra h= line for these, even if *not* present"
+## 
 
 OversignHeaders		From
 
@@ -496,6 +534,7 @@ OversignHeaders		From
 ##  	default "no"
 ##
 ##  Remove all Authentication-Results: headers on all arriving mail.
+##  This may make it more difficult to diagnose a signing breakage.
 
 # RemoveARAll		No
 
@@ -629,19 +668,42 @@ Selector		my-selector-name
 # SignatureTTL		0
 
 ##  SignHeaders dataset
-##  	default (none)
-##
+##  	default (see "recommended" list below)
+## 
+##  NOTE: This field supports the special *,+,- notation,
+##  
 ##  Specifies the list of headers which should be included when generating
 ##  signatures.  The string should be a comma-separated list of header names.
 ##  See the opendkim.conf(5) man page for more information.
 ##
-##  The RFC 6376 §5.4.1 default set does not include MIME structure headers
+##  RFC 6376 does not specify headers which SHOULD be signed 
+##  (using the special RFC2119 meaning of the word SHOULD)
+##  meaning of the word, other than requiring the From: header.
+##  
+##  However, section 5.4.1 of RFC 6376 calls out a list of "Recommended" headers
+##  which are split out in the RFC by context, as bullet points (such as putting
+##  all the list-* headers together).
+##
+##  OpenDKIM signs all headers in that list, if they are present in the message.
+##
+##  That list is:
+##
+##  From, Reply-To, Subject, Date, To, Cc, Resent-Date, Resent-From, Resent-To, 
+##  Resent-Cc, In-Reply-To, References,List-Id, List-Help, List-Unsubscribe, 
+##  List-Subscribe, List-Post, List-Owner, List-Archive
+## 
+##  The recommended set does not include MIME structure headers such as:
 ##  (Content-Type, MIME-Version, Content-Transfer-Encoding).  Leaving these
 ##  unsigned allows an attacker who can modify a message in transit to change
 ##  the MIME structure -- for example, converting a text/plain body to
 ##  text/html or wrapping it in a multipart container to inject new content --
 ##  without invalidating the DKIM signature.  The delta syntax below extends
 ##  the default set to include them.
+##
+##  The "*" expands to the RFC 6376 section 5.4.1 recommended set, as listed above.
+##  If you replace "*" with a fully explicit list, ensure that any headers
+##  listed in OversignHeaders are also present -- omitting them silently
+##  disables their oversigning protection without any error.
 
 SignHeaders		*,+Content-Type,+MIME-Version,+Content-Transfer-Encoding
 


### PR DESCRIPTION
## Summary

- Documents that `OversignHeaders` entries must also appear in `SignHeaders` (or the default signing set) to provide any protection; a header in `OversignHeaders` but not in the signing set produces a valid signature but silently absent oversigning protection
- Documents that `OversignHeaders` does not support the `*,+,-` delta syntax (unlike `SignHeaders` and `OmitHeaders`)
- Corrects `OmitHeaders` documentation: the default list is not "none", and clarifies it acts as a safety override
- Documents `On-Default` more fully: valid values, production warning, and example configurations
- Adds startup warning when an `OversignHeaders` entry is not covered by the effective signing set
- Adds startup warning when a header appears in both `SignHeaders` and `OmitHeaders` (`OmitHeaders` wins, but silently)
- Fleshes out `opendkim.conf.sample` with clearer defaults, examples, and explanations of the `*,+,-` delta syntax

## Background

Prompted by issue #131, which exposed that users naturally assume `OversignHeaders` supports the same `*,+,-` notation as `SignHeaders` and `OmitHeaders`. The deeper problem is that misconfiguring `OversignHeaders` without a matching `SignHeaders` entry produces no error and no visible sign of failure — the signature verifies, but the oversigning protection is silently absent.

## Test plan

- [ ] Verify startup warnings fire when `OversignHeaders` contains a header not in the signing set
- [ ] Verify startup warnings fire when a header appears in both `SignHeaders` and `OmitHeaders`
- [ ] Verify no warnings fire with the default configuration
- [ ] Review man page and sample config for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)