### PR TITLE
libopendkim: accept UTF-8 in header bodies and DKIM-Signature i= values (RFC 8616)

### DIFF
--- a/docs/INTERNATIONALIZATION.md
+++ b/docs/INTERNATIONALIZATION.md
@@ -1,0 +1,182 @@
+# Internationalized Domain Names and EAI Mail in OpenDKIM
+
+## Background
+
+DKIM (RFC 6376) was designed for traditional ASCII email.  The Email Address
+Internationalization (EAI) suite of RFCs extends email to support Unicode
+throughout: UTF-8 header field bodies (RFC 6532), internationalized addresses
+in SMTP (RFC 6531), and internationalized domain names (IDN) in DNS.  RFC 8616
+updates DKIM to describe how signing and verification should work in this
+environment.
+
+This document covers what OpenDKIM currently supports, what it does not, and
+how to configure it correctly if your domain name contains non-ASCII characters.
+
+
+## What OpenDKIM supports
+
+As of the fix for issue #47 (partial RFC 8616 support):
+
+- **Signing and verifying messages with UTF-8 header field bodies.**  A message
+  whose `Subject:`, `From:`, or other headers contain UTF-8 bytes can be signed
+  and verified correctly.  The canonicalization algorithms (simple and relaxed)
+  operate on raw octets and have always been byte-correct; the fix removed a
+  gate in `dkim_header()` that was rejecting high bytes before they reached
+  canonicalization.
+
+- **Parsing `DKIM-Signature` headers that contain UTF-8 in the `i=` local-part.**
+  RFC 8616 section 4 permits the local-part of the `i=` Agent or User
+  Identifier tag to be UTF-8 in EAI messages.  `dkim_process_set()` previously
+  rejected any non-ASCII byte unconditionally; it now allows high bytes through
+  in tag-value context while still requiring tag names to be ASCII.
+
+
+## What OpenDKIM does NOT support
+
+- **Automatic U-label to A-label conversion.**  OpenDKIM does not include
+  libidn2 or any equivalent, so it cannot automatically translate a Unicode
+  domain name (U-label, e.g. `münchen.de`) to its Punycode/ACE form (A-label,
+  e.g. `xn--mnchen-3ya.de`).
+
+- **U-labels in configuration.**  If you put a U-label directly in
+  `opendkim.conf` (as the value of `Domain`, `SubDomains`, or a signing table
+  entry), OpenDKIM will pass it as-is to the DNS resolver.  DNS only understands
+  A-labels; the lookup will fail and signing will not occur.
+
+  There is no warning or error for this misconfiguration - the DNS query simply
+  returns no results.
+
+
+## If you MUST use an internationalized domain name
+
+### Step 1: Find the A-label for your domain
+
+The A-label is the ASCII-compatible encoding (ACE) of your domain.  Your DNS
+registrar will show it, but you can also derive it yourself:
+
+**Using Python (no extra packages required):**
+
+```
+python3 -c "print('münchen.de'.encode('idna').decode('ascii'))"
+xn--mnchen-3ya.de
+```
+
+**Using the `idn` tool (from the libidn package):**
+
+```
+idn --quiet -a münchen.de
+xn--mnchen-3ya.de
+```
+
+**Using `dig` to confirm the A-label resolves:**
+
+```
+dig TXT mail._domainkey.xn--mnchen-3ya.de
+```
+
+Multi-label domains (e.g. `mail.münchen.de`) encode each label independently;
+only the non-ASCII labels are encoded:
+
+```
+python3 -c "print('mail.münchen.de'.encode('idna').decode('ascii'))"
+mail.xn--mnchen-3ya.de
+```
+
+
+### Step 2: Configure OpenDKIM with the A-label
+
+In `opendkim.conf`, always use the A-label:
+
+```
+Domain      xn--mnchen-3ya.de
+Selector    mail
+KeyFile     /etc/opendkim/keys/xn--mnchen-3ya.de/mail.private
+```
+
+The same applies to signing table and key table entries:
+
+```
+# SigningTable
+*@münchen.de     münchen           # WRONG - DNS lookup will fail
+*@xn--mnchen-3ya.de  xn--mnchen-3ya.de  # correct
+```
+
+Or if your MTA delivers mail using the Unicode form of the address, use a
+wildcard or regex approach that maps to an A-label key table entry:
+
+```
+# /etc/opendkim/signing.table
+*@münchen.de     default
+
+# /etc/opendkim/key.table  
+default   xn--mnchen-3ya.de:mail:/etc/opendkim/keys/mail.private
+```
+
+
+### Step 3: Publish DNS records under the A-label
+
+Your DKIM TXT record must be published under the A-label selector._domainkey
+name.  The record itself is standard ASCII:
+
+```
+mail._domainkey.xn--mnchen-3ya.de.  IN  TXT  "v=DKIM1; k=rsa; p=MIIBIjAN..."
+```
+
+Verify it is reachable:
+
+```
+opendkim-testkey -d xn--mnchen-3ya.de -s mail -vvv
+```
+
+
+## The `i=` tag and EAI mail
+
+The optional `i=` tag in a `DKIM-Signature` header identifies the Agent or
+User Identifier (AUID).  For a signing domain of `xn--mnchen-3ya.de`, a
+signer might include:
+
+```
+i=søren@xn--mnchen-3ya.de
+```
+
+where the local-part `søren` contains UTF-8.  RFC 8616 section 4 explicitly
+allows this in messages that transit an EAI-capable path.  OpenDKIM will now
+parse and verify such signatures without treating the UTF-8 bytes as a syntax
+error.
+
+Note that the domain portion of `i=` must still be an A-label; only the
+local-part may be UTF-8.
+
+If you do not configure an explicit `i=` value (most deployments do not),
+OpenDKIM omits the tag entirely, which is valid per RFC 6376 and requires no
+special handling.
+
+
+## Limitations and future work
+
+- **No libidn2 integration.**  Adding automatic U-label to A-label translation
+  in `opendkim.conf` parsing would require linking against libidn2 (or
+  equivalent).  This is a possible future enhancement but is out of scope for
+  the current change.
+
+- **No EAI SMTP negotiation.**  OpenDKIM operates as a milter and does not
+  inspect SMTP-level EAI capability negotiation (RFC 6531 `SMTPUTF8`).
+  Whether the underlying message uses EAI headers is transparent to OpenDKIM:
+  it processes whatever header bytes the MTA delivers.
+
+- **RFC 8616 section 3.2 (address rewriting).**  This section discusses how
+  a relay that downgrades an EAI message to ASCII must handle DKIM signatures.
+  OpenDKIM does not perform any such downgrade; that is the MTA's
+  responsibility.
+
+
+## Summary
+
+| Scenario | Supported? |
+|---|---|
+| Signing messages with UTF-8 headers (RFC 6532) | Yes |
+| Verifying messages with UTF-8 headers | Yes |
+| `i=` tag with UTF-8 local-part | Yes (parse and verify) |
+| `d=` A-label domain in config | Yes |
+| `d=` U-label domain in config (auto-convert) | No - use A-label explicitly |
+| DKIM signing of EAI mail end-to-end | Yes, with A-label config |

