### PR TITLE
Add OpenRC service script (contrib)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,12 +47,14 @@ DISTCHECK_CONFIGURE_FLAGS=--enable-vbr --with-lua --enable-stats --with-odbx --w
 #
 
 # We want to *build and install* these on the target machine.
-nodist_doc_DATA = contrib/systemd/opendkim.tmpfiles \
+nodist_doc_DATA = contrib/openrc/opendkim.openrc \
+                  contrib/systemd/opendkim.tmpfiles \
                   opendkim/opendkim.conf.simple \
                   opendkim/opendkim.conf.simple-verify
 
 # We want to *ship* these.
-EXTRA_DIST =  contrib/systemd/opendkim.tmpfiles.in \
+EXTRA_DIST =  contrib/openrc/opendkim.openrc.in \
+              contrib/systemd/opendkim.tmpfiles.in \
               opendkim/opendkim.conf.simple.in \
               opendkim/opendkim.conf.simple-verify.in
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -61,7 +61,9 @@ EXTRA_DIST =  contrib/systemd/opendkim.tmpfiles.in \
 # be found in the "Installation Directory Variables" section.
 edit = sed -e 's|@DOMAIN[@]|$(DOMAIN)|g' \
            -e 's|@LOCALSTATEDIR[@]|$(localstatedir)|g' \
-           -e 's|@RUNSTATEDIR[@]|$(runstatedir)|g'
+           -e 's|@RUNSTATEDIR[@]|$(runstatedir)|g' \
+           -e 's|@SBINDIR[@]|$(sbindir)|g' \
+           -e 's|@SYSCONFDIR[@]|$(sysconfdir)|g'
 
 # This rule includes EVERY source/intermediate file as a dependency of
 # EVERY output file, which is clearly wrong, but it may be the best we

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,11 +47,13 @@ DISTCHECK_CONFIGURE_FLAGS=--enable-vbr --with-lua --enable-stats --with-odbx --w
 #
 
 # We want to *build and install* these on the target machine.
-nodist_doc_DATA = opendkim/opendkim.conf.simple \
+nodist_doc_DATA = contrib/systemd/opendkim.tmpfiles \
+                  opendkim/opendkim.conf.simple \
                   opendkim/opendkim.conf.simple-verify
 
 # We want to *ship* these.
-EXTRA_DIST =  opendkim/opendkim.conf.simple.in \
+EXTRA_DIST =  contrib/systemd/opendkim.tmpfiles.in \
+              opendkim/opendkim.conf.simple.in \
               opendkim/opendkim.conf.simple-verify.in
 
 # The next rule allow us to replace bindir, libdir, etc.  within

--- a/configure.ac
+++ b/configure.ac
@@ -2733,6 +2733,7 @@ AC_CONFIG_FILES([	Makefile
 			contrib/init/solaris/Makefile
 			contrib/ldap/Makefile
 			contrib/lua/Makefile
+			contrib/openrc/Makefile
 			contrib/patches/Makefile
 			contrib/repute/Makefile
 			contrib/spec/Makefile

--- a/contrib/.gitignore
+++ b/contrib/.gitignore
@@ -1,3 +1,5 @@
 Makefile
 Makefile.in
 opendkim.spec
+openrc/opendkim.openrc
+systemd/opendkim.tmpfiles

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -3,6 +3,6 @@
 
 #AUTOMAKE_OPTIONS = foreign
 
-SUBDIRS = convert docs init ldap lua patches repute spec stats systemd
+SUBDIRS = convert docs init ldap lua openrc patches repute spec stats systemd
 
 dist_doc_DATA = README

--- a/contrib/openrc/Makefile.am
+++ b/contrib/openrc/Makefile.am
@@ -1,0 +1,1 @@
+dist_doc_DATA = README

--- a/contrib/openrc/README
+++ b/contrib/openrc/README
@@ -1,0 +1,11 @@
+Service scripts and configuration for the OpenRC[0] init system. They
+are supported by their authors and/or the maintainers of the OpenDKIM
+package[1] in Gentoo linux (presently, one and the same).
+
+OpenRC uses the tmpfiles.d mechanism[2], so the tmpfiles entry in the
+"systemd" subdirectory is relevant here as well.
+
+
+[0] https://github.com/OpenRC/openrc
+[1] https://packages.gentoo.org/packages/mail-filter/opendkim
+[2] https://www.freedesktop.org/software/systemd/man/latest/tmpfiles.d.html

--- a/contrib/openrc/opendkim.openrc.in
+++ b/contrib/openrc/opendkim.openrc.in
@@ -1,0 +1,52 @@
+#!/sbin/openrc-run
+
+CONFFILE="@SYSCONFDIR@/${RC_SVCNAME}.conf"
+required_files="${CONFFILE}"
+
+command="@SBINDIR@/opendkim"
+pidfile="@RUNSTATEDIR@/${RC_SVCNAME}.pid"
+command_args="-P ${pidfile} -x ${CONFFILE}"
+extra_commands="checkconfig"
+
+depend() {
+	use dns logger net
+	before mta
+}
+
+checkconfig() {
+	#
+	# The opendkim.conf man page says,
+	#
+	#   For parameters that are Boolean in nature, only the first byte
+	#   of the value is processed... For negative values, the following
+	#   are accepted: "F", "f", "N", "n", "0".'
+	#
+	if grep '^[[:space:]]*Background[[:space:]][[:space:]]*[FfNn0]' "${CONFFILE}" \
+		>/dev/null 2>&1; then
+		eend 1 "${RC_SVCNAME} cannot run in the foreground!"
+	fi
+	if ! "${command}" -n "${command_args}"; then
+		eend 1 "${RC_SVCNAME} configuration check failed"
+	fi
+}
+
+start_pre() {
+	# If this isn't a restart, make sure that the user's config isn't
+	# busted before we try to start the daemon (this will produce
+	# better error messages than if we just try to start it blindly).
+	#
+	# If, on the other hand, this *is* a restart, then the stop_pre
+	# action will have ensured that the config is usable and we don't
+	# need to do that again.
+	if [ "${RC_CMD}" != "restart" ]; then
+		checkconfig || return $?
+	fi
+}
+
+stop_pre() {
+	# If this is a restart, check to make sure the user's config
+	# isn't busted before we stop the running daemon.
+	if [ "${RC_CMD}" = "restart" ]; then
+		checkconfig || return $?
+	fi
+}

--- a/contrib/systemd/opendkim.tmpfiles.in
+++ b/contrib/systemd/opendkim.tmpfiles.in
@@ -1,0 +1,5 @@
+# We allow everyone to read/traverse this directory because if it
+# contains a local socket, then (for example) your MTA will want to
+# look in there. Permissions on the socket itself are controlled
+# by the "UserID" and "UMask" directives in the daemon's configuration.
+d @RUNSTATEDIR@/opendkim 0755 opendkim opendkim


### PR DESCRIPTION
Continuing https://github.com/trusteddomainproject/OpenDKIM/pull/41

* Add a tmpfiles entry under contrib/systemd that supports a local socket at the path and under the user now substituted into the sample configs
* Add the OpenRC service script that we've been using in Gentoo for about a decade
* Teach autotools to substitute `@SBINDIR@` and `@SYSCONFDIR@` into that service script and tmpfiles entry
* Add a README in contrib/openrc to explain what the directory is for
* gitignore the built files
