### PR TITLE
opendkim/tests/Makefile.am: add miltertest and opendkim as check deps

### DIFF
--- a/opendkim/tests/Makefile.am
+++ b/opendkim/tests/Makefile.am
@@ -1,3 +1,12 @@
+# Prerequisites for all tests. An abuse of check_DATA.
+check_DATA = ../../miltertest/miltertest ../opendkim
+
+# And rules to build them.
+../../miltertest/miltertest:
+	$(MAKE) -C ../../miltertest miltertest
+../opendkim:
+	$(MAKE) -C ../ opendkim
+
 check_SCRIPTS = t-sign-ss t-sign-rs t-sign-rs-tables t-sign-rs-tables-bad \
 	t-sign-rs-tables-token t-sign-rs-multiple t-sign-rs-mixconf \
 	t-sign-rs-lua t-sign-ss-all t-sign-ss-ltag t-sign-ss-x \


### PR DESCRIPTION
Abuse the `check_DATA` variable to indicate that the _miltertest_ and _opendkim_ programs are dependencies of every test in this directory. Afterwards, add rules to build them. This ensures that `make check` can be run before `make`.