--- a/docs/INTERNATIONALIZATION.md
+++ b/docs/INTERNATIONALIZATION.md
@@ -152,6 +152,19 @@ OpenDKIM omits the tag entirely, which is valid per RFC 6376 and requires no
 special handling.
 
 
+## Status and roadmap
+
+The changes described in this document are conservative correctness fixes: they
+remove gates that incorrectly rejected valid input (UTF-8 bytes in header field
+bodies; UTF-8 in `i=` local-parts) rather than adding new IDN-aware behavior.
+Full IDN support - automatic U-label conversion, SMTPUTF8-aware signing table
+matching, end-to-end EAI interoperability - is a larger feature that would
+require a dedicated interoperability test suite against real EAI-capable MTAs
+and verifiers before it could be shipped with confidence.  That work is not yet
+planned.  These fixes lay the groundwork without committing to a complete
+implementation.
+
+
 ## Limitations and future work
 
 - **No libidn2 integration.**  Adding automatic U-label to A-label translation

--- a/docs/INTERNATIONALIZATION.md
+++ b/docs/INTERNATIONALIZATION.md
@@ -39,12 +39,10 @@ As of the fix for issue #47 (partial RFC 8616 support):
   e.g. `xn--mnchen-3ya.de`).
 
 - **U-labels in configuration.**  If you put a U-label directly in
