### PR TITLE
libopendkim: declare dkim_error and dkim_get_key in dkim-internal.h (fixes #413)

### DIFF
--- a/libopendkim/dkim-atps.c
+++ b/libopendkim/dkim-atps.c
@@ -39,9 +39,6 @@
 # include <openssl/evp.h>
 #endif /* USE_GNUTLS */
 
-/* prototypes */
-extern void dkim_error (DKIM *, const char *, ...);
-
 /* local definitions needed for DNS queries */
 #define MAXPACKET		8192
 #if defined(__RES) && (__RES >= 19940415)

--- a/libopendkim/dkim-canon.c
+++ b/libopendkim/dkim-canon.c
@@ -63,9 +63,6 @@
 #define	DKIM_ISWSP(x)	((x) == 011 || (x) == 040)
 #define	DKIM_ISLWSP(x)	((x) == 011 || (x) == 012 || (x) == 015 || (x) == 040)
 
-/* prototypes */
-extern void dkim_error (DKIM *, const char *, ...);
-
 /* ========================= PRIVATE SECTION ========================= */
 
 /*

--- a/libopendkim/dkim-internal.h
+++ b/libopendkim/dkim-internal.h
@@ -164,5 +164,7 @@ extern DKIM_NAMETABLE *dkim_table_mandatory;
 extern DKIM_STAT dkim_process_set (DKIM *, dkim_set_t, u_char *, size_t,
                                        void *, _Bool, const char *);
 extern DKIM_STAT dkim_siglist_setup (DKIM *);
+extern DKIM_STAT dkim_get_key (DKIM *, DKIM_SIGINFO *, _Bool);
+extern void dkim_error (DKIM *, const char *, ...);
 
 #endif /* ! _DKIM_INTERNAL_H_ */

--- a/libopendkim/dkim-keys.c
+++ b/libopendkim/dkim-keys.c
@@ -39,9 +39,6 @@
 # include <strl.h>
 #endif /* USE_STRL_H */
 
-/* prototypes */
-extern void dkim_error (DKIM *, const char *, ...);
-
 /* local definitions needed for DNS queries */
 #define MAXPACKET		8192
 #if defined(__RES) && (__RES >= 19940415)

--- a/libopendkim/dkim-report.c
+++ b/libopendkim/dkim-report.c
@@ -24,9 +24,6 @@
 #include "dkim-types.h"
 #include "util.h"
 
-/* prototypes */
-extern void dkim_error (DKIM *, const char *, ...);
-
 /* local definitions needed for DNS queries */
 #define MAXPACKET		8192
 #if defined(__RES) && (__RES >= 19940415)

--- a/libopendkim/dkim-test.c
+++ b/libopendkim/dkim-test.c
@@ -51,9 +51,6 @@
 #define	TESTTTL			300
 #define MAXPACKET		8192
 
-/* prototypes from elsewhere */
-extern DKIM_STAT dkim_get_key (DKIM *, DKIM_SIGINFO *, _Bool);
-
 /*
 **  DKIM_TEST_DNS_PUT -- enqueue a DNS reply for automated testing
 **

--- a/libopendkim/dkim-util.c
+++ b/libopendkim/dkim-util.c
@@ -28,9 +28,6 @@
 #include "dkim-types.h"
 #include "dkim-util.h"
 
-/* prototypes */
-extern void dkim_error (DKIM *, const char *, ...);
-
 /*
 **  DKIM_MALLOC -- allocate memory
 **


### PR DESCRIPTION
## Summary
- `dkim_error()` is defined in `libopendkim/dkim.c` but was declared via a matching file-local `extern` copied into `dkim-report.c`, `dkim-keys.c`, `dkim-canon.c`, `dkim-util.c`, and `dkim-atps.c` instead of a shared header.
- `dkim_get_key()` had the same problem, with its own local `extern` in `dkim-test.c`.
- Adds both prototypes to `libopendkim/dkim-internal.h` (already included by all affected files) and removes the six redundant local declarations.

Fixes #413.

## Test plan
- Built cleanly on FreeBSD (Clang) via `autoreconf -fi && ./configure && gmake` in `libopendkim/` with no new errors or warnings.