### PR TITLE
Fix _Bool functions that silently discard -1 error returns

### DIFF
--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -1564,7 +1564,7 @@ dkim_key_hashesok(DKIM_LIB *lib, u_char *hashlist)
 **  	-1 on error
 */
 
-static _Bool
+static int
 dkim_sig_hdrlistok(DKIM *dkim, u_char *hdrlist)
 {
 	_Bool in = FALSE;

--- a/opendkim/opendkim.c
+++ b/opendkim/opendkim.c
@@ -6338,10 +6338,11 @@ dkimf_config_free(struct dkimf_config *conf)
 **  	errlen -- bytes available at "err"
 **
 **  Return value:
-**  	TRUE if no error, FALSE if error.
+**  	TRUE if no error, FALSE if unknown handling key, -1 if invalid
+**  	handling value.
 */
 
-static _Bool
+static int
 dkimf_parsehandler(struct config *cfg, char *name, struct handling *hndl,
                    char *err, size_t errlen)
 {
@@ -6623,28 +6624,28 @@ dkimf_config_load(struct config *data, struct dkimf_config *conf,
 			                  sizeof conf->conf_modestr);
 		}
 
-		if (!dkimf_parsehandler(data, "On-Default",
-		                        &conf->conf_handling, err, errlen) ||
-		    !dkimf_parsehandler(data, "On-BadSignature",
-		                        &conf->conf_handling, err, errlen) ||
-		    !dkimf_parsehandler(data, "On-DNSError",
-		                        &conf->conf_handling, err, errlen) ||
-		    !dkimf_parsehandler(data, "On-KeyNotFound",
-		                        &conf->conf_handling, err, errlen) ||
-		    !dkimf_parsehandler(data, "On-InternalError",
-		                        &conf->conf_handling, err, errlen) ||
-		    !dkimf_parsehandler(data, "On-NoSignature",
-		                        &conf->conf_handling, err, errlen) ||
-		    !dkimf_parsehandler(data, "On-PolicyError",
-		                        &conf->conf_handling, err, errlen) ||
+		if (dkimf_parsehandler(data, "On-Default",
+		                       &conf->conf_handling, err, errlen) != TRUE ||
+		    dkimf_parsehandler(data, "On-BadSignature",
+		                       &conf->conf_handling, err, errlen) != TRUE ||
+		    dkimf_parsehandler(data, "On-DNSError",
+		                       &conf->conf_handling, err, errlen) != TRUE ||
+		    dkimf_parsehandler(data, "On-KeyNotFound",
+		                       &conf->conf_handling, err, errlen) != TRUE ||
+		    dkimf_parsehandler(data, "On-InternalError",
+		                       &conf->conf_handling, err, errlen) != TRUE ||
+		    dkimf_parsehandler(data, "On-NoSignature",
+		                       &conf->conf_handling, err, errlen) != TRUE ||
+		    dkimf_parsehandler(data, "On-PolicyError",
+		                       &conf->conf_handling, err, errlen) != TRUE ||
 #ifdef _FFR_REPUTATION
-		    !dkimf_parsehandler(data, "On-ReptuationError",
-		                        &conf->conf_handling, err, errlen) ||
+		    dkimf_parsehandler(data, "On-ReptuationError",
+		                       &conf->conf_handling, err, errlen) != TRUE ||
 #endif /* _FFR_REPUTATION */
-		    !dkimf_parsehandler(data, "On-Security",
-		                        &conf->conf_handling, err, errlen) ||
-		    !dkimf_parsehandler(data, "On-SignatureError",
-		                        &conf->conf_handling, err, errlen))
+		    dkimf_parsehandler(data, "On-Security",
+		                       &conf->conf_handling, err, errlen) != TRUE ||
+		    dkimf_parsehandler(data, "On-SignatureError",
+		                       &conf->conf_handling, err, errlen) != TRUE)
 			return -1;
 
 		(void) config_get(data, "RemoveARAll", &conf->conf_remarall,


### PR DESCRIPTION
## Summary

cppcheck static analysis turned up two instances of the same root cause: a function declared `static _Bool` that does `return -1;` on an error path. In C99/C11, a `_Bool`-returning function implicitly converts any nonzero `int` expression to `1` (TRUE) at the `return` statement, so these functions actually return `TRUE`, not `-1`, defeating callers that check for a tri-state (TRUE/FALSE/-1) contract.

- `dkim_sig_hdrlistok()` (libopendkim/dkim.c): a `DKIM_MALLOC` failure is silently treated as "header list OK" instead of propagating `DKIM_STAT_NORESOURCE`. cppcheck confirms the caller-side dead code: `dkim.c:2170: Condition 'hstatus==-1' is always false`.
- `dkimf_parsehandler()` (opendkim/opendkim.c): an invalid value for any `On-*` handling directive in the config file populates the error buffer, but the config-load call sites (`!dkimf_parsehandler(...)`) never see the failure, so config loading proceeds as if the directive were valid.

I grepped every `_Bool`-returning function in the tree for `return -1;` inside its body and confirmed these are the only two instances of the idiom.

## Changes

- Both functions changed from `static _Bool` to `static int`, keeping their existing TRUE(1)/FALSE(0)/-1 return values as literal ints.
- Updated the `dkimf_parsehandler()` call sites in `dkimf_config_load()` from `!dkimf_parsehandler(...)` to `dkimf_parsehandler(...) != TRUE`, since both FALSE and -1 need to trip the error path.
- `dkim_sig_hdrlistok()`'s one call site already used an `int` local for the result, so no caller change was needed there.

## Test plan

- [x] `autoreconf -fi && ./configure && gmake` builds clean
- [x] `gmake check`: 174/174 tests pass