### PR TITLE
mlfi_eoh: emit dkim=permerror for malformed DKIM-Signature (fixes #194)

### DIFF
--- a/libopendkim/tests/Makefile.am
+++ b/libopendkim/tests/Makefile.am
@@ -44,7 +44,7 @@ check_PROGRAMS = t-test00 t-test01 t-test02 t-test03 t-test04 \
 	t-test157 t-test158 t-test159 t-test160 \
 	t-test200 t-test201 t-test202 t-test203 \
 	t-test204 t-test205 \
-	t-test206 t-test207 \
+	t-test206 t-test207 t-test208 \
 	t-signperf t-verifyperf
 check_SCRIPTS = t-signperf-sha1 t-signperf-relaxed-relaxed \
 	t-signperf-simple-simple \
@@ -243,6 +243,7 @@ t_test204_SOURCES = t-test204.c t-testdata.h
 t_test205_SOURCES = t-test205.c t-testdata.h
 t_test206_SOURCES = t-test206.c t-testdata.h
 t_test207_SOURCES = t-test207.c t-testdata.h
+t_test208_SOURCES = t-test208.c t-testdata.h
 
 MOSTLYCLEANFILES=
 

--- a/libopendkim/tests/t-test208.c
+++ b/libopendkim/tests/t-test208.c
@@ -1,0 +1,84 @@
+/*
+**  Copyright (c) 2005-2008 Sendmail, Inc. and its suppliers.
+**    All rights reserved.
+**
+**  Copyright (c) 2009, 2011-2013, 2026, The Trusted Domain Project.
+**    All rights reserved.
+*/
+
+/*
+**  t-test208 -- verify that a malformed DKIM-Signature header produces
+**               DKIM_STAT_SYNTAX from dkim_header() and DKIM_STAT_NOSIG
+**               from dkim_eoh(), confirming the library behaviour that
+**               the mlfi_eoh() fix for issue #194 relies on.
+*/
+
+#include "build-config.h"
+
+/* system includes */
+#include <sys/types.h>
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef USE_GNUTLS
+# include <gnutls/gnutls.h>
+#endif /* USE_GNUTLS */
+
+/* libopendkim includes */
+#include "../dkim.h"
+#include "t-testdata.h"
+
+int
+main(int argc, char **argv)
+{
+	DKIM_STAT status;
+	DKIM *dkim;
+	DKIM_LIB *lib;
+
+	printf("*** malformed DKIM-Signature: SYNTAX from dkim_header, NOSIG from dkim_eoh\n");
+
+#ifdef USE_GNUTLS
+	(void) gnutls_global_init();
+#endif /* USE_GNUTLS */
+
+	lib = dkim_init(NULL, NULL);
+	assert(lib != NULL);
+
+	/*
+	**  Feed a message whose only DKIM-Signature has no valid tag-value
+	**  pairs.  dkim_header() must return DKIM_STAT_SYNTAX; the handle
+	**  must remain usable; dkim_eoh() must return DKIM_STAT_NOSIG
+	**  (the bad sig is skipped, leaving no valid signatures).
+	*/
+
+	dkim = dkim_verify(lib, JOBID, NULL, &status);
+	assert(dkim != NULL);
+
+	status = dkim_header(dkim,
+	                     (u_char *) "DKIM-Signature: eeee",
+	                     strlen("DKIM-Signature: eeee"));
+	assert(status == DKIM_STAT_SYNTAX);
+
+	status = dkim_header(dkim, (u_char *) HEADER05, strlen(HEADER05));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_header(dkim, (u_char *) HEADER06, strlen(HEADER06));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_header(dkim, (u_char *) HEADER07, strlen(HEADER07));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_header(dkim, (u_char *) HEADER08, strlen(HEADER08));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_eoh(dkim);
+	assert(status == DKIM_STAT_NOSIG);
+
+	status = dkim_free(dkim);
+	assert(status == DKIM_STAT_OK);
+
+	dkim_close(lib);
+
+	return 0;
+}

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -13477,8 +13477,40 @@ mlfi_eoh(SMFICTX *ctx)
 
 			if (status != DKIM_STAT_OK)
 			{
-				ms = dkimf_libstatus(ctx, dfc->mctx_dkimv,
-				                     "dkim_header()", status);
+				if (status == DKIM_STAT_SYNTAX)
+				{
+					sfsistat action;
+
+					action = dkimf_libstatus(ctx,
+					                         dfc->mctx_dkimv,
+					                         "dkim_header()",
+					                         status);
+					if (action == SMFIS_ACCEPT ||
+					    action == SMFIS_CONTINUE)
+					{
+						/*
+						**  OnBadSignature accept:
+						**  don't return early; let
+						**  mlfi_eom() emit
+						**  dkim=permerror via the
+						**  mctx_headeronly path.
+						*/
+						dfc->mctx_status =
+							DKIMF_STATUS_BADFORMAT;
+						dfc->mctx_addheader = TRUE;
+						dfc->mctx_headeronly = TRUE;
+					}
+					else
+					{
+						ms = action;
+					}
+				}
+				else
+				{
+					ms = dkimf_libstatus(ctx, dfc->mctx_dkimv,
+					                     "dkim_header()",
+					                     status);
+				}
 			}
 		}
 	}
