### PR TITLE
opendkim/opendkim.conf.simple.in: add UserID and UMask examples

### DIFF
--- a/opendkim/opendkim.conf.simple.in
+++ b/opendkim/opendkim.conf.simple.in
@@ -16,6 +16,17 @@ Socket                  inet:8891@localhost
 # (that the included service scripts use) is below.
 #Socket                 local:@RUNSTATEDIR@/opendkim/opendkim.sock
 
+# An unprivileged user to run as. Our service scripts attempt to
+# use the "opendkim" user and group by default.
+#UserID			opendkim
+
+# The UMask applied when creating the PID file (before dropping
+# privileges) and the local UNIX socket (after dropping
+# privileges). To share a socket with e.g. postfix via group
+# permissions, use something like the following.
+#UMask			0117
+
+
 ReportAddress           postmaster@@DOMAIN@
 SendReports             yes
 


### PR DESCRIPTION
Another baby step toward https://github.com/trusteddomainproject/OpenDKIM/pull/41. I'm planning to use "opendkim" as the owner of the directory where a local socket could live, so it makes sense to (a) politely suggest this convention, and (b) provide a `UMask` example that is actually usable in that scenario.

(If it doesn't work out of the box, users do insane things like `chmod 777` everything until it starts "working.")