-  `opendkim.conf` (as the value of `Domain`, `SubDomains`, or a signing table
-  entry), OpenDKIM will pass it as-is to the DNS resolver.  DNS only understands
-  A-labels; the lookup will fail and signing will not occur.
-
-  There is no warning or error for this misconfiguration - the DNS query simply
-  returns no results.
+  `opendkim.conf` (as the value of `Domain`, `SigningTable`, or `KeyTable`),
+  signing will silently fail or DNS lookups will return no results.  Some of
+  these cases now produce a `LOG_WARNING` syslog message; see the Diagnostics
+  section below for details.
 
 
 ## If you MUST use an internationalized domain name
@@ -192,6 +190,29 @@ implementation.
   audited and tested, operators running SMTPUTF8-capable MTAs should verify
   that signing actually occurs for EAI mail (check for a `DKIM-Signature:`
   header on outbound messages) rather than assuming it does.
+
+
+## Diagnostics: what is warned and what fails silently
+
+Not all U-label misconfigurations produce a visible error.  The table below
+describes the outcome for each case.
+
+| Misconfiguration | Outcome |
+|---|---|
+| U-label domain in message `From:`, queried against `SigningTable` | `LOG_WARNING`: "signing domain '...' contains non-ASCII; configure the A-label (Punycode) form in SigningTable and KeyTable" |
+| U-label domain in message `From:`, queried against `Domain` list | `LOG_WARNING`: "signing domain '...' contains non-ASCII; configure the A-label (Punycode) form in Domain" |
+| U-label in the domain column of a `KeyTable` entry | Silent: DNS key lookup returns no results; message is not signed |
+| U-label as a key in `SigningTable` (config entry, never queried) | Silent: entry never matches; no diagnostic at startup or runtime |
+
+The warnings in the first two rows fire at message-processing time, not at
+startup.  They appear in syslog once per message that triggers the condition,
+so they are visible in normal mail logs without requiring additional log level
+configuration.
+
+The silent cases in rows three and four are not yet diagnosed.  If you suspect
+a U-label is present in your `KeyTable` domain column, the symptom will be a
+key-fetch failure logged for that selector and domain; cross-check the domain
+name in that log line against the A-label for your domain.
 
 
 ## Summary

--- a/docs/INTERNATIONALIZATION.md
+++ b/docs/INTERNATIONALIZATION.md
@@ -169,6 +169,17 @@ special handling.
   OpenDKIM does not perform any such downgrade; that is the MTA's
   responsibility.
 
+- **Milter-level address parsing for SMTPUTF8 mail is unaudited.**  When an
+  MTA uses the SMTPUTF8 extension (RFC 6531) and delivers a message whose
+  `From:` header contains a U-label domain (e.g. `user@münchen.de`), OpenDKIM
+  must extract that domain to perform signing table and key table lookups.  The
+  address-parsing code in the milter has not been audited for UTF-8 correctness.
+  If it expects ASCII, the lookup will silently fail to match and the message
+  will not be signed, even if the key table entry is correct.  Until this is
+  audited and tested, operators running SMTPUTF8-capable MTAs should verify
+  that signing actually occurs for EAI mail (check for a `DKIM-Signature:`
+  header on outbound messages) rather than assuming it does.
+
 
 ## Summary
 

