### PR TITLE
.gitignore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ build-aux
 opendkim-[0-9].[0-9].[0-9]
 .vscode
 .claude
+.DS_Store


### PR DESCRIPTION
## Summary
- Adds `.DS_Store` to `.gitignore`. Split out of #429, which had picked it up incidentally.

## Test plan
- [x] Trivial one-line ignore-file change; no build/test impact.