### PR TITLE
librbl/rbl.c: add missing stdio.h

### DIFF
--- a/librbl/rbl.c
+++ b/librbl/rbl.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
+#include <stdio.h>
 
 /* librbl includes */
 #include "rbl.h"


### PR DESCRIPTION
Needed for the `snprintf()` family of functions, and fixes the build on musl with `--enable-rbl`.