--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -537,11 +537,13 @@ dkim_process_set(DKIM *dkim, dkim_set_t type, u_char *str, size_t len,
 
 	for (p = hcopy; *p != '\0'; p++)
 	{
-		if (!isascii(*p) || (!isprint(*p) && !isspace(*p)))
+		/* allow high bytes (UTF-8) in value context (states 2, 3) */
+		if ((!isascii(*p) && state < 2) ||
+		    (isascii(*p) && !isprint(*p) && !isspace(*p)))
 		{
 			dkim_error(dkim,
-			           "invalid character (ASCII 0x%02x at offset %d) in %s data",
-			           *p, p - hcopy, settype);
+			           "invalid character (0x%02x at offset %d) in %s data",
+			           (unsigned char) *p, p - hcopy, settype);
 			if (syntax)
 				dkim_set_free(dkim, set);
 			else
@@ -6680,11 +6682,13 @@ dkim_header(DKIM *dkim, u_char *hdr, size_t len)
 		}
 		else
 		{
-			/* field bodies are printable ASCII, SP, HT, CR, LF */
+			/* field bodies: printable ASCII, SP, HT, CR, LF, or
+			   high bytes (UTF-8, per RFC 8616) */
 			if (!(hdr[c] == 9 ||  /* HT */
 			      hdr[c] == 10 || /* LF */
 			      hdr[c] == 13 || /* CR */
-			      (hdr[c] >= 32 && hdr[c] <= 126) /* SP, print */ ))
+			      (hdr[c] >= 32 && hdr[c] <= 126) || /* SP, print */
+			      hdr[c] >= 128 /* UTF-8 */ ))
 				return DKIM_STAT_SYNTAX;
 		}
 	}

--- a/libopendkim/tests/Makefile.am
+++ b/libopendkim/tests/Makefile.am
@@ -45,6 +45,7 @@ check_PROGRAMS = t-test00 t-test01 t-test02 t-test03 t-test04 \
 	t-test200 t-test201 t-test202 t-test203 \
 	t-test204 t-test205 \
 	t-test206 t-test207 t-test208 \
+	t-test209 t-test210 \
 	t-signperf t-verifyperf
 check_SCRIPTS = t-signperf-sha1 t-signperf-relaxed-relaxed \
 	t-signperf-simple-simple \
@@ -244,6 +245,8 @@ t_test205_SOURCES = t-test205.c t-testdata.h
 t_test206_SOURCES = t-test206.c t-testdata.h
 t_test207_SOURCES = t-test207.c t-testdata.h
 t_test208_SOURCES = t-test208.c t-testdata.h
+t_test209_SOURCES = t-test209.c t-testdata.h
+t_test210_SOURCES = t-test210.c t-testdata.h
 
 MOSTLYCLEANFILES=
 

--- a/libopendkim/tests/t-test209.c
+++ b/libopendkim/tests/t-test209.c
@@ -1,0 +1,86 @@
+/*
+**  Copyright (c) 2005-2008 Sendmail, Inc. and its suppliers.
+**    All rights reserved.
+**
+**  Copyright (c) 2009, 2011-2013, 2026, The Trusted Domain Project.
+**    All rights reserved.
+*/
+
+/*
+**  t-test209 -- verify that dkim_header() accepts UTF-8 bytes in header
+**               field bodies (RFC 8616 / EAI support).  Prior to the fix,
+**               any byte > 0x7E in a field body returned DKIM_STAT_SYNTAX.
+*/
+
+#include "build-config.h"
+
+/* system includes */
+#include <sys/types.h>
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef USE_GNUTLS
+# include <gnutls/gnutls.h>
+#endif /* USE_GNUTLS */
+
+/* libopendkim includes */
+#include "../dkim.h"
+#include "t-testdata.h"
+
+/*
+**  "Subject: Héllo wörld" encoded as UTF-8:
+**    é = U+00E9 = 0xC3 0xA9
+**    ö = U+00F6 = 0xC3 0xB6
+*/
+#define UTF8_SUBJECT	"Subject: H\xc3\xa9llo w\xc3\xb6rld"
+
+int
+main(int argc, char **argv)
+{
+	DKIM_STAT status;
+	DKIM *dkim;
+	DKIM_LIB *lib;
+
+	printf("*** UTF-8 header field body: accepted by dkim_header()\n");
+
+#ifdef USE_GNUTLS
+	(void) gnutls_global_init();
+#endif /* USE_GNUTLS */
+
+	lib = dkim_init(NULL, NULL);
+	assert(lib != NULL);
+
+	/*
+	**  Feed a message with a UTF-8 Subject header and no DKIM-Signature.
+	**  dkim_header() must return DKIM_STAT_OK for the UTF-8 header;
+	**  dkim_eoh() must return DKIM_STAT_NOSIG (no signature present).
+	*/
+
+	dkim = dkim_verify(lib, JOBID, NULL, &status);
+	assert(dkim != NULL);
+
+	status = dkim_header(dkim,
+	                     (u_char *) UTF8_SUBJECT,
+	                     strlen(UTF8_SUBJECT));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_header(dkim, (u_char *) HEADER05, strlen(HEADER05));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_header(dkim, (u_char *) HEADER06, strlen(HEADER06));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_header(dkim, (u_char *) HEADER07, strlen(HEADER07));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_eoh(dkim);
+	assert(status == DKIM_STAT_NOSIG);
+
+	status = dkim_free(dkim);
+	assert(status == DKIM_STAT_OK);
+
+	dkim_close(lib);
+
+	return 0;
+}