@@ -13571,9 +13603,13 @@ mlfi_eoh(SMFICTX *ctx)
 		return SMFIS_CONTINUE;
 
 	  case DKIM_STAT_NOSIG:
-		dfc->mctx_status = DKIMF_STATUS_NOSIGNATURE;
-		if (conf->conf_alwaysaddar)
-			dfc->mctx_addheader = TRUE;
+		/* don't overwrite BADFORMAT set by a dkim_header() syntax error */
+		if (dfc->mctx_status != DKIMF_STATUS_BADFORMAT)
+		{
+			dfc->mctx_status = DKIMF_STATUS_NOSIGNATURE;
+			if (conf->conf_alwaysaddar)
+				dfc->mctx_addheader = TRUE;
+		}
 		return SMFIS_CONTINUE;
 
 	  case DKIM_STAT_NOKEY:


### PR DESCRIPTION
## Summary

- When `dkim_header()` returns `DKIM_STAT_SYNTAX` for a malformed `DKIM-Signature`, `mlfi_eoh()` was setting `ms` and returning early, bypassing `mlfi_eom()` entirely. With `AlwaysAddARHeader` or `SoftwareHeader` enabled, the message was accepted with no `Authentication-Results` header — making it indistinguishable from mail that was never processed by OpenDKIM.
- RFC 8601 §2.7.1 defines `dkim=permerror` for exactly this case.
- The fix routes syntax errors through the existing `mctx_headeronly` / `DKIMF_STATUS_BADFORMAT` path that `mlfi_eom()` already handles correctly, rather than short-circuiting past it.

## How it works

When `dkim_header()` returns `DKIM_STAT_SYNTAX`, instead of setting `ms` (which causes `mlfi_eoh()` to return early), the fix sets `mctx_headeronly`, `mctx_addheader`, and `mctx_status=DKIMF_STATUS_BADFORMAT`. `mlfi_eoh()` returns `SMFIS_CONTINUE`; `mlfi_body()` skips the body via the existing `mctx_headeronly` check; `mlfi_eom()` reaches its own `mctx_headeronly` branch which emits `dkim=permerror` and accepts.

A guard is also added to the `DKIM_STAT_NOSIG` branch of the `dkim_eoh()` result switch so it does not overwrite a `BADFORMAT` status already set from the header loop. (A handle with a bad `DKIM-Signature` produces `NOSIG` from `dkim_eoh_verify()` once the bad sig's `set_bad` flag is set.)

## Test

`t-test208` confirms the library behaviour the fix relies on: `dkim_header()` returns `DKIM_STAT_SYNTAX` for a malformed `DKIM-Signature`, the handle remains usable, and `dkim_eoh()` returns `DKIM_STAT_NOSIG`. Verified on FreeBSD.

## Test plan

- [ ] Build and run `make check` — t-test208 should pass
- [ ] Manual test: send a message with `DKIM-Signature: eeee` through a milter instance configured with `AlwaysAddARHeader yes`; confirm `Authentication-Results` header contains `dkim=permerror`