### PR TITLE
README/CHANGES: document LMDB 1.0 on-disk format incompatibility

### DIFF
--- a/CHANGES-202605.md
+++ b/CHANGES-202605.md
@@ -161,6 +161,7 @@ A systematic audit of memory and resource leaks (issue #272) produced fixes acro
 - **Dual-algorithm signing example**: Added KeyTable example and caveats for signing with both RSA and ed25519. (#270)
 - **`HowToRelease` modernized**: Updated for GitHub workflow, consistent release asset naming. (#338)
 - **Spelling fixes**: Various typos in docs and code comments. (#347)
+- **LMDB 1.0 file format incompatibility**: Documented in the README that LMDB 1.0 changed its on-disk file format incompatibly with 0.9.x, and that there is no automatic detection or upgrade of an existing database file. Operators upgrading the LMDB library on a system with an existing OpenDKIM LMDB database must dump with the old version's mdb_dump and reload with the new version's mdb_load.
 
 ---
 

--- a/README
+++ b/README
@@ -109,6 +109,15 @@ o If you wish to interface the filter with LDAP servers, OpenLDAP v2.1.3
 o For local hash or btree database support in either the filter or the
   library, Oracle's BerkeleyDB is required.  All versions are supported.
 
+o LMDB is an optional local key/data store backend (--with-lmdb).  LMDB 1.0
+  changed its on-disk file format in a way that is NOT compatible with 0.9.x,
+  and there is no automatic detection or in-place upgrade of an existing
+  database file: opening a 0.9.x data.mdb with a 1.0.x build (or vice versa)
+  will not work correctly. If you are upgrading the LMDB library on a system
+  where OpenDKIM already has an LMDB-backed database on disk, dump it with
+  the OLD version's mdb_dump before upgrading, then reload it with the NEW
+  version's mdb_load afterward.
+
 o If you are interested in tinkering with the build and packaging structure,
   you may need to upgrade to these versions of GNU's "autotools" components:
 	autoconf (GNU Autoconf) 2.61


### PR DESCRIPTION
## Summary
- LMDB 1.0 changed its on-disk file format in a way that is incompatible with 0.9.x, and there is no automatic detection or in-place upgrade of an existing database file.
- Documents this in the README's DEPENDENCIES section (new `--with-lmdb` bullet) with the dump/reload workaround (old version's `mdb_dump`, then new version's `mdb_load`).
- Adds a matching entry to CHANGES-202605.md under Documentation.

## Test plan
- [x] Docs-only change; no build/test impact.