### PR TITLE
libopendkim: wire up dkim_res_nslist so Nameservers applies to default resolver

### DIFF
--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -4618,6 +4618,7 @@ dkim_init(void *(*caller_mallocf)(void *closure, size_t nbytes),
 	libhandle->dkiml_dns_start = dkim_res_query;
 	libhandle->dkiml_dns_cancel = dkim_res_cancel;
 	libhandle->dkiml_dns_waitreply = dkim_res_waitreply;
+	libhandle->dkiml_dns_setns = dkim_res_nslist;
 	
 #define FEATURE_INDEX(x)	((x) / (8 * sizeof(u_int)))
 #define FEATURE_OFFSET(x)	((x) % (8 * sizeof(u_int)))


### PR DESCRIPTION
## Summary

- `dkim_res_nslist()` has existed since the resolver abstraction was introduced and correctly calls `res_setservers()`, but `dkiml_dns_setns` was never assigned during library init for the default resolver backend.
- `dkim_dns_nslist()` checks `lib->dkiml_dns_setns != NULL` before calling it, so without the assignment the `Nameservers` config option silently did nothing -- returning `DKIM_DNS_SUCCESS` without touching the resolver state.
- The only build path that wired this up was `USE_UNBOUND` (via `dkimf_unbound_setup`), so `Nameservers` only worked in libunbound builds. Standard distro packages (e.g., RHEL/EPEL) don't use libunbound, making the option a documented no-op in practice.
- Fix is one line: assign `dkim_res_nslist` to `dkiml_dns_setns` alongside the other default resolver callbacks in `dkim_init()`.

On platforms where `res_setservers()` is not available (`HAVE_RES_SETSERVERS` not defined at build time), `dkim_res_nslist()` already returns success without doing anything, so behavior on those platforms is unchanged.

Closes #407.

## Test plan

- [ ] Configure `Nameservers` pointing to a known external resolver; verify via packet capture or resolver logs that queries go to the specified server and not the system default
- [ ] Omitting `Nameservers` from config: queries continue to use system resolv.conf -- no regression
- [ ] Build without `USE_UNBOUND`: confirm `Nameservers` is now respected
- [ ] Build with `USE_UNBOUND`: confirm no change in behavior (unbound path unaffected)