### PR TITLE
libopendkim/dkim.c: fix potential out-of-bounds write

### DIFF
--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -7394,11 +7394,11 @@ dkim_getsighdr_d(DKIM *dkim, size_t initial, u_char **buf, size_t *buflen)
 		     pv != NULL;
 		     pv = strtok_r(NULL, DELIMITER, &ctx))
 		{
-			for (p = pv, q = which; *p != '=' && q <= end; p++, q++)
+			for (p = pv, q = which; *p != '=' && q < end; p++, q++)
 			{
 				*q = *p;
-				*(q + 1) = '\0';
 			}
+			*q = '\0';
 
 			whichlen = strlen(which);
 


### PR DESCRIPTION
In `dkim_getsighdr_d()`, we have

```C
char which[MAXTAGNAME + 1];
end = which + MAXTAGNAME;
```

and then

```C
for (p = pv, q = which; *p != '=' && q <= end; p++, q++) {
  *q = *p;
  *(q + 1) = '\0';
}
```

If p is never '=', we may wind up with `q == end`. In that case,

```C
*(q + 1) = *(which + MAXTAGNAME + 1)
```

is the desugaring of `which[MAXTAGNAME + 1]`. This, of course, is the nonexistent `MAXTAGNAME + 2`nd element of "which". To fix it, we change the non-strict comparison of `q <= end` to a strict one.

This eliminates a GCC warning,

```
In function 'dkim_getsighdr_d',
    inlined from 'dkim_getsighdr_d' at dkim.c:7300:1:
dkim.c:7400:42: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 7400 |                                 *(q + 1) = '\0';
      |                                          ^
dkim.c: In function 'dkim_getsighdr_d':
dkim.c:7387:22: note: at offset 9 into destination object 'which' of size 9
 7387 |                 char which[MAXTAGNAME + 1];
      |                      ^
```

As a minor optimization we null-terminate "which" after the loop rather than (repeatedly) inside it.