### PR TITLE
libopendkim/docs/Makefile.am: dist_doc_DATA -> dist_html_DATA

### DIFF
--- a/libopendkim/docs/Makefile.am
+++ b/libopendkim/docs/Makefile.am
@@ -1,7 +1,7 @@
 
 #AUTOMAKE_OPTIONS = foreign
 
-dist_doc_DATA = dkim.html \
+dist_html_DATA = dkim.html \
 	dkim_add_querymethod.html \
 	dkim_add_xtag.html \
 	dkim_alg_t.html \


### PR DESCRIPTION
The names "doc" and "html" are somewhat special in that they correspond to the `--docdir` and `--htmldir` ./configure flags:

```
  --docdir=DIR            documentation root [DATAROOTDIR/doc/opendkim]
  --htmldir=DIR           html documentation [DOCDIR]
```

All of the documentation in libopendkim/docs is HTML, so we update the name of the automake variable to install it to the `--htmldir`. As the default `--htmldir` is the value of `--docdir`, this is backwards-compatible.