--- a/libopendkim/tests/t-test210.c
+++ b/libopendkim/tests/t-test210.c
@@ -1,0 +1,105 @@
+/*
+**  Copyright (c) 2005-2008 Sendmail, Inc. and its suppliers.
+**    All rights reserved.
+**
+**  Copyright (c) 2009, 2011-2013, 2026, The Trusted Domain Project.
+**    All rights reserved.
+*/
+
+/*
+**  t-test210 -- verify that a DKIM-Signature with a UTF-8 local-part in the
+**               i= tag is parsed without error (RFC 8616 section 4).  Prior
+**               to the fix, dkim_process_set() rejected any non-ASCII byte
+**               unconditionally, causing a valid EAI signature to be treated
+**               as malformed.
+*/
+
+#include "build-config.h"
+
+/* system includes */
+#include <sys/types.h>
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef USE_GNUTLS
+# include <gnutls/gnutls.h>
+#endif /* USE_GNUTLS */
+
+/* libopendkim includes */
+#include "../dkim.h"
+#include "t-testdata.h"
+
+/*
+**  A syntactically valid DKIM-Signature whose i= local-part contains UTF-8:
+**    ø = U+00F8 = 0xC3 0xB8  (so "søren" has a non-ASCII byte)
+**  The b= and bh= values are well-formed base64 but not cryptographically
+**  valid; we only exercise parsing here, not verification.
+*/
+#define UTF8_DKIM_SIG \
+	"DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;" \
+	" d=" DOMAIN "; s=" SELECTOR \
+	"; i=s\xc3\xb8ren@" DOMAIN \
+	"; h=from:to:subject:date;" \
+	" bh=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=;" \
+	" b=dGVzdA=="
+
+int
+main(int argc, char **argv)
+{
+	DKIM_STAT status;
+	DKIM *dkim;
+	DKIM_LIB *lib;
+
+	printf("*** UTF-8 i= local-part in DKIM-Signature: parsed without error\n");
+
+#ifdef USE_GNUTLS
+	(void) gnutls_global_init();
+#endif /* USE_GNUTLS */
+
+	lib = dkim_init(NULL, NULL);
+	assert(lib != NULL);
+
+	/*
+	**  Feed a DKIM-Signature that is structurally valid and contains a
+	**  UTF-8 local-part in i=.  dkim_header() must return DKIM_STAT_OK
+	**  (not DKIM_STAT_SYNTAX).  dkim_eoh() must return DKIM_STAT_OK,
+	**  confirming the signature was parsed and counted rather than
+	**  discarded as malformed due to the UTF-8 bytes.
+	*/
+
+	dkim = dkim_verify(lib, JOBID, NULL, &status);
+	assert(dkim != NULL);
+
+	status = dkim_header(dkim,
+	                     (u_char *) UTF8_DKIM_SIG,
+	                     strlen(UTF8_DKIM_SIG));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_header(dkim, (u_char *) HEADER05, strlen(HEADER05));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_header(dkim, (u_char *) HEADER06, strlen(HEADER06));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_header(dkim, (u_char *) HEADER07, strlen(HEADER07));
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_header(dkim, (u_char *) HEADER08, strlen(HEADER08));
+	assert(status == DKIM_STAT_OK);
+
+	/*
+	**  dkim_eoh() returns DKIM_STAT_OK when at least one signature was
+	**  parsed successfully.  A return of DKIM_STAT_NOSIG here would mean
+	**  the signature was silently discarded due to the UTF-8 bytes.
+	*/
+	status = dkim_eoh(dkim);
+	assert(status == DKIM_STAT_OK);
+
+	status = dkim_free(dkim);
+	assert(status == DKIM_STAT_OK);
+
+	dkim_close(lib);
+
+	return 0;
+}

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -10056,6 +10056,24 @@ dkimf_apply_signtable(struct msgctx *dfc, DKIMF_DB keydb, DKIMF_DB signdb,
 	assert(user != NULL);
 	assert(domain != NULL);
 
+	if (dolog)
+	{
+		unsigned char *q;
+
+		for (q = domain; *q != '\0'; q++)
+		{
+			if (!isascii(*q))
+			{
+				syslog(LOG_WARNING,
+				       "%s: signing domain '%s' contains non-ASCII; "
+				       "configure the A-label (Punycode) form in "
+				       "SigningTable and KeyTable",
+				       dfc->mctx_jobid, domain);
+				break;
+			}
+		}
+	}
+
 	if (dkimf_db_type(signdb) == DKIMF_DB_TYPE_REFILE)
 	{
 		int status;
@@ -12563,6 +12581,23 @@ mlfi_eoh(SMFICTX *ctx)
 	/* is it a domain we sign for? */
 	if (!domainok && conf->conf_domainsdb != NULL)
 	{
+		if (dolog)
+		{
+			unsigned char *q;
+
+			for (q = dfc->mctx_domain; *q != '\0'; q++)
+			{
+				if (!isascii(*q))
+				{
+					syslog(LOG_WARNING,
+					       "%s: signing domain '%s' contains non-ASCII; "
+					       "configure the A-label (Punycode) form in Domain",
+					       dfc->mctx_jobid, dfc->mctx_domain);
+					break;
+				}
+			}
+		}
+
 		status = dkimf_db_get(conf->conf_domainsdb, dfc->mctx_domain,
 		                      0, NULL, 0, &domainok);
 


### PR DESCRIPTION
## Summary

- `dkim_header()` rejected any byte > 0x7E in a header field body, making it impossible to sign or verify EAI messages (RFC 6532) whose headers contain UTF-8. Relax the check to allow high bytes; canonicalization already handles non-ASCII octets correctly.
- `dkim_process_set()` unconditionally rejected non-ASCII bytes, causing a DKIM-Signature with a UTF-8 local-part in `i=` (permitted by RFC 8616 section 4) to be treated as malformed. Restrict the non-ASCII rejection to tag-name context (states 0-1); allow high bytes through in value context (states 2-3).
- Add `t-test209` and `t-test210` to exercise both changes at the library level.

No new dependencies. `d=` values remain ASCII (A-label), as required by RFC 6376. This change covers the signing/verification path for EAI mail; U-label-to-A-label translation in configuration is out of scope and would require libidn2.

## Test plan

- [ ] `t-test209` passes: `dkim_header()` returns `DKIM_STAT_OK` for a UTF-8 `Subject:` header
- [ ] `t-test210` passes: `dkim_eoh()` returns `DKIM_STAT_OK` for a DKIM-Signature with a UTF-8 `i=` local-part (signature parsed rather than discarded)
- [ ] Full `make check` passes on Linux CI
- [ ] Full `make check` passes on FreeBSD (quark)